### PR TITLE
[codex] send input preview as Feishu file

### DIFF
--- a/.github/workflows/wyckoff_input_preview.yml
+++ b/.github/workflows/wyckoff_input_preview.yml
@@ -24,6 +24,12 @@ jobs:
       DEBUG_MODEL_IO: "1"
       DEBUG_MODEL_IO_FULL: "1"
       DAILY_JOB_PREVIEW_ONLY: "1"
+      STEP3_INPUT_PREVIEW_PATH: ${{ github.workspace }}/logs/step3_llm_input_preview.md
+      FEISHU_INPUT_PREVIEW_AS_FILE: "1"
+      FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
+      FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+      FEISHU_PREVIEW_CHAT_ID: ${{ secrets.FEISHU_PREVIEW_CHAT_ID }}
+      FEISHU_CHAT_ID: ${{ secrets.FEISHU_CHAT_ID }}
       # 测试任务不触发实盘再平衡
       DAILY_JOB_SKIP_STEP4: "1"
       TZ: Asia/Shanghai

--- a/scripts/step3_batch_report.py
+++ b/scripts/step3_batch_report.py
@@ -49,7 +49,7 @@ from tools.report_builder import (
 from tools.report_builder import (
     build_track_user_message as _build_track_user_message,
 )
-from utils.feishu import send_feishu_notification
+from utils.feishu import send_feishu_file, send_feishu_notification
 from utils.notify import send_dingtalk_notification, send_wecom_notification
 from utils.trading_clock import resolve_end_calendar_day
 
@@ -160,9 +160,6 @@ def _send_input_preview(
     wecom_webhook: str = "",
     dingtalk_webhook: str = "",
 ) -> tuple[bool, str]:
-    """
-    预演模式：不调用模型，仅展示将发送给模型的输入内容。
-    """
     total_selected = sum(int(x.get("selected_count", 0) or 0) for x in previews)
     blocks: list[str] = [
         "# 🧪 Step3 模型输入预演（未调用大模型）",
@@ -179,31 +176,88 @@ def _send_input_preview(
         "",
     ]
     for idx, item in enumerate(previews, start=1):
-        blocks.extend(
-            [
-                f"## USER MESSAGE {idx} / {len(previews)}",
-                "",
-                f"- 轨道: `{item.get('track', '')}`",
-                f"- 股票数: `{item.get('selected_count', 0)}`",
-                "",
-                "```text",
-                str(item.get("user_message", "") or ""),
-                "```",
-                "",
-            ]
-        )
+        blocks += [
+            f"## USER MESSAGE {idx} / {len(previews)}",
+            "",
+            f"- 轨道: `{item.get('track', '')}`",
+            f"- 股票数: `{item.get('selected_count', 0)}`",
+            "",
+            "```text",
+            str(item.get("user_message", "") or ""),
+            "```",
+            "",
+        ]
     report = "\n".join(blocks).rstrip() + "\n"
     title = f"🧪 模型输入预演 {date.today().strftime('%Y-%m-%d')}"
-    sent = send_feishu_notification(webhook_url, title, report) if webhook_url else True
+    artifact_path = _write_input_preview_artifact(report)
+    file_enabled = _preview_file_enabled()
+    file_sent = send_feishu_file(artifact_path) if file_enabled else False
+    notification = _build_input_preview_notice(model, total_selected, previews, artifact_path) if file_sent else report
+    sent = send_feishu_notification(webhook_url, title, notification) if webhook_url else file_sent or not file_enabled
     if wecom_webhook:
-        send_wecom_notification(wecom_webhook, title, report)
+        send_wecom_notification(wecom_webhook, title, notification)
     if dingtalk_webhook:
-        send_dingtalk_notification(dingtalk_webhook, title, report)
+        send_dingtalk_notification(dingtalk_webhook, title, notification)
     if not sent:
         print("[step3] 预演报告飞书推送失败")
         return (False, report)
-    print(f"[step3] 预演报告发送成功，股票数={total_selected}")
+    print(f"[step3] 预演报告发送成功，股票数={total_selected}, file_sent={file_sent}, path={artifact_path}")
     return (True, report)
+
+
+def _preview_file_enabled() -> bool:
+    return os.getenv("FEISHU_INPUT_PREVIEW_AS_FILE", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _write_input_preview_artifact(report: str) -> str:
+    path = os.getenv("STEP3_INPUT_PREVIEW_PATH", "").strip()
+    if not path:
+        path = os.path.join(os.getenv("LOGS_DIR", "logs"), "step3_llm_input_preview.md")
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(report)
+    return path
+
+
+def _github_run_url() -> str:
+    server_url = os.getenv("GITHUB_SERVER_URL", "").strip()
+    repository = os.getenv("GITHUB_REPOSITORY", "").strip()
+    run_id = os.getenv("GITHUB_RUN_ID", "").strip()
+    if not server_url or not repository or not run_id:
+        return ""
+    return f"{server_url}/{repository}/actions/runs/{run_id}"
+
+
+def _build_input_preview_notice(
+    model: str,
+    total_selected: int,
+    previews: list[dict],
+    artifact_path: str,
+) -> str:
+    run_number = os.getenv("GITHUB_RUN_NUMBER", "").strip()
+    artifact_name = f"input-preview-logs-{run_number}" if run_number else "input-preview-logs-*"
+    track_parts = [
+        f"{str(item.get('track', '') or 'Unknown')} {int(item.get('selected_count', 0) or 0)}" for item in previews
+    ]
+    lines = [
+        "完整 LLM input 已作为飞书文件发送，卡片不再展开长文本。",
+        "",
+        f"- 目标模型: `{model}`",
+        f"- 输入股票数: `{total_selected}`",
+        f"- 分轨: `{', '.join(track_parts) if track_parts else '-'}`",
+        f"- 文件名: `{os.path.basename(artifact_path)}`",
+        f"- Actions 备份 artifact: `{artifact_name}`",
+    ]
+    run_url = _github_run_url()
+    if run_url:
+        lines.append(f"- Run: {run_url}")
+    lines.extend(
+        [
+            "",
+            "任务结束后，在本次 Actions 页面底部 Artifacts 下载该文件。",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def _has_required_sections(report: str) -> bool:

--- a/tests/test_daily_job_preview.py
+++ b/tests/test_daily_job_preview.py
@@ -86,3 +86,66 @@ def test_signal_confirmation_dry_run_does_not_write(monkeypatch):
 
     assert confirmed == [{"code": "000001"}]
     assert writes == []
+
+
+def test_step3_input_preview_sends_summary_and_writes_artifact(monkeypatch, tmp_path):
+    import scripts.step3_batch_report as step3
+
+    sent: dict[str, str] = {}
+    artifact_path = tmp_path / "step3_llm_input_preview.md"
+    monkeypatch.setenv("STEP3_INPUT_PREVIEW_PATH", str(artifact_path))
+    monkeypatch.setenv("FEISHU_INPUT_PREVIEW_AS_FILE", "1")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "YoungCan-Wang/WyckoffTradingAgent")
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setenv("GITHUB_RUN_NUMBER", "456")
+
+    def fake_send_feishu(_webhook_url, title, content):
+        sent["title"] = title
+        sent["content"] = content
+        return True
+
+    monkeypatch.setattr(step3, "send_feishu_notification", fake_send_feishu)
+    monkeypatch.setattr(step3, "send_feishu_file", lambda path: path == str(artifact_path))
+
+    ok, report = step3._send_input_preview(
+        webhook_url="https://example.invalid/hook",
+        model="gemini-test",
+        system_prompt="SYSTEM PROMPT BODY",
+        previews=[{"track": "Trend", "selected_count": 2, "user_message": "VERY LONG USER MESSAGE"}],
+    )
+
+    assert ok is True
+    assert report == artifact_path.read_text(encoding="utf-8")
+    assert "SYSTEM PROMPT BODY" in report
+    assert "VERY LONG USER MESSAGE" in report
+    assert "SYSTEM PROMPT BODY" not in sent["content"]
+    assert "VERY LONG USER MESSAGE" not in sent["content"]
+    assert "step3_llm_input_preview.md" in sent["content"]
+    assert "input-preview-logs-456" in sent["content"]
+    assert "https://github.com/YoungCan-Wang/WyckoffTradingAgent/actions/runs/123" in sent["content"]
+
+
+def test_step3_input_preview_falls_back_to_original_when_file_send_fails(monkeypatch, tmp_path):
+    import scripts.step3_batch_report as step3
+
+    sent: dict[str, str] = {}
+    monkeypatch.setenv("STEP3_INPUT_PREVIEW_PATH", str(tmp_path / "step3_llm_input_preview.md"))
+    monkeypatch.setenv("FEISHU_INPUT_PREVIEW_AS_FILE", "1")
+    monkeypatch.setattr(step3, "send_feishu_file", lambda _path: False)
+    monkeypatch.setattr(
+        step3,
+        "send_feishu_notification",
+        lambda _webhook_url, _title, content: sent.setdefault("content", content) is not None,
+    )
+
+    ok, _report = step3._send_input_preview(
+        webhook_url="https://example.invalid/hook",
+        model="gemini-test",
+        system_prompt="SYSTEM PROMPT BODY",
+        previews=[{"track": "Trend", "selected_count": 2, "user_message": "VERY LONG USER MESSAGE"}],
+    )
+
+    assert ok is True
+    assert "SYSTEM PROMPT BODY" in sent["content"]
+    assert "VERY LONG USER MESSAGE" in sent["content"]

--- a/utils/feishu.py
+++ b/utils/feishu.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import time
@@ -641,6 +642,104 @@ def send_tail_buy_card(webhook_url: str, title: str, content: str) -> bool:
         return True
     print(f"[feishu] tail_buy rich card failed: {err}")
     return False
+
+
+def _feishu_api_base_url() -> str:
+    return os.getenv("FEISHU_OPENAPI_BASE_URL", "https://open.feishu.cn/open-apis").strip().rstrip("/")
+
+
+def _feishu_file_credentials(chat_id: str, app_id: str, app_secret: str) -> tuple[str, str, str]:
+    app_id = (app_id or os.getenv("FEISHU_APP_ID", "")).strip()
+    app_secret = (app_secret or os.getenv("FEISHU_APP_SECRET", "")).strip()
+    chat_id = (
+        chat_id
+        or os.getenv("FEISHU_PREVIEW_CHAT_ID", "")
+        or os.getenv("FEISHU_CHAT_ID", "")
+        or os.getenv("LARK_PREVIEW_CHAT_ID", "")
+        or os.getenv("LARK_CHAT_ID", "")
+    ).strip()
+    return app_id, app_secret, chat_id
+
+
+def _tenant_access_token(app_id: str, app_secret: str) -> str:
+    resp = requests.post(
+        f"{_feishu_api_base_url()}/auth/v3/tenant_access_token/internal",
+        json={"app_id": app_id, "app_secret": app_secret},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    if int(payload.get("code", -1)) != 0:
+        raise RuntimeError(str(payload.get("msg") or payload))
+    token = str(payload.get("tenant_access_token", "") or "").strip()
+    if not token:
+        raise RuntimeError("tenant_access_token missing")
+    return token
+
+
+def _upload_feishu_file(file_path: str, token: str) -> str:
+    filename = os.path.basename(file_path)
+    with open(file_path, "rb") as f:
+        resp = requests.post(
+            f"{_feishu_api_base_url()}/im/v1/files",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"file_type": "stream", "file_name": filename},
+            files={"file": (filename, f, "text/markdown")},
+            timeout=30,
+        )
+    resp.raise_for_status()
+    payload = resp.json()
+    if int(payload.get("code", -1)) != 0:
+        raise RuntimeError(str(payload.get("msg") or payload))
+    file_key = str((payload.get("data") or {}).get("file_key", "") or "").strip()
+    if not file_key:
+        raise RuntimeError("file_key missing")
+    return file_key
+
+
+def _send_feishu_file_message(file_key: str, token: str, chat_id: str, receive_id_type: str) -> None:
+    resp = requests.post(
+        f"{_feishu_api_base_url()}/im/v1/messages",
+        params={"receive_id_type": receive_id_type},
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json; charset=utf-8"},
+        json={
+            "receive_id": chat_id,
+            "msg_type": "file",
+            "content": json.dumps({"file_key": file_key}, ensure_ascii=False),
+        },
+        timeout=15,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    if int(payload.get("code", -1)) != 0:
+        raise RuntimeError(str(payload.get("msg") or payload))
+
+
+def send_feishu_file(
+    file_path: str,
+    *,
+    chat_id: str = "",
+    app_id: str = "",
+    app_secret: str = "",
+    receive_id_type: str = "chat_id",
+) -> bool:
+    """通过飞书 OpenAPI 上传文件，并向指定会话发送 file 消息。"""
+    if not file_path or not os.path.isfile(file_path):
+        print(f"[feishu] file send skipped: file not found: {file_path}")
+        return False
+    app_id, app_secret, chat_id = _feishu_file_credentials(chat_id, app_id, app_secret)
+    if not app_id or not app_secret or not chat_id:
+        print("[feishu] file send skipped: missing FEISHU_APP_ID/FEISHU_APP_SECRET/FEISHU_PREVIEW_CHAT_ID")
+        return False
+    try:
+        token = _tenant_access_token(app_id, app_secret)
+        file_key = _upload_feishu_file(file_path, token)
+        _send_feishu_file_message(file_key, token, chat_id, receive_id_type)
+        print(f"[feishu] file sent: {os.path.basename(file_path)}")
+        return True
+    except Exception as e:
+        print(f"[feishu] file send failed: {type(e).__name__}: {e}")
+        return False
 
 
 def send_feishu_notification(webhook_url: str, title: str, content: str) -> bool:


### PR DESCRIPTION
## Summary

- add Feishu OpenAPI file upload/send support for Step3 input preview artifacts
- make the input preview workflow write the full LLM input to `logs/step3_llm_input_preview.md` and try file delivery first
- keep the original full Feishu card content as the fallback when file delivery is unavailable

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/quality_gate.py --check-functions`
- `uv run python -m pytest tests/test_daily_job_preview.py -q`
- `uv run python -m pytest tests/ -x -q`
- `git diff --check`