### PR TITLE
chore: split CI quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,11 @@ on:
       - "**.py"
       - "pyproject.toml"
       - "scripts/quality_gate.py"
+      - "scripts/check_pr_policy.py"
+      - "scripts/check_workflow_hygiene.py"
       - ".metrics/**"
       - "requirements.txt"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
       - "web/**"
   pull_request:
     branches: [main, feature/visible]
@@ -17,58 +19,137 @@ on:
       - "**.py"
       - "pyproject.toml"
       - "scripts/quality_gate.py"
+      - "scripts/check_pr_policy.py"
+      - "scripts/check_workflow_hygiene.py"
       - ".metrics/**"
       - "requirements.txt"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
       - "web/**"
 
-jobs:
-  python:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
+permissions:
+  contents: read
 
+jobs:
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
+          python-version: "3.11"
+      - name: Install ruff
+        run: python -m pip install ruff
+      - name: Ruff lint
+        run: ruff check .
+      - name: Ruff format
+        run: ruff format --check .
 
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Function length and LOC trend
+        run: python scripts/quality_gate.py --ci
+
+  workflow-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install workflow parser
+        run: python -m pip install pyyaml
+      - name: Check workflow hygiene
+        run: python scripts/check_workflow_hygiene.py
+
+  pr-policy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Collect changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr-changed-files.txt
+      - name: Validate PR body and file policy
+        run: python scripts/check_pr_policy.py --event-path "$GITHUB_EVENT_PATH" --changed-files-file /tmp/pr-changed-files.txt
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[streamlit,dev]"
-
-      - name: Lint (ruff check)
-        run: ruff check .
-
-      - name: Format check (ruff format)
-        run: ruff format --check .
-
-      - name: Quality gate (function length + LOC trend)
-        run: python scripts/quality_gate.py --ci
-
-      - name: Sanity check (import)
-        run: |
-          python -c "import streamlit; import akshare; import pandas; print('OK')"
-
       - name: Py compile all modules
-        run: |
-          python -m py_compile $(find agents app cli core integrations pages scripts tools utils -name "*.py")
-
+        run: python -m py_compile $(find agents app cli core integrations pages scripts tools utils -name "*.py")
       - name: Run tests
         run: python -m pytest tests/ -x -q
 
+  smoke-dry-run:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[streamlit,dev]"
+      - name: Sanity imports
+        run: python -c "import streamlit; import akshare; import pandas; print('OK')"
       - name: Daily job dry-run
         run: python scripts/daily_job.py --dry-run
         env:
           FEISHU_WEBHOOK_URL: "https://example.com"
           GEMINI_API_KEY: "fake-key-for-dry-run"
+
+  coverage-report:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[streamlit,dev]" coverage
+      - name: Run coverage report
+        run: |
+          python -m coverage erase
+          python -m coverage run -m pytest tests/ -x -q
+          python -m coverage report
+          python -m coverage json -o coverage.json
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report-${{ github.run_number }}
+          path: coverage.json
+          retention-days: 7
+          if-no-files-found: ignore
 
   web-check:
     runs-on: ubuntu-latest
@@ -88,6 +169,6 @@ jobs:
       - name: TypeScript check
         run: pnpm -r exec tsc --noEmit
         working-directory: web
-      - name: Run web tests (harness)
+      - name: Run web tests
         run: pnpm --filter @wyckoff/web test
         working-directory: web

--- a/.github/workflows/sector_continuity.yml
+++ b/.github/workflows/sector_continuity.yml
@@ -3,6 +3,10 @@ name: Sector Continuity Report
 on:
   workflow_dispatch:
 
+concurrency:
+  group: sector-continuity-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/single_symbol_funnel_diagnosis.yml
+++ b/.github/workflows/single_symbol_funnel_diagnosis.yml
@@ -21,6 +21,10 @@ on:
         default: "320"
         type: string
 
