### PR TITLE
chore: adjust premarket risk schedule to 07:00 Beijing

### DIFF
--- a/.github/workflows/premarket_risk.yml
+++ b/.github/workflows/premarket_risk.yml
@@ -2,8 +2,9 @@ name: Premarket Risk
 
 on:
   schedule:
-    # 北京时间 08:25（UTC+8）= UTC 同日 00:25，周一到周五盘前执行
-    - cron: "25 0 * * 1-5"
+    # 北京时间 07:00（UTC+8）= UTC 前一日 23:00；为保证“北京时间周一到周五”触发，UTC 需配置为周日到周四
+    # 目的：提前执行并尽量避开早高峰排队，给盘前风控留足缓冲时间
+    - cron: "0 23 * * 0-4"
   workflow_dispatch:
 
 concurrency:

--- a/scripts/premarket_risk_job.py
+++ b/scripts/premarket_risk_job.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-盘前风控任务（周一到周五 07:55, Asia/Shanghai）：
+盘前风控任务（周一到周五 07:00, Asia/Shanghai）：
 - 富时 A50（akshare）
 - VIX（优先 Stooq，失败回退 Yahoo）
 


### PR DESCRIPTION
## Summary
- adjust premarket risk GitHub Actions cron to run at 07:00 Beijing time
- sync `scripts/premarket_risk_job.py` header comment with the new schedule

## Why
- reduce risk of queue delays pushing execution too close to market hours
- keep workflow schedule and script docs consistent

## Notes
- UTC cron is set to previous day 23:00 (Sun-Thu) to represent Beijing Mon-Fri 07:00