### PR TITLE
feat(feishu,premarket): add premarket action matrix and inline Chines…

### DIFF
--- a/scripts/premarket_risk_job.py
+++ b/scripts/premarket_risk_job.py
@@ -30,6 +30,42 @@ RISK_VIX_CRASH_PCT = float(os.getenv("PREMARKET_VIX_CRASH_PCT", "15.0"))
 RISK_VIX_OFF_PCT = float(os.getenv("PREMARKET_VIX_RISK_OFF_PCT", "8.0"))
 
 
+def _build_action_matrix(regime: str) -> list[str]:
+    """盘前动作开关（仅门控建议，不直接下单）"""
+    if regime == "BLACK_SWAN":
+        return [
+            "🔒 **盘前动作开关**（BLACK_SWAN）",
+            "- ✅ `EXIT`：允许（破位/止损优先执行）",
+            "- ✅ `TRIM`：允许（主动降风险）",
+            "- ⚠️ `HOLD`：允许（仅守防线，不主观乐观）",
+            "- ⛔ `LIGHT_ADD`：禁止",
+            "- ⛔ `PROBE`：禁止",
+            "- ⛔ `ATTACK`：禁止",
+            "- ⛔ `FULL_ATTACK`：禁止",
+        ]
+    if regime == "RISK_OFF":
+        return [
+            "🔒 **盘前动作开关**（RISK_OFF）",
+            "- ✅ `EXIT`：允许",
+            "- ✅ `TRIM`：允许",
+            "- ✅ `HOLD`：允许（防守为主）",
+            "- ⚠️ `LIGHT_ADD`：仅允许对**已有浮盈仓位**小幅加仓（总权益 <= 5%）",
+            "- ⛔ `PROBE`：默认禁止",
+            "- ⛔ `ATTACK`：禁止",
+            "- ⛔ `FULL_ATTACK`：禁止",
+        ]
+    return [
+        "🔓 **盘前动作开关**（NORMAL）",
+        "- ✅ `EXIT`：允许",
+        "- ✅ `TRIM`：允许",
+        "- ✅ `HOLD`：允许",
+        "- ⚠️ `LIGHT_ADD`：条件允许（仅确认强势且量价匹配）",
+        "- ⚠️ `PROBE`：条件允许（控制仓位）",
+        "- ⚠️ `ATTACK`：条件允许（需盘中二次确认）",
+        "- ⛔ `FULL_ATTACK`：默认禁止；仅在强一致 Risk-On 且盘中确认后考虑",
+    ]
+
+
 def _now() -> str:
     return datetime.now(TZ).strftime("%Y-%m-%d %H:%M:%S")
 
@@ -322,21 +358,28 @@ def main() -> int:
     _log(f"A50: {json.dumps(a50, ensure_ascii=False)}", logs_path)
     _log(f"VIX: {json.dumps(vix, ensure_ascii=False)}", logs_path)
     _log(f"风控结论: regime={regime}, reasons={reasons}", logs_path)
+    action_lines = _build_action_matrix(regime)
+    _log("盘前动作开关: " + " | ".join(action_lines[1:]), logs_path)
 
