### PR TITLE
refactor(auth/step4): isolate per-user data and lock Action rebalance…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,14 +14,13 @@ TUSHARE_TOKEN=
 GEMINI_API_KEY=
 GEMINI_MODEL=gemini-2.5-flash
 
-# Step4 private portfolio + Telegram delivery
-# Example:
-# MY_PORTFOLIO_STATE={"free_cash":100000,"positions":[{"code":"000001","name":"示例股","cost":10.0,"buy_dt":"20260101","shares":1000,"strategy":"示例策略"}]}
-# total_equity 可选；不填时会按 free_cash + 持仓最新市值自动推导
-# 读取顺序：Supabase USER_LIVE 优先；若 USER_LIVE 不可用，回退到 MY_PORTFOLIO_STATE
-MY_PORTFOLIO_STATE=
+# Step4 private portfolio delivery
+# 定时任务只执行该用户（必须是 Supabase Auth 的 user_id）
+SUPABASE_USER_ID=
 TG_BOT_TOKEN=
 TG_CHAT_ID=
+# 可选兜底：若 USER_LIVE:<user_id> 不可用则使用此 JSON
+MY_PORTFOLIO_STATE=
 
 # Step3 RAG 防雷（可选，未配置 key 自动跳过）
 RAG_VETO_ENABLED=1

--- a/.github/workflows/wyckoff_funnel.yml
+++ b/.github/workflows/wyckoff_funnel.yml
@@ -24,6 +24,7 @@ jobs:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_USER_ID: ${{ secrets.SUPABASE_USER_ID }}
       TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
       SERPAPI_API_KEY: ${{ secrets.SERPAPI_API_KEY }}
       TZ: Asia/Shanghai

--- a/README.md
+++ b/README.md
@@ -94,13 +94,17 @@ python -u -m integrations.fetch_a_share_csv --symbols 000973 600798 601390
 | `GEMINI_API_KEY` | 是 | AI 研报 |
 | `TUSHARE_TOKEN` | 是 | 行情与市值数据 |
 | `GEMINI_MODEL` | 否 | 未配则用默认模型 |
-| `MY_PORTFOLIO_STATE` | Step4 用 | 可选，格式见 `.env.example` |
-| `TG_BOT_TOKEN` | Step4 用 | 可选 |
-| `TG_CHAT_ID` | Step4 用 | 可选 |
-| `SUPABASE_URL` | Step4 用 | 可选，云端持仓同步 |
-| `SUPABASE_KEY` | Step4 用 | 可选，云端持仓同步 |
-| `TAVILY_API_KEY` | 否 | RAG 防雷，未配则跳过 |
-| `SERPAPI_API_KEY` | 否 | RAG 防雷备用搜索源，未配则跳过 |
+| `SUPABASE_URL` | Step4 用 | 是（Step4 依赖 USER_LIVE） |
+| `SUPABASE_KEY` | ❌ | Supabase 匿名 Key。 |
+| `SUPABASE_SERVICE_ROLE_KEY` | ❌ | Supabase 管理员 Key (用于脚本读写)。 |
+| `SUPABASE_USER_ID` | ❌ | **用户锁定**：指定 Step4 运行的目标用户 ID。 |
+| `MY_PORTFOLIO_STATE` | ❌ | **本地账本**：如果不使用 Supabase，可用 JSON 字符串配置持仓 (格式见 `.env.example`)。 |
+| `TG_BOT_TOKEN` | ❌ | **私密推送**：Telegram Bot Token，用于接收私密交易建议。 |
+| `TG_CHAT_ID` | ❌ | Telegram Chat ID。 |
+| `TAVILY_API_KEY` | ❌ | **防雷**：用于 RAG 新闻检索 (Tavily)，推荐配置。 |
+| `SERPAPI_API_KEY` | ❌ | **防雷备用**：Tavily 挂了时自动切换到 Google News (SerpApi)。 |
+
+> **提示**：以上配置只在你需要对应功能时才需填写。最基础运行仅需前 3 项。
 
 ### 验证
 
@@ -129,12 +133,12 @@ python -u -m integrations.fetch_a_share_csv --symbols 000973 600798 601390
 - `[step3] 飞书推送失败` / `feishu_failed`
   - 原因：Webhook 无效、限流、网络问题
   - 处理：重新生成飞书机器人 Webhook 并替换 Secret
-- `阶段 3 私人再平衡: 跳过（MY_PORTFOLIO_STATE 未配置）`
-  - 原因：未配置账户状态
-  - 处理：配置 `MY_PORTFOLIO_STATE` 后重跑
+- `阶段 3 私人再平衡: 跳过（SUPABASE_USER_ID 未配置/用户持仓缺失）`
+  - 原因：未配置 `SUPABASE_USER_ID`，或 `USER_LIVE:<user_id>`/`MY_PORTFOLIO_STATE` 都不可用
+  - 处理：在 Secrets 配置 `SUPABASE_USER_ID`；优先保证 Supabase 有 `USER_LIVE:<user_id>`，必要时提供 `MY_PORTFOLIO_STATE` 兜底
 - `阶段 3 私人再平衡: 跳过（TG_BOT_TOKEN/TG_CHAT_ID 未配置）`
-  - 原因：未配置 Telegram
-  - 处理：配置 Telegram Secrets 后重跑
+  - 原因：Telegram Secret 未配置
+  - 处理：配置 `TG_BOT_TOKEN` 和 `TG_CHAT_ID` 后重跑
 - `User location is not supported for the API use`
   - 原因：模型地域限制
   - 处理：更换可用网络出口或供应商
