### PR TITLE
Fix loading UI rendering; harden auth flows; accept trailing 'Z' in ISO cache timestamps

### DIFF
--- a/stock_cache.py
+++ b/stock_cache.py
@@ -11,6 +11,11 @@ from constants import TABLE_STOCK_CACHE_DATA, TABLE_STOCK_CACHE_META
 from supabase_client import get_supabase_client
 
 
+def _parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO datetime strings and accept trailing 'Z' timezone markers."""
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
 @dataclass
 class CacheMeta:
     symbol: str
@@ -70,9 +75,9 @@ def get_cache_meta(symbol: str, adjust: str) -> Optional[CacheMeta]:
             symbol=row["symbol"],
             adjust=row["adjust"],
             source=row["source"],
-            start_date=datetime.fromisoformat(row["start_date"]).date(),
-            end_date=datetime.fromisoformat(row["end_date"]).date(),
-            updated_at=datetime.fromisoformat(row["updated_at"]),
+            start_date=_parse_iso_datetime(row["start_date"]).date(),
+            end_date=_parse_iso_datetime(row["end_date"]).date(),
+            updated_at=_parse_iso_datetime(row["updated_at"]),
         )
     except APIError:
         return None

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -1,4 +1,6 @@
 import html
+import textwrap
+
 import streamlit as st
 
 
@@ -9,24 +11,34 @@ def show_page_loading(
     quote: str | None = None,
 ) -> st.delta_generator.DeltaGenerator:
     """展示加载占位，可选展示一句名人名言（如股市大牛语录）。"""
+    safe_title = html.escape(str(title or ""))
+    safe_subtitle = html.escape(str(subtitle or ""))
+
     quote_html = ""
     if quote:
-        safe = html.escape(quote)
-        quote_html = f'<div style="font-size: 12px; color: #888; margin-top: 16px; font-style: italic; max-width: 360px; margin-left: auto; margin-right: auto;">"{safe}"</div>'
-    placeholder = st.empty()
-    placeholder.markdown(
+        safe_quote = html.escape(str(quote))
+        quote_html = (
+            '<div style="font-size: 12px; color: #888; margin-top: 16px; '
+            'font-style: italic; max-width: 360px; margin-left: auto; margin-right: auto;">'
+            f'"{safe_quote}"'
+            "</div>"
+        )
+
+    loading_html = textwrap.dedent(
         f"""
         <div style="width: 100%; min-height: 40vh; display: flex; align-items: center; justify-content: center;">
             <div style="text-align:center; padding: 24px 12px;">
                 <div style="font-size: 28px; margin-bottom: 8px;">⏳</div>
-                <div style="font-size: 16px; font-weight: 600;">{title}</div>
+                <div style="font-size: 16px; font-weight: 600;">{safe_title}</div>
                 <div style="font-size: 13px; color: #666; margin-top: 6px;">
-                    {subtitle}
+                    {safe_subtitle}
                 </div>
                 {quote_html}
             </div>
         </div>
-        """,
-        unsafe_allow_html=True,
-    )
+        """
+    ).strip()
+
+    placeholder = st.empty()
+    placeholder.markdown(loading_html, unsafe_allow_html=True)
     return placeholder


### PR DESCRIPTION
### Motivation
- Fix a bug where the global loading placeholder rendered raw `<div>` text instead of HTML due to markdown indentation. 
- Sanitize loading UI text to avoid accidental HTML injection from titles/subtitles/quotes. 
- Improve authentication UX and session resilience and make cache meta parsing accept ISO timestamps ending with a trailing `Z`.

### Description
- Update `ui_helpers.py` to `textwrap.dedent(...).strip()` the multiline HTML template and `html.escape` the `title`, `subtitle`, and `quote` before injection so `st.markdown(..., unsafe_allow_html=True)` renders correctly. 
- Enhance `auth_component.py` by adding email normalization and validation (`_normalize_email`, `_is_valid_email`), introducing `_MIN_PASSWORD_LEN`, improving form validation messages, handling `AuthApiError` more explicitly, clearing stale tokens when `supabase.auth.set_session` fails, and replacing a bare `except:` with `except Exception`. 
- Add `_parse_iso_datetime` to `stock_cache.py` and use it in `get_cache_meta` so ISO datetimes with trailing `Z` are parsed as UTC. 

### Testing
- Ran `python -m compileall -q ui_helpers.py` which completed successfully. 
- Verified the `show_page_loading` source contains `dedent` and `unsafe_allow_html=True` via a short `inspect` script which printed success. 
- Launched the app with `streamlit run streamlit_app.py --server.port 8501 --server.address 0.0.0.0` and captured a Playwright screenshot of the home page to validate the loading UI renders correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698da80d09148325b88f40ad8886f8cb)