### PR TITLE
Improve auth UX and session resilience; accept 'Z' ISO timestamps in cache

### DIFF
--- a/stock_cache.py
+++ b/stock_cache.py
@@ -11,6 +11,11 @@ from constants import TABLE_STOCK_CACHE_DATA, TABLE_STOCK_CACHE_META
 from supabase_client import get_supabase_client
 
 
+def _parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO datetime strings and accept trailing 'Z' timezone markers."""
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
 @dataclass
 class CacheMeta:
     symbol: str
@@ -70,9 +75,9 @@ def get_cache_meta(symbol: str, adjust: str) -> Optional[CacheMeta]:
             symbol=row["symbol"],
             adjust=row["adjust"],
             source=row["source"],
-            start_date=datetime.fromisoformat(row["start_date"]).date(),
-            end_date=datetime.fromisoformat(row["end_date"]).date(),
-            updated_at=datetime.fromisoformat(row["updated_at"]),
+            start_date=_parse_iso_datetime(row["start_date"]).date(),
+            end_date=_parse_iso_datetime(row["end_date"]).date(),
+            updated_at=_parse_iso_datetime(row["updated_at"]),
         )
     except APIError:
         return None


### PR DESCRIPTION
### Motivation
- Reduce failed/invalid auth requests and improve user feedback by validating and normalizing credentials before calling Supabase. 
- Make token restore more robust to stale/invalid tokens to avoid repeated failed restore attempts.
- Ensure cache metadata parsing accepts ISO timestamps with trailing `Z` (UTC) so cache lookups are reliable.

### Description
- Add email normalization and format validation with `_normalize_email` and `_is_valid_email`, and introduce `_MIN_PASSWORD_LEN` to centralize password length checks in `auth_component.py`.
- Validate presence and format of email/password on login and registration to prevent unnecessary Supabase API calls and provide clearer error messages in `login_form` and registration flow.
- Harden session restore by clearing `st.session_state.access_token`/`refresh_token` when `supabase.auth.set_session` fails, and replace a bare `except:` with `except Exception` in `logout` for cleaner exception handling in `auth_component.py`.
- Remove an unnecessary `time.sleep(0.5)` after successful login to make UX snappier and keep loading indicator scoping via `show_page_loading`.
- Add `_parse_iso_datetime` to `stock_cache.py` which normalizes trailing `Z` to `+00:00` and use it in `get_cache_meta` to parse `start_date`, `end_date`, and `updated_at` safely.

### Testing
- Compiled the modified auth module with `python -m compileall -q auth_component.py` which completed successfully.
- Ran the test runner with `python -m pytest -q` and observed `no tests ran` because the repository contains no automated tests; no failures were reported by the test runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da80d09148325b88f40ad8886f8cb)