+concurrency:
+  group: single-symbol-funnel-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/scripts/check_pr_policy.py
+++ b/scripts/check_pr_policy.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Validate pull request body and changed-file policy gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SUMMARY_HEADINGS = {
+    "summary",
+    "problem",
+    "goal",
+    "fix summary",
+    "change summary",
+    "变更摘要",
+    "摘要",
+    "目标",
+    "问题",
+}
+VALIDATION_HEADINGS = {
+    "validation",
+    "test plan",
+    "tests",
+    "results",
+    "验证",
+    "测试",
+    "测试计划",
+    "结果",
+}
+SECRET_PATTERNS = (
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"\bBearer\s+eyJ[A-Za-z0-9_.-]+"),
+    re.compile(r"\b(?:ANTHROPIC|OPENAI|OPENROUTER|GEMINI|TUSHARE|SUPABASE)_[A-Z0-9_]*KEY\s*="),
+)
+DANGEROUS_FILENAMES = {".env", ".env.local", "id_rsa", "id_ed25519"}
+DANGEROUS_SUFFIXES = {".db", ".dump", ".key", ".log", ".pem", ".sqlite", ".sqlite3"}
+DANGEROUS_PREFIXES = ("logs/", ".traces/", "artifacts/")
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    ok: bool
+    failures: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def _heading_names(body: str) -> set[str]:
+    headings: set[str] = set()
+    for line in body.splitlines():
+        match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
+        if match:
+            headings.add(match.group(1).strip().lower())
+    return headings
+
+
+def _dangerous_files(changed_files: list[str]) -> list[str]:
+    dangerous: list[str] = []
+    for raw_path in changed_files:
+        path = raw_path.strip()
+        if not path:
+            continue
+        lower_path = path.lower()
+        name = Path(path).name.lower()
+        suffix = Path(path).suffix.lower()
+        if name in DANGEROUS_FILENAMES:
+            dangerous.append(path)
+        elif suffix in DANGEROUS_SUFFIXES:
+            dangerous.append(path)
+        elif lower_path.startswith(DANGEROUS_PREFIXES):
+            dangerous.append(path)
+    return dangerous
+
+
+def validate_policy(body: str, changed_files: list[str]) -> PolicyResult:
+    failures: list[str] = []
+    warnings: list[str] = []
+    body = body.strip()
+    if not body:
+        return PolicyResult(ok=False, failures=("PR body is empty",), warnings=())
+
+    headings = _heading_names(body)
+    if not headings.intersection(SUMMARY_HEADINGS):
+        failures.append("PR body is missing a Summary/变更摘要 section")
+    if not headings.intersection(VALIDATION_HEADINGS):
+        failures.append("PR body is missing a Validation/验证 section")
+
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(body):
+            failures.append("PR body appears to contain a secret or bearer token")
+            break
+
+    dangerous = _dangerous_files(changed_files)
+    if dangerous:
+        failures.append("PR includes local logs, trace artifacts, database dumps, or secret-like files")
+        warnings.append("Blocked files: " + ", ".join(dangerous[:8]))
+
+    return PolicyResult(ok=not failures, failures=tuple(failures), warnings=tuple(warnings))
+
+
+def _load_body(args: argparse.Namespace) -> str:
+    if args.body is not None:
+        return args.body
+    if args.body_file:
+        return Path(args.body_file).read_text(encoding="utf-8")
+    event_path = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        data = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        body = data.get("pull_request", {}).get("body")
+        if isinstance(body, str):
+            return body
+    raise SystemExit("error: provide --body, --body-file, or --event-path with pull_request.body")
+
+
+def _load_changed_files(args: argparse.Namespace) -> list[str]:
+    if args.changed_file:
+        return args.changed_file
+    if args.changed_files_file:
+        return [
+            line.strip()
+            for line in Path(args.changed_files_file).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body", help="PR body text")
+    parser.add_argument("--body-file", help="File containing the PR body")
+    parser.add_argument("--event-path", help="GitHub event JSON path")
+    parser.add_argument("--changed-files-file", help="File containing changed paths, one per line")
+    parser.add_argument("--changed-file", action="append", default=[], help="Changed path; repeatable")
+    args = parser.parse_args(argv)
+
+    result = validate_policy(_load_body(args), _load_changed_files(args))
+    if result.ok:
+        print("PR Policy: PASS")
+        for warning in result.warnings:
+            print(f"  WARN {warning}")
+        return 0
+
+    print("PR Policy: FAIL")
+    for failure in result.failures:
+        print(f"  FAIL {failure}")
+    for warning in result.warnings:
+        print(f"  INFO {warning}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_workflow_hygiene.py
+++ b/scripts/check_workflow_hygiene.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Check GitHub workflow hygiene rules that keep scheduled jobs maintainable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+AUTOMATION_TRIGGER_NAMES = {"schedule", "workflow_dispatch"}
+
+
+def _workflow_on(data: dict[str, Any]) -> Any:
+    return data.get("on", data.get(True))
+
+
+def _trigger_names(raw_on: Any) -> set[str]:
+    if isinstance(raw_on, str):
+        return {raw_on}
+    if isinstance(raw_on, list):
+        return {str(item) for item in raw_on}
+    if isinstance(raw_on, dict):
+        return {str(key) for key in raw_on}
+    return set()
+
+
+def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = job.get("steps", [])
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _has_upload_artifact(job: dict[str, Any]) -> bool:
+    return any(str(step.get("uses", "")).startswith("actions/upload-artifact@") for step in _steps(job))
+
+
+def _prepares_logs(job: dict[str, Any]) -> bool:
+    for step in _steps(job):
+        name = str(step.get("name", "")).lower()
+        run = str(step.get("run", "")).lower()
+        if "prepare logs" in name or "mkdir -p logs" in run:
+            return True
+    return False
+
+
+def _check_workflow(path: Path) -> list[str]:
+    failures: list[str] = []
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return [f"{path}: workflow must be a mapping"]
+
+    raw_on = _workflow_on(data)
+    triggers = _trigger_names(raw_on)
+    if not triggers:
+        failures.append(f"{path}: missing workflow trigger")
+
+    is_ci = path.name == "ci.yml"
+    is_automation = bool(triggers.intersection(AUTOMATION_TRIGGER_NAMES)) and not triggers.intersection(
+        {"pull_request", "push"}
+    )
+    if is_automation and not data.get("concurrency"):
+        failures.append(f"{path}: automation workflow must define top-level concurrency")
+
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict) or not jobs:
+        return failures + [f"{path}: missing jobs"]
+
+    for job_name, raw_job in jobs.items():
+        if not isinstance(raw_job, dict):
+            failures.append(f"{path}: job {job_name} must be a mapping")
+            continue
+        if is_automation and not is_ci and _prepares_logs(raw_job) and not _has_upload_artifact(raw_job):
+            failures.append(f"{path}: job {job_name} prepares logs but does not upload artifacts")
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        failures.extend(_check_workflow(path))
+
+    if failures:
+        print("Workflow hygiene: FAIL")
+        for failure in failures:
+            print(f"  FAIL {failure}")
+        return 2
+
+    print("Workflow hygiene: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_policy_gates.py
+++ b/tests/test_ci_policy_gates.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_pr_policy import validate_policy
+from scripts.check_workflow_hygiene import _check_workflow
+
+
+def test_pr_policy_accepts_bilingual_summary_and_validation():
+    body = "## 变更摘要\n\n- 拆分 CI\n\n## 验证\n\n- pytest"
+
+    result = validate_policy(body, ["scripts/check_pr_policy.py"])
+
+    assert result.ok is True
+
+
+def test_pr_policy_blocks_logs_and_secret_like_body():
+    body = "## Summary\n\nUses Bearer eyJabc.def.ghi\n\n## Validation\n\n- pytest"
+
+    result = validate_policy(body, ["logs/run.log"])
+
+    assert result.ok is False
+    assert any("secret" in item for item in result.failures)
+    assert any("local logs" in item for item in result.failures)
+
+
+def test_workflow_hygiene_requires_concurrency_for_manual_automation(tmp_path: Path):
+    workflow = tmp_path / "manual.yml"
+    workflow.write_text(
+        """
+name: Manual
+on:
+  workflow_dispatch:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    failures = _check_workflow(workflow)
+
+    assert any("concurrency" in failure for failure in failures)
+
+
+def test_workflow_hygiene_accepts_logs_with_artifact(tmp_path: Path):
+    workflow = tmp_path / "manual.yml"
+    workflow.write_text(
+        """
+name: Manual
+on:
+  workflow_dispatch:
+concurrency:
+  group: manual-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare logs dir
+        run: mkdir -p logs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: logs
+          path: logs/*
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    assert _check_workflow(workflow) == []


### PR DESCRIPTION
## Summary

- Split Wyckoff CI into focused lint, quality gate, workflow hygiene, PR policy, test, smoke dry-run, coverage report, and web check jobs.
- Add deterministic PR policy and workflow hygiene scripts with focused tests.
- Add missing concurrency to manual automation workflows so the new hygiene gate passes.

## Validation

- uv run ruff check .
- uv run ruff format --check .
- uv run python -m pytest tests/ -x -q
- uv run python scripts/check_workflow_hygiene.py
- uv run python scripts/quality_gate.py --ci
- git diff --check