### PR TITLE
fix: retain recommendation tracking by market dates

### DIFF
--- a/.github/workflows/db_maintenance.yml
+++ b/.github/workflows/db_maintenance.yml
@@ -2,8 +2,8 @@ name: DB Maintenance
 
 on:
   schedule:
-    # 北京时间 23:05（UTC+8）
-    - cron: "5 15 * * *"
+    # 北京时间次日 06:20（UTC+8），在美股收盘后任务之后、A股开盘前执行。
+    - cron: "20 22 * * 1-5"
   workflow_dispatch:
 
 concurrency:

--- a/scripts/db_maintenance.py
+++ b/scripts/db_maintenance.py
@@ -17,6 +17,8 @@ from core.constants import (
     TABLE_DAILY_NAV,
     TABLE_MARKET_SIGNAL_DAILY,
     TABLE_RECOMMENDATION_TRACKING,
+    TABLE_RECOMMENDATION_TRACKING_HK,
+    TABLE_RECOMMENDATION_TRACKING_US,
     TABLE_SIGNAL_PENDING,
     TABLE_TAIL_BUY_HISTORY,
     TABLE_TRADE_ORDERS,
@@ -36,6 +38,11 @@ CLEANUP_RULES: list[tuple[str, str, int, str]] = [
 ]
 RECOMMENDATION_KEEP_DATES = 30
 RECOMMENDATION_DATE_PAGE_SIZE = 1000
+RECOMMENDATION_TRACKING_TABLES = (
+    TABLE_RECOMMENDATION_TRACKING,
+    TABLE_RECOMMENDATION_TRACKING_US,
+    TABLE_RECOMMENDATION_TRACKING_HK,
+)
 
 
 def _cutoff_value(ttl_days: int, kind: str) -> str | int:
@@ -72,18 +79,13 @@ def _to_int_date(value: object) -> int | None:
         return None
 
 
-def _latest_recommend_dates(client, keep_dates: int, page_size: int) -> list[int]:
+def _latest_recommend_dates(client, table: str, keep_dates: int, page_size: int) -> list[int]:
     dates: list[int] = []
     seen: set[int] = set()
     before_date: int | None = None
 
     while len(dates) < keep_dates:
-        query = (
-            client.table(TABLE_RECOMMENDATION_TRACKING)
-            .select("recommend_date")
-            .order("recommend_date", desc=True)
-            .limit(page_size)
-        )
+        query = client.table(table).select("recommend_date").order("recommend_date", desc=True).limit(page_size)
         if before_date is not None:
             query = query.lt("recommend_date", before_date)
 
@@ -105,8 +107,9 @@ def _latest_recommend_dates(client, keep_dates: int, page_size: int) -> list[int
     return dates
 
 
-def cleanup_recommendation_tracking(
+def cleanup_recommendation_table(
     client,
+    table: str,
     *,
     keep_dates: int = RECOMMENDATION_KEEP_DATES,
     page_size: int = RECOMMENDATION_DATE_PAGE_SIZE,
@@ -114,7 +117,7 @@ def cleanup_recommendation_tracking(
 ) -> tuple[str, int | None]:
     keep_dates = max(int(keep_dates), 1)
     page_size = max(int(page_size), 1)
-    dates = _latest_recommend_dates(client, keep_dates, page_size)
+    dates = _latest_recommend_dates(client, table, keep_dates, page_size)
     if len(dates) < keep_dates:
         count = 0 if dry_run else None
         return f"keep_all, keep_dates={keep_dates}, distinct_dates={len(dates)}", count
@@ -122,18 +125,28 @@ def cleanup_recommendation_tracking(
     cutoff = dates[keep_dates - 1]
     try:
         if dry_run:
-            resp = (
-                client.table(TABLE_RECOMMENDATION_TRACKING)
-                .select("*", count="exact")
-                .lt("recommend_date", cutoff)
-                .limit(0)
-                .execute()
-            )
+            resp = client.table(table).select("*", count="exact").lt("recommend_date", cutoff).limit(0).execute()
             return f"dry_run, keep_dates={keep_dates}, cutoff={cutoff}", resp.count or 0
-        client.table(TABLE_RECOMMENDATION_TRACKING).delete().lt("recommend_date", cutoff).execute()
+        client.table(table).delete().lt("recommend_date", cutoff).execute()
         return f"ok, keep_dates={keep_dates}, cutoff={cutoff}", None
     except Exception as e:
         return f"error: {e}", None
+
+
+def cleanup_recommendation_tracking(
+    client,
+    *,
+    keep_dates: int = RECOMMENDATION_KEEP_DATES,
+    page_size: int = RECOMMENDATION_DATE_PAGE_SIZE,
+    dry_run: bool = False,
+) -> tuple[str, int | None]:
+    return cleanup_recommendation_table(
+        client,
+        TABLE_RECOMMENDATION_TRACKING,
+        keep_dates=keep_dates,
+        page_size=page_size,
+        dry_run=dry_run,
+    )
 
 
 def main() -> int:
@@ -158,11 +171,12 @@ def main() -> int:
         if status.startswith("error"):
             all_ok = False
 
-    status, count = cleanup_recommendation_tracking(client, dry_run=args.dry_run)
-    suffix = f" ({count} rows)" if count is not None else ""
-    print(f"[db_maintenance] {TABLE_RECOMMENDATION_TRACKING}: {status}{suffix}")
-    if status.startswith("error"):
-        all_ok = False
+    for table in RECOMMENDATION_TRACKING_TABLES:
+        status, count = cleanup_recommendation_table(client, table, dry_run=args.dry_run)
+        suffix = f" ({count} rows)" if count is not None else ""
+        print(f"[db_maintenance] {table}: {status}{suffix}")
+        if status.startswith("error"):
+            all_ok = False
 
     return 0 if all_ok else 1
 

--- a/tests/test_db_maintenance.py
+++ b/tests/test_db_maintenance.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from scripts.db_maintenance import cleanup_recommendation_tracking
+from scripts.db_maintenance import cleanup_recommendation_table, cleanup_recommendation_tracking
 
 
 @dataclass
@@ -12,8 +12,9 @@ class _Response:
 
 
 class _FakeTable:
-    def __init__(self, client: _FakeClient):
+    def __init__(self, client: _FakeClient, name: str):
         self.client = client
+        self.name = name
         self.delete_mode = False
         self.filters: list[tuple[str, int]] = []
         self.limit_value: int | None = None
@@ -41,13 +42,13 @@ class _FakeTable:
         return self
 
     def execute(self):
-        rows = self.client.rows
+        rows = self.client.tables.setdefault(self.name, [])
         for column, value in self.filters:
             rows = [row for row in rows if row[column] < value]
 
         if self.delete_mode:
             deleted_ids = {id(row) for row in rows}
-            self.client.rows = [row for row in self.client.rows if id(row) not in deleted_ids]
+            self.client.tables[self.name] = [row for row in self.client.tables[self.name] if id(row) not in deleted_ids]
             return _Response(data=[])
 
         ordered = sorted(rows, key=lambda row: row["recommend_date"], reverse=self.order_desc)
@@ -56,11 +57,15 @@ class _FakeTable:
 
 
 class _FakeClient:
-    def __init__(self, rows: list[dict]):
-        self.rows = rows
+    def __init__(self, rows: list[dict] | dict[str, list[dict]]):
+        self.tables = {"recommendation_tracking": rows} if isinstance(rows, list) else rows
 
-    def table(self, _name: str):
-        return _FakeTable(self)
+    @property
+    def rows(self) -> list[dict]:
+        return self.tables["recommendation_tracking"]
+
+    def table(self, name: str):
+        return _FakeTable(self, name)
 
 
 def test_cleanup_recommendation_tracking_keeps_latest_distinct_dates():
@@ -86,3 +91,28 @@ def test_cleanup_recommendation_tracking_dry_run_counts_rows_before_cutoff():
     assert status == "dry_run, keep_dates=3, cutoff=20260430"
     assert count == 2
     assert len(client.rows) == 8
+
+
+def test_cleanup_recommendation_table_uses_requested_table():
+    client = _FakeClient(
+        {
+            "recommendation_tracking": [{"recommend_date": 20260505, "code": 1}],
+            "recommendation_tracking_us": [
+                {"recommend_date": 20260505, "code": "A.US"},
+                {"recommend_date": 20260504, "code": "B.US"},
+                {"recommend_date": 20260503, "code": "C.US"},
+            ],
+        }
+    )
+
+    status, count = cleanup_recommendation_table(
+        client,
+        "recommendation_tracking_us",
+        keep_dates=2,
+        page_size=10,
+    )
+
+    assert status == "ok, keep_dates=2, cutoff=20260504"
+    assert count is None
+    assert [row["recommend_date"] for row in client.tables["recommendation_tracking_us"]] == [20260505, 20260504]
+    assert client.rows == [{"recommend_date": 20260505, "code": 1}]


### PR DESCRIPTION
## Summary\n- keep the latest 30 distinct recommendation dates for CN, US, and HK tracking tables\n- move DB maintenance to 06:20 Beijing time after the US-market post-close window and before A-share open\n- keep the existing CN cleanup wrapper for compatibility and add coverage for market-specific tables\n\n## Verification\n- pytest tests/test_db_maintenance.py -q\n- ruff check scripts/db_maintenance.py tests/test_db_maintenance.py\n- ruff format --check scripts/db_maintenance.py tests/test_db_maintenance.py\n- python scripts/quality_gate.py --check-functions\n- scripts/db_maintenance.py --dry-run against current Supabase config