### PR TITLE
fix: keep partial tickflow batch results

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -177,7 +177,7 @@ class TestDataFetcher:
         result = latest_trade_date_from_hist(df)
         assert result == date(2025, 1, 2)
 
-    def test_tickflow_batch_partial_returns_none(self, monkeypatch):
+    def test_tickflow_batch_partial_keeps_available_frames(self, monkeypatch):
         import tools.data_fetcher as dfetcher
 
         class FakeTickFlowClient:
@@ -205,7 +205,11 @@ class TestDataFetcher:
 
         result = dfetcher._fetch_all_ohlcv_tickflow_batch(["000001", "000002"], window, False, 200, 0)
 
-        assert result is None
+        assert result is not None
+        df_map, stats = result
+        assert list(df_map) == ["000001"]
+        assert stats["fetch_ok"] == 1
+        assert stats["fetch_fail"] == 1
 
     def test_fetch_hist_direct_source_bypasses_cached_repository(self, monkeypatch):
         import integrations.data_source as data_source

--- a/tools/data_fetcher.py
+++ b/tools/data_fetcher.py
@@ -262,16 +262,17 @@ def _fetch_all_ohlcv_tickflow_batch(
     if not df_map:
         return None
     missing = max(len(symbols) - len(df_map), 0)
-    if failed_batches or missing:
-        print(
-            f"[funnel] TickFlow 批量日K不完整，回退单票链路: "
-            f"成功={len(df_map)}, 缺失={missing}, 失败批次={failed_batches}"
-        )
-        return None
     stats = _tickflow_fetch_stats(len(symbols), df_map, fetch_spot_patched, started)
-    print(
-        f"[funnel] TickFlow 批量日K完成: 成功={stats['fetch_ok']}, 失败={stats['fetch_fail']}, 耗时={stats['fetch_elapsed_s']}s"
-    )
+    if failed_batches or missing:
+        missing_sample = ",".join([s for s in symbols if s not in df_map][:8])
+        print(
+            f"[funnel] TickFlow 批量日K部分完成: 成功={stats['fetch_ok']}, 缺失={missing}, "
+            f"失败批次={failed_batches}, sample_missing={missing_sample or '-'}, 耗时={stats['fetch_elapsed_s']}s"
+        )
+    else:
+        print(
+            f"[funnel] TickFlow 批量日K完成: 成功={stats['fetch_ok']}, 失败={stats['fetch_fail']}, 耗时={stats['fetch_elapsed_s']}s"
+        )
     return df_map, stats
 
 


### PR DESCRIPTION
## Summary\n- keep usable TickFlow batch K-line results when a batch response is partial\n- count missing symbols as fetch failures instead of falling back to single-symbol fetches for the whole universe\n- update the regression test for partial batch responses\n\n## Tests\n- pytest tests/test_tools.py tests/integrations/test_tickflow_client_market_batch.py tests/test_wyckoff_funnel_etf.py -q\n- ruff check tools/data_fetcher.py tests/test_tools.py\n- ruff format --check tools/data_fetcher.py tests/test_tools.py\n- python scripts/quality_gate.py --check-functions