@@ -144,9 +148,7 @@ python -u -m integrations.fetch_a_share_csv --symbols 000973 600798 601390
 
 ### 私人决断（可选）
 
-若配置了持仓和 Telegram，选股和研报跑完后会单独发一份「针对你账户的买卖建议」到你的 Telegram，只有你能看到。不配则跳过，不影响选股和研报。
-
-账户格式见 `.env.example`。其中 `total_equity` 是可选字段，不填会自动按“`free_cash + 持仓最新市值`”推导。TG_CHAT_ID 需先给 bot 发 `/start`，再从 getUpdates 返回里取 chat.id。
+Step4 完全由 GitHub Actions Secrets 驱动：读取 `SUPABASE_USER_ID` 定位 `USER_LIVE:<user_id>`，读取 `TG_BOT_TOKEN/TG_CHAT_ID` 推送 Telegram，模型使用 `GEMINI_API_KEY/GEMINI_MODEL`。若 Supabase 持仓缺失可用 `MY_PORTFOLIO_STATE` 做兜底。
 
 ---
 

--- a/app/auth_component.py
+++ b/app/auth_component.py
@@ -3,7 +3,11 @@ import re
 import streamlit as st
 from supabase import AuthApiError
 
-from integrations.supabase_client import get_supabase_client, load_user_settings
+from integrations.supabase_client import (
+    get_supabase_client,
+    load_user_settings,
+    reset_user_settings_state,
+)
 from app.ui_helpers import show_page_loading
 
 try:
@@ -275,6 +279,7 @@ def logout():
     except Exception:
         pass
     clear_tokens_from_storage()
+    reset_user_settings_state()
     st.session_state.user = None
     st.session_state.access_token = None
     st.session_state.refresh_token = None

--- a/app/layout.py
+++ b/app/layout.py
@@ -1,5 +1,3 @@
-import os
-
 import streamlit as st
 
 from app.auth_component import check_auth, login_form
@@ -26,33 +24,30 @@ def init_session_state() -> None:
     _set_default("custom_export_source_id", "")
     _set_default("wyckoff_payload", None)
 
-    _set_default("feishu_webhook", os.getenv("FEISHU_WEBHOOK_URL", ""))
+    # 用户敏感配置不从环境变量兜底，避免跨账号污染
+    _set_default("feishu_webhook", "")
     if st.session_state.feishu_webhook is None:
         st.session_state.feishu_webhook = ""
 
-    _set_default("gemini_api_key", os.getenv("GEMINI_API_KEY", ""))
+    _set_default("gemini_api_key", "")
     if st.session_state.gemini_api_key is None:
         st.session_state.gemini_api_key = ""
 
-    _set_default("tushare_token", os.getenv("TUSHARE_TOKEN", ""))
+    _set_default("tushare_token", "")
     if st.session_state.tushare_token is None:
         st.session_state.tushare_token = ""
 
-    _set_default("gemini_model", os.getenv("GEMINI_MODEL", "gemini-2.0-flash"))
+    _set_default("gemini_model", "gemini-2.0-flash")
     if st.session_state.gemini_model is None:
         st.session_state.gemini_model = "gemini-2.0-flash"
 
-    _set_default("tg_bot_token", os.getenv("TG_BOT_TOKEN", ""))
+    _set_default("tg_bot_token", "")
     if st.session_state.tg_bot_token is None:
         st.session_state.tg_bot_token = ""
 
-    _set_default("tg_chat_id", os.getenv("TG_CHAT_ID", ""))
+    _set_default("tg_chat_id", "")
     if st.session_state.tg_chat_id is None:
         st.session_state.tg_chat_id = ""
-
-    _set_default("my_portfolio_state", os.getenv("MY_PORTFOLIO_STATE", ""))
-    if st.session_state.my_portfolio_state is None:
-        st.session_state.my_portfolio_state = ""
 
     # 从 localStorage 恢复 token（刷新页面后登录态保持）
     access = st.session_state.get("access_token") or ""

--- a/integrations/supabase_client.py
+++ b/integrations/supabase_client.py
@@ -5,6 +5,18 @@ from postgrest.exceptions import APIError
 from core.constants import TABLE_USER_SETTINGS
 
 
+def reset_user_settings_state() -> None:
+    """
+    重置当前会话中的用户敏感配置，防止跨账号残留。
+    """
+    st.session_state.feishu_webhook = ""
+    st.session_state.gemini_api_key = ""
+    st.session_state.tushare_token = ""
+    st.session_state.gemini_model = "gemini-2.0-flash"
+    st.session_state.tg_bot_token = ""
+    st.session_state.tg_chat_id = ""
+
+
 def _get_supabase_client_base() -> Client:
     # 优先尝试从 os.getenv 读取（本地 .env 文件）
     # 其次尝试从 st.secrets 读取（Streamlit Cloud 部署环境）
@@ -60,6 +72,9 @@ def get_supabase_client() -> Client:
 
 def load_user_settings(user_id: str):
     """从 Supabase 加载用户配置到 st.session_state"""
