### PR TITLE
fix: show earliest tracking selection row

### DIFF
--- a/web/apps/web/src/routes/tracking.tsx
+++ b/web/apps/web/src/routes/tracking.tsx
@@ -671,7 +671,7 @@ function getLatestRecommendDates(rows: Recommendation[], limit: number): number[
 }
 
 function dedupeRecommendations(rows: Recommendation[]): Recommendation[] {
-  const sortedRows = [...rows].sort((a, b) => b.recommend_date - a.recommend_date)
+  const sortedRows = [...rows].sort((a, b) => a.recommend_date - b.recommend_date)
   const byCode = new Map<number | string, Recommendation>()
   for (const row of sortedRows) {
     const existing = byCode.get(row.code)


### PR DESCRIPTION
## Summary\n- when tracking rows are deduped by code, use the earliest recommendation row as the display baseline\n- this makes selection date, initial price, and change percentage all refer to the first retained selection\n- keep recommendation count aggregation unchanged\n\n## Tests\n- COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm -r exec tsc --noEmit\n- COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm --filter @wyckoff/web test\n- COREPACK_ENABLE_AUTO_PIN=0 corepack pnpm --filter @wyckoff/web build