-    content = "\n".join(
+    content_parts = [
+        f"**当前北京时间**: {_now()}",
+        f"**结论**: `{regime}`",
+        f"**触发原因**: {'；'.join(reasons)}",
+        "",
+        f"**A50** ({a50.get('source')}): "
+        f"date={a50.get('date')}, close={a50.get('close')}, pct={a50.get('pct_chg')}",
+        f"**VIX** ({vix.get('source')}): "
+        f"date={vix.get('date')}, close={vix.get('close')}, pct={vix.get('pct_chg')}",
+        "",
+    ]
+    content_parts.extend(action_lines)
+    content_parts.extend(
         [
-            f"**当前北京时间**: {_now()}",
-            f"**结论**: `{regime}`",
-            f"**触发原因**: {'；'.join(reasons)}",
             "",
-            f"**A50** ({a50.get('source')}): "
-            f"date={a50.get('date')}, close={a50.get('close')}, pct={a50.get('pct_chg')}",
-            f"**VIX** ({vix.get('source')}): "
-            f"date={vix.get('date')}, close={vix.get('close')}, pct={vix.get('pct_chg')}",
-            "",
-            "说明：该任务仅做盘前风控判定，不执行选股和下单。",
+            "说明：该任务仅做盘前风控与动作门控建议，不执行选股和下单。",
         ]
     )
+    content = "\n".join(content_parts)
 
     if args.dry_run:
         _log("--dry-run: 不发送飞书", logs_path)

--- a/utils/feishu.py
+++ b/utils/feishu.py
@@ -9,8 +9,62 @@
 from __future__ import annotations
 
 import os
+import re
 import requests
 import time
+
+
+_TERM_GLOSSARY_PATTERNS: list[tuple[re.Pattern, str]] = [
+    # Regime / risk state
+    (re.compile(r"\bBLACK_SWAN\b(?!\s*[（(])"), "BLACK_SWAN（黑天鹅高风险）"),
+    (re.compile(r"\bRISK_OFF\b(?!\s*[（(])"), "RISK_OFF（风险收缩）"),
+    (re.compile(r"\bRISK_ON\b(?!\s*[（(])"), "RISK_ON（风险偏好）"),
+    (re.compile(r"\bNORMAL\b(?!\s*[（(])"), "NORMAL（常态）"),
+    (re.compile(r"\bPANIC_REPAIR\b(?!\s*[（(])"), "PANIC_REPAIR（恐慌修复）"),
+    # Macro / market indicators
+    (re.compile(r"\bVIX\b(?!\s*[（(])"), "VIX（波动率恐慌指数）"),
+    (re.compile(r"\bA50\b(?!\s*[（(])"), "A50（富时中国A50期货）"),
+    (re.compile(r"\bATR\b(?!\s*[（(])"), "ATR（真实波动幅度）"),
+    (re.compile(r"\bRPS\b(?!\s*[（(])"), "RPS（相对强弱百分位）"),
+    (re.compile(r"\bQPS\b(?!\s*[（(])"), "QPS（每秒请求量）"),
+    # OMS actions
+    (re.compile(r"\bFULL_ATTACK\b(?!\s*[（(])"), "FULL_ATTACK（全仓进攻）"),
+    (re.compile(r"\bLIGHT_ADD\b(?!\s*[（(])"), "LIGHT_ADD（轻量加仓）"),
+    (re.compile(r"\bATTACK\b(?!\s*[（(])"), "ATTACK（进攻建仓）"),
+    (re.compile(r"\bPROBE\b(?!\s*[（(])"), "PROBE（试探建仓）"),
+    (re.compile(r"\bTRIM\b(?!\s*[（(])"), "TRIM（减仓）"),
+    (re.compile(r"\bHOLD\b(?!\s*[（(])"), "HOLD（持有观察）"),
+    (re.compile(r"\bEXIT\b(?!\s*[（(])"), "EXIT（清仓离场）"),
+    (re.compile(r"\bNO_TRADE\b(?!\s*[（(])"), "NO_TRADE（拒单）"),
+    (re.compile(r"\bAPPROVED\b(?!\s*[（(])"), "APPROVED（核准执行）"),
+    # Wyckoff terms
+    (re.compile(r"\bComposite Man\b(?!\s*[（(])"), "Composite Man（综合人/主力）"),
+    (re.compile(r"\bTape Reading\b(?!\s*[（(])"), "Tape Reading（盘面解读）"),
+    (re.compile(r"\bSpring\b(?!\s*[（(])"), "Spring（弹簧/假跌破）"),
+    (re.compile(r"\bLPS\b(?!\s*[（(])"), "LPS（最后支撑点）"),
+    (re.compile(r"\bSOS\b(?!\s*[（(])"), "SOS（强势信号）"),
+    (re.compile(r"\bUTAD\b(?!\s*[（(])"), "UTAD（上冲诱多）"),
+    (re.compile(r"\bEVR\b(?!\s*[（(])"), "EVR（努力无结果）"),
+    (re.compile(r"\bJAC\b(?!\s*[（(])"), "JAC（跃过小溪）"),
+    (re.compile(r"\bBUEC\b(?!\s*[（(])"), "BUEC（回踩小溪边缘）"),
+    # Common trade terms
+    (re.compile(r"\bStop[- ]?Loss\b(?!\s*[（(])", re.IGNORECASE), "Stop-Loss（止损位）"),
+    (re.compile(r"\bEntry\b(?!\s*[（(])", re.IGNORECASE), "Entry（入场区）"),
+    (re.compile(r"\bTarget\b(?!\s*[（(])", re.IGNORECASE), "Target（目标位）"),
+]
+
+
+def _annotate_financial_terms(content: str) -> str:
+    """
+    将常见金融英文术语补充为“术语（中文解释）”，提升飞书可读性。
+    已带括号解释的术语会跳过，避免重复注释。
+    """
+    if not content:
+        return content
+    out = content
+    for pattern, replacement in _TERM_GLOSSARY_PATTERNS:
+        out = pattern.sub(replacement, out)
+    return out
 
 
 def _normalize_for_lark_md(content: str) -> str:
@@ -98,7 +152,8 @@ def send_feishu_notification(webhook_url: str, title: str, content: str) -> bool
     if not webhook_url or not webhook_url.strip():
         return False
 
-    normalized = _normalize_for_lark_md(content)
+    annotated = _annotate_financial_terms(content)
+    normalized = _normalize_for_lark_md(annotated)
     max_len = int(os.getenv("FEISHU_LARK_MAX_LEN", "2800"))
     chunks = _split_lark_md(normalized, max_len=max_len)
 


### PR DESCRIPTION
…e glossary for financial terms

- premarket risk card now includes 7-level action gating matrix based on regime (NORMAL/RISK_OFF/BLACK_SWAN): EXIT/TRIM/HOLD/LIGHT_ADD/PROBE/ATTACK/FULL_ATTACK\n- add premarket log line for action gating details to improve traceability\n- upgrade premarket card footer wording to clarify it only provides risk and action gating guidance\n- centralize Feishu readability enhancement: annotate common finance terms as English + Chinese explanation before markdown normalization\n- glossary covers regime states, macro indicators (A50/VIX/ATR/RPS), OMS actions, Wyckoff terms, and common trade fields (Stop-Loss/Entry/Target)\n- annotation is idempotent-friendly via negative-lookahead to avoid duplicating already explained terms