+    reset_user_settings_state()
+    if not user_id:
+        return False
     try:
         supabase = get_supabase_client()
         response = (
@@ -78,7 +93,6 @@ def load_user_settings(user_id: str):
             st.session_state.gemini_model = settings.get("gemini_model") or "gemini-2.5-flash"
             st.session_state.tg_bot_token = settings.get("tg_bot_token") or ""
             st.session_state.tg_chat_id = settings.get("tg_chat_id") or ""
-            st.session_state.my_portfolio_state = settings.get("my_portfolio_state") or ""
             return True
     except APIError as e:
         print(f"Supabase API Error in load_user_settings: {e.code} - {e.message}")

--- a/integrations/supabase_portfolio.py
+++ b/integrations/supabase_portfolio.py
@@ -12,6 +12,7 @@ import os
 from typing import Any
 
 from supabase import Client, create_client
+from core.constants import TABLE_USER_SETTINGS
 
 TABLE_PORTFOLIOS = "portfolios"
 TABLE_PORTFOLIO_POSITIONS = "portfolio_positions"
@@ -96,6 +97,61 @@ def load_portfolio_state(portfolio_id: str = "USER_LIVE") -> dict[str, Any] | No
     except Exception as e:
         print(f"[supabase_portfolio] load_portfolio_state failed: {e}")
         return None
+
+
+def build_user_live_portfolio_id(user_id: str) -> str:
+    user_id = str(user_id or "").strip()
+    return f"USER_LIVE:{user_id}"
+
+
+def list_step4_targets(target_user_id: str | None = None) -> list[dict[str, Any]]:
+    """
+    自动发现可执行 Step4 的用户目标：
+    - 来自 user_settings（必须有 user_id / tg_bot_token / tg_chat_id）
+    - 自动映射 portfolio_id=USER_LIVE:<user_id>
+    - 仅返回 Supabase 中已存在且结构可用的 portfolio
+    """
+    if not is_supabase_configured():
+        return []
+    try:
+        client = _get_supabase_admin_client()
+        query = (
+            client.table(TABLE_USER_SETTINGS)
+            .select("user_id,tg_bot_token,tg_chat_id,gemini_api_key,gemini_model")
+        )
+        target_user_id = str(target_user_id or "").strip()
+        if target_user_id:
+            query = query.eq("user_id", target_user_id).limit(1)
+        resp = query.execute()
+        targets: list[dict[str, Any]] = []
+        for row in resp.data or []:
+            user_id = str(row.get("user_id", "") or "").strip()
+            if target_user_id and user_id != target_user_id:
+                continue
+            tg_bot_token = str(row.get("tg_bot_token", "") or "").strip()
+            tg_chat_id = str(row.get("tg_chat_id", "") or "").strip()
+            if not user_id or not tg_bot_token or not tg_chat_id:
+                continue
+            portfolio_id = build_user_live_portfolio_id(user_id)
+            p = load_portfolio_state(portfolio_id)
+            if not isinstance(p, dict):
+                continue
+            if p.get("free_cash") is None or not isinstance(p.get("positions"), list):
+                continue
+            targets.append(
+                {
+                    "user_id": user_id,
+                    "portfolio_id": portfolio_id,
+                    "tg_bot_token": tg_bot_token,
+                    "tg_chat_id": tg_chat_id,
+                    "gemini_api_key": str(row.get("gemini_api_key", "") or "").strip(),
+                    "gemini_model": str(row.get("gemini_model", "") or "").strip(),
+                }
+            )
+        return targets
+    except Exception as e:
+        print(f"[supabase_portfolio] list_step4_targets failed: {e}")
+        return []
 
 
 def check_daily_run_exists(portfolio_id: str, trade_date: str) -> bool:
@@ -230,4 +286,3 @@ def upsert_daily_nav(
     except Exception as e:
         print(f"[supabase_portfolio] upsert_daily_nav failed: {e}")
         return False
-

--- a/pages/Portfolio.py
+++ b/pages/Portfolio.py
@@ -16,7 +16,7 @@ from app.navigation import show_right_nav
 from app.ui_helpers import show_page_loading
 from integrations.supabase_client import get_supabase_client
 
-PORTFOLIO_ID = "USER_LIVE"
+PORTFOLIO_SCOPE = "USER_LIVE"
 TABLE_PORTFOLIOS = "portfolios"
 TABLE_POSITIONS = "portfolio_positions"
 
@@ -89,20 +89,33 @@ def _estimate_positions_value(rows: list[dict[str, Any]]) -> float:
     return float(total)
 
 
-def _load_user_live() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+def _current_portfolio_id() -> str | None:
+    """
+    按登录用户隔离持仓：
+    USER_LIVE:<user_id>
+    """
+    user = st.session_state.get("user")
+    if isinstance(user, dict):
+        user_id = str(user.get("id") or "").strip()
+        if user_id:
+            return f"{PORTFOLIO_SCOPE}:{user_id}"
+    return None
+
+
+def _load_user_live(portfolio_id: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     supabase = get_supabase_client()
 
     p_resp = (
         supabase.table(TABLE_PORTFOLIOS)
         .select("portfolio_id,name,free_cash,total_equity")
-        .eq("portfolio_id", PORTFOLIO_ID)
+        .eq("portfolio_id", portfolio_id)
         .limit(1)
         .execute()
     )
     if not p_resp.data:
         supabase.table(TABLE_PORTFOLIOS).upsert(
             {
-                "portfolio_id": PORTFOLIO_ID,
+                "portfolio_id": portfolio_id,
                 "name": "Real Portfolio",
                 "free_cash": 0.0,
                 "total_equity": None,
@@ -111,7 +124,7 @@ def _load_user_live() -> tuple[dict[str, Any], list[dict[str, Any]]]:
             on_conflict="portfolio_id",
         ).execute()
         portfolio = {
-            "portfolio_id": PORTFOLIO_ID,
+            "portfolio_id": portfolio_id,
             "name": "Real Portfolio",
             "free_cash": 0.0,
             "total_equity": None,
@@ -122,7 +135,7 @@ def _load_user_live() -> tuple[dict[str, Any], list[dict[str, Any]]]:
     pos_resp = (
         supabase.table(TABLE_POSITIONS)
         .select("code,name,shares,cost_price,buy_dt,strategy")
-        .eq("portfolio_id", PORTFOLIO_ID)
+        .eq("portfolio_id", portfolio_id)
         .order("code")
         .execute()
     )
@@ -161,6 +174,7 @@ def _to_editor_df(rows: list[dict[str, Any]]) -> pd.DataFrame:
 
 def _save_user_live(
     *,
+    portfolio_id: str,
     free_cash: float,
     total_equity: float | None,
     editor_df: pd.DataFrame,
@@ -200,7 +214,7 @@ def _save_user_live(
             continue
 
         payload_by_code[code] = {
-            "portfolio_id": PORTFOLIO_ID,
+            "portfolio_id": portfolio_id,
             "code": code,
             "name": name,
             "shares": shares,
@@ -219,7 +233,7 @@ def _save_user_live(
     try:
         supabase.table(TABLE_PORTFOLIOS).upsert(
             {
-                "portfolio_id": PORTFOLIO_ID,
+                "portfolio_id": portfolio_id,
                 "name": "Real Portfolio",
                 "free_cash": float(free_cash),
                 "total_equity": (None if total_equity is None else float(total_equity)),
@@ -232,7 +246,7 @@ def _save_user_live(
             (
                 supabase.table(TABLE_POSITIONS)
                 .delete()
-                .eq("portfolio_id", PORTFOLIO_ID)
+                .eq("portfolio_id", portfolio_id)
                 .eq("code", code)
                 .execute()
             )
@@ -292,10 +306,14 @@ with content_col:
     )
 
     st.title("💼 持仓管理")
+    portfolio_id = _current_portfolio_id()
+    if not portfolio_id:
+        st.error("无法识别当前用户，已拒绝加载持仓信息。请重新登录。")
+        st.stop()
 
-    loading = show_page_loading(title="加载持仓中...", subtitle="正在读取 USER_LIVE")
+    loading = show_page_loading(title="加载持仓中...", subtitle="正在读取当前账号持仓")
     try:
-        portfolio, positions = _load_user_live()
+        portfolio, positions = _load_user_live(portfolio_id)
     finally:
         loading.empty()
 
@@ -338,7 +356,7 @@ with content_col:
         manual_total_equity if manual_total_equity is not None else display_total_equity
     )
 
-    st.caption("编辑过程中不会自动刷新；点击“保存 USER_LIVE”后才会提交并重载。")
+    st.caption("当前页仅显示当前登录账号持仓。编辑过程中不会自动刷新，点击保存后才会提交并重载。")
 
     with st.form("portfolio_edit_form", clear_on_submit=False):
         c1, c2, c3 = st.columns([1, 1, 1])
@@ -402,7 +420,7 @@ with content_col:
             key="portfolio_editor",
         )
 
-        submitted = st.form_submit_button("💾 保存 USER_LIVE", use_container_width=True)
+        submitted = st.form_submit_button("💾 保存当前账号持仓", use_container_width=True)
         if submitted:
             try:
                 free_cash_value = _parse_money_input(free_cash_input, "现金")
@@ -418,6 +436,7 @@ with content_col:
             loader = show_page_loading(title="保存中...", subtitle="正在写入 Supabase")
             try:
                 ok, msg = _save_user_live(
+                    portfolio_id=portfolio_id,
                     free_cash=free_cash_value,
                     total_equity=total_equity_value,
                     editor_df=editor_df,

--- a/pages/Settings.py
+++ b/pages/Settings.py
@@ -22,6 +22,14 @@ with content_col:
     # 获取当前用户 ID
     user = st.session_state.get("user") or {}
     user_id = user.get("id") if isinstance(user, dict) else None
+    if not user_id:
+        st.error("无法识别当前用户，设置页已拒绝展示。请重新登录。")
+        st.stop()
+
+    # 顶部展示 user_id，方便复制
+    with st.expander("🔑 账户信息", expanded=True):
+        st.info(f"当前用户 ID (SUPABASE_USER_ID): `{user_id}`")
+        st.caption("请复制此 ID 并配置到 GitHub Secrets 的 SUPABASE_USER_ID 中，以便定时任务能识别您的账户。")
 
 
     def on_save_settings():
@@ -37,7 +45,6 @@ with content_col:
             "gemini_model": st.session_state.gemini_model,
             "tg_bot_token": st.session_state.tg_bot_token,
             "tg_chat_id": st.session_state.tg_chat_id,
-            "my_portfolio_state": st.session_state.my_portfolio_state,
         }
 
         loading = show_page_loading(title="加载中...", subtitle="正在保存到云端")
@@ -125,17 +132,9 @@ with content_col:
             st.markdown("可选，用于 Telegram 私密推送买卖建议。")
             new_tg_bot = st.text_input("Telegram Bot Token", value=st.session_state.tg_bot_token, type="password", key="tg_bot")
             new_tg_chat = st.text_input("Telegram Chat ID", value=st.session_state.tg_chat_id, type="password", key="tg_chat")
-            new_portfolio = st.text_area(
-                "持仓 JSON（MY_PORTFOLIO_STATE）",
-                value=st.session_state.my_portfolio_state,
-                height=120,
-                placeholder='{"free_cash":100000,"positions":[...]}',
-                key="portfolio_input",
-            )
             if st.button("💾 保存 Step4 配置", key="save_step4"):
                 st.session_state.tg_bot_token = new_tg_bot
                 st.session_state.tg_chat_id = new_tg_chat
-                st.session_state.my_portfolio_state = new_portfolio
                 on_save_settings()
 
         st.info("☁️ 您的配置已启用云端同步，将在所有登录设备间自动漫游。")

--- a/scripts/daily_job.py
+++ b/scripts/daily_job.py
@@ -3,13 +3,13 @@
 定时任务主入口：Wyckoff Funnel → 批量研报
 
 配置来源：仅读取环境变量（GitHub Secrets），与 Streamlit 用户配置（Supabase）完全独立。
-环境变量：FEISHU_WEBHOOK_URL, GEMINI_API_KEY, GEMINI_MODEL, TG_BOT_TOKEN, TG_CHAT_ID,
-SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY(可选), MY_PORTFOLIO_STATE(兜底)
+环境变量：FEISHU_WEBHOOK_URL, GEMINI_API_KEY, GEMINI_MODEL,
+SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY(可选), SUPABASE_USER_ID,
+TG_BOT_TOKEN, TG_CHAT_ID, MY_PORTFOLIO_STATE(可选兜底)
 """
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 from datetime import datetime
@@ -27,7 +27,7 @@ STEP3_REASON_MAP = {
 }
 STEP4_REASON_MAP = {
     "missing_api_key": "GEMINI_API_KEY 缺失",
-    "skipped_invalid_portfolio": "持仓配置缺失或格式错误，已跳过",
+    "skipped_invalid_portfolio": "用户持仓缺失或格式错误，已跳过",
     "skipped_telegram_unconfigured": "Telegram 未配置，已跳过",
     "skipped_idempotency": "今日已运行，已跳过",
     "skipped_no_decisions": "模型未给出有效决策，已跳过",
@@ -50,46 +50,27 @@ def _log(msg: str, logs_path: str | None = None) -> None:
             f.write(line + "\n")
 
 
-def _detect_step4_readiness() -> tuple[bool, str]:
-    """
-    检测 Step4 所需配置是否齐全：
-    1) 优先账户信息 USER_LIVE(Supabase)，否则回退 MY_PORTFOLIO_STATE
-    2) Telegram 推送配置 TG_BOT_TOKEN / TG_CHAT_ID
-    """
-    tg_bot_token = os.getenv("TG_BOT_TOKEN", "").strip()
-    tg_chat_id = os.getenv("TG_CHAT_ID", "").strip()
-    if not tg_bot_token:
-        return (False, "TG_BOT_TOKEN 未配置")
-    if not tg_chat_id:
-        return (False, "TG_CHAT_ID 未配置")
+def _load_step4_target() -> tuple[dict | None, str]:
+    target_user_id = os.getenv("SUPABASE_USER_ID", "").strip()
+    if not target_user_id:
+        return None, "SUPABASE_USER_ID 未配置"
 
-    # 1) 优先 Supabase USER_LIVE
+    portfolio_id = f"USER_LIVE:{target_user_id}"
     try:
         from integrations.supabase_portfolio import load_portfolio_state
-
-        sb_data = load_portfolio_state("USER_LIVE")
-        if isinstance(sb_data, dict):
-            if sb_data.get("free_cash") is not None and isinstance(sb_data.get("positions"), list):
-                return (True, "ok (supabase:user_live)")
-    except Exception:
-        pass
-
-    # 2) 回退 Secret：MY_PORTFOLIO_STATE
-    raw = os.getenv("MY_PORTFOLIO_STATE", "").strip()
-    if not raw:
-        return (False, "USER_LIVE 未就绪，且 MY_PORTFOLIO_STATE 未配置")
-    try:
-        data = json.loads(raw)
     except Exception as e:
-        return (False, f"MY_PORTFOLIO_STATE 非法 JSON: {e}")
-    if not isinstance(data, dict):
-        return (False, "MY_PORTFOLIO_STATE 必须是 JSON 对象")
-    if not isinstance(data.get("positions"), list):
-        return (False, "MY_PORTFOLIO_STATE 缺少/非法 positions（必须是数组）")
-    if data.get("free_cash") is None:
-        return (False, "MY_PORTFOLIO_STATE 缺少 free_cash")
+        return None, f"supabase portfolio 读取器不可用: {e}"
 
-    return (True, "ok")
+    # 强制按唯一 user_id 读取目标账户
+    p = load_portfolio_state(portfolio_id)
+    has_env_fallback = bool(os.getenv("MY_PORTFOLIO_STATE", "").strip())
+    if not isinstance(p, dict) and not has_env_fallback:
+        return None, f"未匹配到 user_id={target_user_id} 的持仓（{portfolio_id}）"
+
+    return {
+        "user_id": target_user_id,
+        "portfolio_id": portfolio_id,
+    }, ("ok_supabase" if isinstance(p, dict) else "ok_env_fallback")
 
 
 def main() -> int:
@@ -180,47 +161,69 @@ def main() -> int:
         summary.append({"step": "批量研报", "ok": True, "err": None, "elapsed_s": 0, "output": "skipped (no symbols)"})
         _log("阶段 2 批量研报: 跳过（无筛选结果）", logs_path)
 
-    # 阶段 3：私人账户再平衡（未检测到 Step4 所需配置时直接跳过）
-    step4_ready, step4_reason = _detect_step4_readiness()
-    if not step4_ready:
+    # 阶段 3：私人账户再平衡（按 SUPABASE_USER_ID 唯一执行）
+    step4_target, step4_target_reason = _load_step4_target()
+    if not step4_target:
         summary.append({
             "step": "私人再平衡",
             "ok": True,
             "err": None,
             "elapsed_s": 0,
-            "output": f"skipped ({step4_reason})",
+            "output": f"skipped ({step4_target_reason})",
         })
-        _log(f"阶段 3 私人再平衡: 跳过（{step4_reason}）", logs_path)
+        _log(f"阶段 3 私人再平衡: 跳过（{step4_target_reason}）", logs_path)
     else:
-        t0 = datetime.now(TZ)
-        step4_ok = True
-        step4_err = None
-        step4_reason = "ok"
-        try:
-            step4_ok, step4_reason = run_step4(
-                external_report=step3_report_text,
-                benchmark_context=benchmark_context,
-                api_key=api_key,
-                model=model,
+        tg_bot_token = os.getenv("TG_BOT_TOKEN", "").strip()
+        tg_chat_id = os.getenv("TG_CHAT_ID", "").strip()
+        if not tg_bot_token or not tg_chat_id:
+            summary.append({
+                "step": "私人再平衡",
+                "ok": True,
+                "err": None,
+                "elapsed_s": 0,
+                "output": "skipped (TG_BOT_TOKEN/TG_CHAT_ID 未配置)",
+            })
+            _log("阶段 3 私人再平衡: 跳过（TG_BOT_TOKEN/TG_CHAT_ID 未配置）", logs_path)
+            step4_target = None
+        if step4_target is None:
+            pass
+        else:
+            t0 = datetime.now(TZ)
+            user_id = str(step4_target.get("user_id", "") or "").strip()
+            portfolio_id = str(step4_target.get("portfolio_id", "") or "").strip()
+            step4_ok = True
+            step4_reason = "ok"
+            step4_err = None
+            try:
+                step4_ok, step4_reason = run_step4(
+                    external_report=step3_report_text,
+                    benchmark_context=benchmark_context,
+                    api_key=api_key,
+                    model=model,
+                    portfolio_id=portfolio_id,
+                    tg_bot_token=tg_bot_token,
+                    tg_chat_id=tg_chat_id,
+                )
+                step4_err = None if step4_ok else STEP4_REASON_MAP.get(step4_reason, step4_reason)
+            except Exception as e:
+                step4_ok = False
+                step4_reason = "unexpected_exception"
+                step4_err = str(e)
+            elapsed4 = (datetime.now(TZ) - t0).total_seconds()
+            summary.append({
+                "step": "私人再平衡",
+                "ok": step4_ok and step4_err is None,
+                "err": step4_err,
+                "elapsed_s": round(elapsed4, 1),
+                "output": (
+                    f"user={user_id}, portfolio={portfolio_id}, reason={step4_reason}"
+                ),
+            })
+            _log(
+                f"阶段 3 私人再平衡: user={user_id}, portfolio={portfolio_id}, "
+                f"ok={step4_ok}, reason={step4_reason}, elapsed={elapsed4:.1f}s, err={step4_err}",
+                logs_path,
             )
-            step4_err = None if step4_ok else STEP4_REASON_MAP.get(step4_reason, step4_reason)
-        except Exception as e:
-            step4_ok = False
-            step4_reason = "unexpected_exception"
-            step4_err = str(e)
-        elapsed4 = (datetime.now(TZ) - t0).total_seconds()
-        summary.append({
-            "step": "私人再平衡",
-            "ok": step4_ok and step4_err is None,
-            "err": step4_err,
-            "elapsed_s": round(elapsed4, 1),
-            "output": (
-                "telegram"
-                if (step4_ok and step4_reason == "ok")
-                else (f"skipped ({step4_reason})" if step4_ok else "failed")
-            ),
-        })
-        _log(f"阶段 3 私人再平衡: ok={step4_ok}, elapsed={elapsed4:.1f}s, err={step4_err}", logs_path)
 
     # 汇总
     total_elapsed = sum(s.get("elapsed_s", 0) for s in summary)

--- a/scripts/step4_rebalancer.py
+++ b/scripts/step4_rebalancer.py
@@ -62,7 +62,6 @@ STEP4_ENABLE_SPOT_PATCH = os.getenv("STEP4_ENABLE_SPOT_PATCH", "1").strip().lowe
 STEP4_SPOT_PATCH_RETRIES = int(os.getenv("STEP4_SPOT_PATCH_RETRIES", "2"))
 STEP4_SPOT_PATCH_SLEEP = float(os.getenv("STEP4_SPOT_PATCH_SLEEP", "0.3"))
 STEP4_ATR_SLIPPAGE_FACTOR = float(os.getenv("STEP4_ATR_SLIPPAGE_FACTOR", "0.25"))
-LIVE_PORTFOLIO_ID = "USER_LIVE"
 
 
 @dataclass
@@ -478,49 +477,6 @@ class WyckoffOrderEngine:
         )
 
 
-def load_portfolio_from_env(env_key: str = "MY_PORTFOLIO_STATE") -> PortfolioState:
-    raw = os.getenv(env_key, "").strip()
-    if not raw:
-        raise ValueError(f"{env_key} 未配置")
-    try:
-        data = json.loads(raw)
-    except Exception as e:
-        raise ValueError(f"{env_key} 非法 JSON: {e}") from e
-    if not isinstance(data, dict):
-        raise ValueError(f"{env_key} 必须是 JSON 对象")
-
-    free_cash = float(data.get("free_cash", 0.0) or 0.0)
-    total_equity_raw = data.get("total_equity")
-    total_equity = float(total_equity_raw) if total_equity_raw is not None else None
-
-    positions_raw = data.get("positions", []) or []
-    if not isinstance(positions_raw, list):
-        raise ValueError("positions 必须是数组")
-
-    positions: list[PositionItem] = []
-    for idx, item in enumerate(positions_raw, start=1):
-        if not isinstance(item, dict):
-            print(f"[step4] 跳过非法持仓#{idx}: 非对象")
-            continue
-        code = str(item.get("code", "")).strip()
-        if not re.fullmatch(r"\d{6}", code):
-            print(f"[step4] 跳过非法持仓#{idx}: code 非6位")
-            continue
-        positions.append(
-            PositionItem(
-                code=code,
-                name=str(item.get("name", code)).strip() or code,
-                cost=float(item.get("cost", 0.0) or 0.0),
-                buy_dt=str(item.get("buy_dt", "")).strip(),
-                shares=int(item.get("shares", 0) or 0),
-                strategy=str(item.get("strategy", "")).strip(),
-                stop_loss=float(item.get("stop_loss")) if item.get("stop_loss") is not None else None,
-            )
-        )
-
-    return PortfolioState(free_cash=free_cash, total_equity=total_equity, positions=positions)
-
-
 def _build_portfolio_from_dict(data: dict) -> PortfolioState:
     if not isinstance(data, dict):
         raise ValueError("portfolio data 必须是对象")
@@ -554,19 +510,36 @@ def _build_portfolio_from_dict(data: dict) -> PortfolioState:
     return PortfolioState(free_cash=free_cash, total_equity=total_equity, positions=positions)
 
 
-def load_portfolio_with_fallback() -> tuple[PortfolioState, str]:
+def _load_portfolio_from_env(env_key: str = "MY_PORTFOLIO_STATE") -> PortfolioState:
+    raw = os.getenv(env_key, "").strip()
+    if not raw:
+        raise ValueError(f"{env_key} 未配置")
+    try:
+        data = json.loads(raw)
+    except Exception as e:
+        raise ValueError(f"{env_key} 非法 JSON: {e}") from e
+    if not isinstance(data, dict):
+        raise ValueError(f"{env_key} 必须是 JSON 对象")
+    return _build_portfolio_from_dict(data)
+
+
+def load_portfolio_from_supabase(portfolio_id: str) -> tuple[PortfolioState, str]:
     """
-    优先读取 Supabase LIVE_PORTFOLIO_ID；失败或未配置时回退 MY_PORTFOLIO_STATE。
+    优先从 Supabase 读取指定 portfolio_id；
+    若缺失则回退到 MY_PORTFOLIO_STATE（Action Secret）。
     返回：(PortfolioState, source)
     """
-    sb_data = load_portfolio_state_from_supabase(LIVE_PORTFOLIO_ID)
+    sb_data = load_portfolio_state_from_supabase(portfolio_id)
     if sb_data:
         try:
-            return (_build_portfolio_from_dict(sb_data), f"supabase:{LIVE_PORTFOLIO_ID.lower()}")
+            return (_build_portfolio_from_dict(sb_data), f"supabase:{portfolio_id.lower()}")
         except Exception as e:
-            print(f"[step4] Supabase {LIVE_PORTFOLIO_ID} 解析失败，回退 env: {e}")
-    p = load_portfolio_from_env()
-    return (p, "env:MY_PORTFOLIO_STATE")
+            raise ValueError(f"Supabase {portfolio_id} 解析失败: {e}") from e
+    try:
+        p = _load_portfolio_from_env("MY_PORTFOLIO_STATE")
+        return (p, "env:MY_PORTFOLIO_STATE")
+    except Exception as e:
+        raise ValueError(f"Supabase {portfolio_id} 未就绪，且 env 持仓不可用: {e}") from e
 
 
 def _job_end_calendar_day() -> date:
@@ -990,13 +963,18 @@ def _split_telegram_message(content: str, max_len: int = TELEGRAM_MAX_LEN) -> li
     return chunks
 
 
-def send_to_telegram(message_text: str) -> bool:
+def send_to_telegram(
+    message_text: str,
+    *,
+    tg_bot_token: str,
+    tg_chat_id: str,
+) -> bool:
     import requests
 
-    token = os.getenv("TG_BOT_TOKEN", "").strip()
-    chat_id = os.getenv("TG_CHAT_ID", "").strip()
+    token = str(tg_bot_token or "").strip()
+    chat_id = str(tg_chat_id or "").strip()
     if not token or not chat_id:
-        print("[step4] TG_BOT_TOKEN/TG_CHAT_ID 未配置，跳过 Telegram 推送")
+        print("[step4] tg_bot_token/tg_chat_id 未配置，跳过 Telegram 推送")
         return False
 
     proxy_url = os.getenv("PROXY_URL", "").strip()
@@ -1126,24 +1104,30 @@ def run(
     benchmark_context: dict | None,
     api_key: str,
     model: str,
+    *,
+    portfolio_id: str,
+    tg_bot_token: str,
+    tg_chat_id: str,
 ) -> tuple[bool, str]:
     if not api_key or not api_key.strip():
         return (False, "missing_api_key")
+    if not portfolio_id:
+        return (True, "skipped_invalid_portfolio")
 
     try:
-        portfolio, portfolio_source = load_portfolio_with_fallback()
+        portfolio, portfolio_source = load_portfolio_from_supabase(portfolio_id)
     except Exception as e:
         print(f"[step4] 持仓读取失败: {e}")
         return (True, "skipped_invalid_portfolio")
-    print(f"[step4] 持仓来源: {portfolio_source}")
+    print(f"[step4] 持仓来源: {portfolio_source} | portfolio_id={portfolio_id}")
 
-    if not os.getenv("TG_BOT_TOKEN", "").strip() or not os.getenv("TG_CHAT_ID", "").strip():
-        print("[step4] TG_BOT_TOKEN/TG_CHAT_ID 未配置，跳过 Step4 推送")
+    if not str(tg_bot_token or "").strip() or not str(tg_chat_id or "").strip():
+        print("[step4] tg_bot_token/tg_chat_id 未配置，跳过 Step4 推送")
         return (True, "skipped_telegram_unconfigured")
 
     trade_date = _job_end_calendar_day().strftime("%Y-%m-%d")
-    if check_daily_run_exists(LIVE_PORTFOLIO_ID, trade_date):
-        print(f"[step4] 幂等性检查: {LIVE_PORTFOLIO_ID} {trade_date} 已运行过，跳过。")
+    if check_daily_run_exists(portfolio_id, trade_date):
+        print(f"[step4] 幂等性检查: {portfolio_id} {trade_date} 已运行过，跳过。")
         return (True, "skipped_idempotency")
 
     end_day = _job_end_calendar_day()
@@ -1296,10 +1280,10 @@ def run(
         if t.is_holding and t.effective_stop_loss is not None:
             updates.append({"code": t.code, "stop_loss": t.effective_stop_loss})
     if updates:
-        if update_position_stops(LIVE_PORTFOLIO_ID, updates):
-            print(f"[step4] 已更新 {len(updates)} 个持仓的止损价")
+        if update_position_stops(portfolio_id, updates):
+            print(f"[step4] 已更新 {len(updates)} 个持仓的止损价 | portfolio_id={portfolio_id}")
         else:
-            print("[step4] 持仓止损价更新失败")
+            print(f"[step4] 持仓止损价更新失败 | portfolio_id={portfolio_id}")
 
     run_id = datetime.now(CN_TZ).strftime("%Y%m%d_%H%M%S") + "_" + str(uuid4())[:8]
     ticket_rows = [
@@ -1335,34 +1319,41 @@ def run(
         free_cash_after=free_cash_after,
         tickets=tickets,
     )
-    sent = send_to_telegram(report)
+    sent = send_to_telegram(
+        report,
+        tg_bot_token=tg_bot_token,
+        tg_chat_id=tg_chat_id,
+    )
     if not sent:
         return (False, "telegram_failed")
 
     # Telegram 发送成功后才写入幂等标记，保证失败可重试
     if save_ai_trade_orders(
         run_id=run_id,
-        portfolio_id=LIVE_PORTFOLIO_ID,
+        portfolio_id=portfolio_id,
         model=model,
         trade_date=trade_date,
         market_view=market_view,
         orders=ticket_rows,
     ):
-        print(f"[step4] 已写入 AI 订单记录: run_id={run_id}, count={len(ticket_rows)}")
+        print(f"[step4] 已写入 AI 订单记录: run_id={run_id}, count={len(ticket_rows)}, portfolio_id={portfolio_id}")
     else:
-        print("[step4] AI 订单记录写入失败（已忽略，不阻断流程）")
+        print(f"[step4] AI 订单记录写入失败（已忽略，不阻断流程） | portfolio_id={portfolio_id}")
 
     positions_value = max(float(total_equity) - float(portfolio.free_cash), 0.0)
     if upsert_daily_nav(
-        portfolio_id=LIVE_PORTFOLIO_ID,
+        portfolio_id=portfolio_id,
         trade_date=trade_date,
         free_cash=portfolio.free_cash,
         total_equity=float(total_equity),
         positions_value=positions_value,
     ):
-        print(f"[step4] 已写入 USER_LIVE 日净值快照: {trade_date}")
+        print(f"[step4] 已写入 {portfolio_id} 日净值快照: {trade_date}")
     else:
-        print("[step4] USER_LIVE 日净值快照写入失败（已忽略）")
+        print(f"[step4] {portfolio_id} 日净值快照写入失败（已忽略）")
 
-    print(f"[step4] 交易工单发送成功: decisions={len(decisions)}, tickets={len(tickets)}, model={model}")
+    print(
+        f"[step4] 交易工单发送成功: decisions={len(decisions)}, tickets={len(tickets)}, "
+        f"model={model}, portfolio_id={portfolio_id}"
+    )
     return (True, "ok")


### PR DESCRIPTION
…r to single user id

- enforce per-user portfolio scope in Web: USER_LIVE:<user_id> for Portfolio/Settings pages\n- clear sensitive session state on logout and before loading user settings to avoid cross-account bleed\n- remove Web env fallbacks for sensitive keys (gemini/tg/tushare/feishu)\n- rework daily_job stage3 to run a single target from Action secret SUPABASE_USER_ID\n- keep Step4 runtime keys from Actions env (GEMINI/TG) and support MY_PORTFOLIO_STATE fallback if Supabase holding is missing\n- update workflow env wiring and docs/.env example accordingly