### PR TITLE
Guard wyckoff payload access and add safe Supabase/cookie handling

### DIFF
--- a/auth_component.py
+++ b/auth_component.py
@@ -34,10 +34,10 @@ def _cookie_manager() -> EncryptedCookieManager | None:
         st.session_state.access_token = None
         st.session_state.refresh_token = None
         st.session_state.cookie_manager = None
-        st.warning(
-            "登录状态无法恢复，已清空本地登录信息。请重新登录。"
-        )
-        st.caption("提示：如果浏览器阻止第三方 Cookie，也可能导致该问题。")
+        if not st.session_state.get("cookie_warning_shown"):
+            st.warning("登录状态无法恢复，已清空本地登录信息。请重新登录。")
+            st.caption("提示：如果浏览器阻止第三方 Cookie，也可能导致该问题。")
+            st.session_state.cookie_warning_shown = True
         return None
     return manager
 

--- a/pages/WyckoffScreeners.py
+++ b/pages/WyckoffScreeners.py
@@ -878,7 +878,7 @@ if run:
         "jump_stats": jump_stats if tactic == "突破临界" else None,
     }
 
-payload = st.session_state.wyckoff_payload
+payload = st.session_state.get("wyckoff_payload")
 if payload:
     _render_results(
         payload, group_power=group_power, debug_log=debug_log, use_cache=use_cache


### PR DESCRIPTION
### Motivation
- Prevent a crash when `wyckoff_payload` is not yet initialized in `st.session_state` and avoid a KeyError that breaks page rendering. 
- Fail-safe Supabase initialization to avoid runtime crashes during auth flows. 
- Avoid blocking Streamlit rendering when the cookie manager is not ready and ensure local auth state is cleared to prompt a clean re-login. 

### Description
- Read the payload defensively using `st.session_state.get("wyckoff_payload")` to avoid `KeyError` before initialization. 
- Add `_safe_get_supabase_client()` that wraps `get_supabase_client()` and returns `None` while showing an explanatory `st.error`/`st.caption` on initialization failure. 
- Change `_cookie_manager()` to return `EncryptedCookieManager | None`, clear `st.session_state` keys (`user`, `access_token`, `refresh_token`, `cookie_manager`) and show a `st.warning`/`st.caption` when the manager is not ready instead of calling `st.stop()`. 
- Guard cookie reads/writes and auth flows in `login_form()`, `check_auth()`, and `logout()` by checking for `None` from `_cookie_manager()` and early-return when Supabase is unavailable via `_safe_get_supabase_client()`. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979b21a6b8c832592aa078b27d5a834)