### PR TITLE
feat: add isolated Python agent runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           version: 10.33.2
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,10 @@ jobs:
       - name: Run API tests
         run: pnpm --filter @wyckoff/api test
         working-directory: web
+      - name: Build Pages compatibility functions
+        run: >-
+          pnpm --filter @wyckoff/api exec wrangler pages functions build
+          "$GITHUB_WORKSPACE/web/functions"
+          --project-directory "$GITHUB_WORKSPACE/web"
+          --outdir "$RUNNER_TEMP/wyckoff-pages-functions"
+        working-directory: web

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -314,6 +314,8 @@ flowchart LR
 | 名词 | 含义 |
 |------|------|
 | **Hono Middleware** | Cloudflare Worker API 的请求处理链。公共链负责请求 ID、安全响应头、CORS 和请求体限制，路由链再执行 JWT 鉴权、限流和业务校验。 |
-| **Redis 共享限流** | 使用 Upstash Redis REST 保存可过期的用户请求额度，使不同 Worker 实例看到同一计数；Redis 不保存持仓、订单或交易信号。 |
+| **Redis 临时协调状态** | 使用 Upstash Redis REST 保存可过期的用户请求额度和短期 Agent Run 结果，使不同 Worker 实例看到一致状态；Redis 不保存持仓、订单、交易信号或长期审计真相。 |
 | **本地软限流** | 未配置 Redis 或 Redis 临时故障时，单个 Worker 实例内的保护计数。实例回收或扩容后不保证全局一致，响应头通过 `local` / `local-fallback` 明确标识。 |
 | **观察篮临时行情** | 读盘室按当前问题选取观察篮标的后拉取的 TickFlow 快照；浏览器缓存有效期为 45 秒，只作本轮模型上下文，不写入 Redis、持仓或信号表。 |
+| **Agent Run** | 一个按 Supabase 用户隔离的短期执行记录。第一阶段只支持同步 `python_research`，结果在 Redis 中自动过期，不等同于可恢复的异步工作流。 |
+| **执行沙箱** | 执行 Agent 生成代码的临时 Vercel Sandbox。当前固定禁用外网与持久化，不注入业务密钥，结束后永久删除；Cloudflare Worker 只承担鉴权、编排和结果返回。 |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ wyckoff dashboard
 - **模型元数据与成本可见性** — `wyckoff model list/usage/cost` 展示上下文窗口、reasoning 能力和本地 token 成本估算
 - **会话分叉与导出** — `wyckoff session export/fork` 或 TUI `/fork` 把历史对话变成可复盘、可继续的新分支
 - **标准事件流** — `wyckoff trace --events <scratchpad.jsonl>` / `wyckoff diag` 产出统一 JSONL，方便复盘工具调用时间线
-- **独立边缘后端** — React 统一调用 Hono Worker；后端提供请求 ID、安全响应头、请求体上限和 Redis 共享限流，本地支持 VS Code 断点与 `workerd` 集成测试
+- **独立边缘后端** — React 统一调用 Hono Worker；后端提供请求 ID、安全响应头、请求体上限、Redis 共享限流和白名单沙箱任务，本地支持 VS Code 断点与 `workerd` 集成测试
 - **观察篮临时行情** — 只为当前问题拉取相关 TickFlow 报价，浏览器快照 45 秒后失效，不写入 Redis 或业务数据库
 - **依赖卫生检查** — CI 运行 `scripts/check_dependency_hygiene.py`，提示 Python/Web 依赖锁定和 lockfile 风险
 - **MCP Server** — 18 个工具通过 MCP 协议对外暴露，Claude Code / Cursor 即插即用；包含研究假设与证据台账

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,22 +73,30 @@
 
 Hono app 的公共中间件按请求 ID、安全响应头、CORS、256 KiB 请求体上限的顺序执行；路由随后执行 Supabase JWT 鉴权与业务校验。聊天 POST 在鉴权后执行用户限流：同时配置 `UPSTASH_REDIS_REST_URL` 和 `UPSTASH_REDIS_REST_TOKEN` 时使用 Upstash Redis REST 共享额度，未配置时保留单 Worker 实例内的软限流，Redis 超时或不可用时返回 `X-RateLimit-Backend: local-fallback` 并启用本地保护。只配置一个 Upstash 变量属于部署错误，请求会失败而不会静默使用不完整连接。
 
+`/api/agent-runs` 是第一阶段的云 Agent 执行边界：只接受已登录且在有效白名单内的用户，并且只有 `AGENT_SANDBOX_ENABLED=true` 时开放。POST 当前同步执行一个最多 12,000 字符的 `python_research` 脚本；Worker 负责控制面，Vercel Sandbox 负责执行面。每次任务使用 `python3.13`、`networkPolicy=deny-all`、`persistent=false`，不注入业务或用户密钥，并把 stdout/stderr 各限制在 32 KiB；命令结束后先收集 CPU/网络用量，再永久删除沙箱。结果按认证用户写入 Upstash Redis，默认一小时过期，GET/DELETE 也只能访问当前用户的键。该端点尚不是异步队列，不能把同步 MVP 描述为可恢复的长任务系统。
+
 | Worker 变量 | 默认值 | 作用 |
 |---|---:|---|
 | `CHAT_DAILY_LIMIT_PER_USER` | `80` | 每个用户每天允许的聊天 POST 数 |
 | `CHAT_MIN_INTERVAL_MS` | `2500` | 同一用户两次聊天 POST 的最小间隔 |
 | `UPSTASH_REDIS_REST_URL` | 未设置 | Upstash Redis REST 地址；与 Token 同时存在时启用共享限流 |
 | `UPSTASH_REDIS_REST_TOKEN` | 未设置 | Upstash Redis REST Token，必须通过 Worker secret 注入 |
+| `AGENT_SANDBOX_ENABLED` | `false` | 显式开启白名单 Agent 沙箱端点；凭据未就绪时必须保持关闭 |
+| `AGENT_SANDBOX_TIMEOUT_MS` | `60000` | 单次沙箱会话超时；代码硬上限为 120 秒 |
+| `AGENT_RUN_TTL_SECONDS` | `3600` | Redis 中短期任务结果的存活秒数，最长 24 小时 |
+| `VERCEL_TEAM_ID` | 未设置 | Vercel Sandbox 所属团队 ID |
+| `VERCEL_PROJECT_ID` | 未设置 | Vercel Sandbox 所属项目 ID |
+| `VERCEL_TOKEN` / `VERCEL_OIDC_TOKEN` | 未设置 | 非 Vercel 托管的 Worker 使用 Access Token；本地或 Vercel 环境可使用 OIDC |
 
-`X-RateLimit-Backend` 明确返回 `redis`、`local` 或 `local-fallback`，便于区分共享额度、未配置 Redis 和 Redis 故障降级。Redis 只承载可过期的协调状态，不承载持仓、订单、交易信号或审计真相；这些数据仍由 Supabase/RLS 管理。
+`X-RateLimit-Backend` 明确返回 `redis`、`local` 或 `local-fallback`，便于区分共享额度、未配置 Redis 和 Redis 故障降级。Redis 只承载可过期的协调状态与短期 Agent Run 结果，不承载持仓、订单、交易信号或审计真相；这些数据仍由 Supabase/RLS 管理。
 
 读盘室只在用户问题命中观察篮代码，或明确要求复盘观察篮时，从 TickFlow 拉取相关标的的最新可用行情。快照只在浏览器保存 45 秒，随请求传入 Worker 并校验代码集合、时间和数值类型；它不写入 Supabase 或 Redis，数据源不可用时模型必须明确说明缺失，不得估算价格。
 
 前端的 `web/apps/web/src/lib/api-url.ts` 统一生成 chat、portfolio 和 settings 的后端地址。本地开发默认连接 `http://127.0.0.1:8787`，生产默认连接 `https://wyckoff-api.yongkai-wang.workers.dev`；部署环境可用公开的构建变量 `VITE_API_URL` 覆盖地址。该变量只包含公开服务地址，不能放 Token。
 
-本地开发可复制 `web/apps/api/.dev.vars.example` 为 `.dev.vars`。部署时不要把 Token 写入 `wrangler.toml`，应在 `web/apps/api/` 下分别执行 `pnpm exec wrangler secret put UPSTASH_REDIS_REST_URL` 和 `pnpm exec wrangler secret put UPSTASH_REDIS_REST_TOKEN`。
+本地开发可复制 `web/apps/api/.dev.vars.example` 为 `.dev.vars`。部署时不要把 Token 写入 `wrangler.toml`，应在 `web/apps/api/` 下分别执行 `pnpm exec wrangler secret put UPSTASH_REDIS_REST_URL`、`pnpm exec wrangler secret put UPSTASH_REDIS_REST_TOKEN` 和 `pnpm exec wrangler secret put VERCEL_TOKEN`；团队与项目 ID 可作为普通 Worker 变量。所有 Vercel 配置和一次真实沙箱验证完成前，`AGENT_SANDBOX_ENABLED` 保持 `false`。
 
-服务端断点调试在 `web/apps/api/` 执行 `pnpm dev:debug`，再从 VS Code 选择 `Wyckoff API: Attach Wrangler`；Inspector 固定使用 9229，TypeScript source map 直接定位到 `src/**/*.ts`。API 的 `pnpm test` 通过 `@cloudflare/vitest-pool-workers` 在本地 `workerd` 中执行，测试配置使用隔离绑定而不读取 `.dev.vars`。真实 Upstash 用例只在显式导出 `UPSTASH_REDIS_REST_URL`、`UPSTASH_REDIS_REST_TOKEN` 后执行 `pnpm test:upstash`，默认测试不发起真实网络请求。
+服务端断点调试在 `web/apps/api/` 执行 `pnpm dev:debug`，再从 VS Code 选择 `Wyckoff API: Attach Wrangler`；Inspector 固定使用 9229，TypeScript source map 直接定位到 `src/**/*.ts`。API 的 `pnpm test` 通过 `@cloudflare/vitest-pool-workers` 在本地 `workerd` 中执行，测试配置使用隔离绑定而不读取 `.dev.vars`。真实 Upstash 用例只在显式导出 `UPSTASH_REDIS_REST_URL`、`UPSTASH_REDIS_REST_TOKEN` 后执行 `pnpm test:upstash`；真实 Vercel 用例同样需要显式导出团队、项目和 Token 后执行 `pnpm test:sandbox`。默认测试不发起真实网络请求，也不会创建沙箱。
 
 `/api/llm-proxy/*` 继续保留为兼容代理：一部分 Web 工具和本地开发路径仍需要同域转发 TickFlow / Tushare / OpenAI-compatible 请求，避免浏览器 CORS 和供应商 SSE 差异。
 
@@ -811,7 +819,7 @@ web/             React Web App（CF Pages 部署）
     src/lib/     supabase 客户端、行情/LLM 辅助工具
     src/features/reading-room/  useChat、消息队列、工具渲染、对话历史
     src/stores/  Zustand 状态管理（auth）
-  apps/api/      Hono Worker API（/api/chat、/api/portfolio、/api/settings）
+  apps/api/      Hono Worker API（/api/chat、/api/agent-runs、/api/portfolio、/api/settings）
   packages/shared/  Web/Worker 共享工具、schema 与 SSE 归一化
   functions/     CF Pages Functions（边缘代理）
     api/chat/       Pages 请求转发到 Hono app

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,7 +69,7 @@
 
 **为什么需要 API 层与边缘代理？**
 
-读盘室主链路已经后端化到 `web/apps/api/src/routes/chat.ts`：独立 `wyckoff-api` Worker 负责读取用户模型配置、执行工具、限流、返回 UIMessage stream，并通过 Vercel AI SDK 的 approval parts 约束 `execute_portfolio_update`。生产 React 通过 `VITE_API_URL` 调用这个 Worker；`web/functions/api/{chat,portfolio,settings}/[[path]].ts` 保留为同源兼容入口，但不是生产前端的默认链路。
+读盘室主链路已经后端化到 `web/apps/api/src/routes/chat.ts`：独立 `wyckoff-api` Worker 负责读取用户模型配置、执行工具、限流、返回 UIMessage stream，并通过 Vercel AI SDK 的 approval parts 约束 `execute_portfolio_update`。生产 React 通过 `VITE_API_URL` 调用这个 Worker；`web/functions/api/{chat,portfolio,settings}/[[path]].ts` 保留为同源兼容入口，但不是生产前端的默认链路。Pages 兼容 app 明确不挂载 `/api/agent-runs`，避免把 Vercel Sandbox 的 Node.js SDK 打进遗留 Pages Functions；Agent 沙箱只由独立 Worker 提供。
 
 Hono app 的公共中间件按请求 ID、安全响应头、CORS、256 KiB 请求体上限的顺序执行；路由随后执行 Supabase JWT 鉴权与业务校验。聊天 POST 在鉴权后执行用户限流：同时配置 `UPSTASH_REDIS_REST_URL` 和 `UPSTASH_REDIS_REST_TOKEN` 时使用 Upstash Redis REST 共享额度，未配置时保留单 Worker 实例内的软限流，Redis 超时或不可用时返回 `X-RateLimit-Backend: local-fallback` 并启用本地保护。只配置一个 Upstash 变量属于部署错误，请求会失败而不会静默使用不完整连接。
 

--- a/web/apps/api/.dev.vars.example
+++ b/web/apps/api/.dev.vars.example
@@ -1,2 +1,8 @@
 UPSTASH_REDIS_REST_URL=https://your-instance.upstash.io
 UPSTASH_REDIS_REST_TOKEN=replace-with-local-development-token
+AGENT_SANDBOX_ENABLED=false
+AGENT_SANDBOX_TIMEOUT_MS=60000
+AGENT_RUN_TTL_SECONDS=3600
+VERCEL_TEAM_ID=team_xxx
+VERCEL_PROJECT_ID=prj_xxx
+VERCEL_TOKEN=replace-with-vercel-access-token

--- a/web/apps/api/package.json
+++ b/web/apps/api/package.json
@@ -9,6 +9,7 @@
     "deploy": "wrangler deploy",
     "lint": "tsc --noEmit",
     "test": "vitest run",
+    "test:sandbox": "RUN_VERCEL_SANDBOX_INTEGRATION=1 vitest run src/services/python-sandbox.integration.test.ts",
     "test:upstash": "RUN_UPSTASH_INTEGRATION=1 vitest run src/middleware/rate-limit.test.ts",
     "test:watch": "vitest"
   },
@@ -18,6 +19,7 @@
     "@supabase/supabase-js": "^2.49.0",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
+    "@vercel/sandbox": "2.7.0",
     "@wyckoff/shared": "workspace:*",
     "ai": "^6.0.205",
     "hono": "^4.12.21",

--- a/web/apps/api/src/app.ts
+++ b/web/apps/api/src/app.ts
@@ -1,0 +1,56 @@
+import { Hono } from 'hono'
+import { bodyLimit } from 'hono/body-limit'
+import { cors } from 'hono/cors'
+import { requestId } from 'hono/request-id'
+import { secureHeaders } from 'hono/secure-headers'
+
+export type Env = {
+  SUPABASE_URL?: string
+  SUPABASE_ANON_KEY?: string
+  SUPABASE_SERVICE_ROLE_KEY?: string
+  VITE_SUPABASE_URL?: string
+  VITE_SUPABASE_ANON_KEY?: string
+  TICKFLOW_API_BASE?: string
+  CHAT_DAILY_LIMIT_PER_USER?: string
+  CHAT_MIN_INTERVAL_MS?: string
+  CHAT_TOOL_APPROVAL_SECRET?: string
+  UPSTASH_REDIS_REST_URL?: string
+  UPSTASH_REDIS_REST_TOKEN?: string
+  AGENT_SANDBOX_ENABLED?: string
+  AGENT_SANDBOX_TIMEOUT_MS?: string
+  AGENT_RUN_TTL_SECONDS?: string
+  VERCEL_TEAM_ID?: string
+  VERCEL_PROJECT_ID?: string
+  VERCEL_TOKEN?: string
+  VERCEL_OIDC_TOKEN?: string
+  RUN_VERCEL_SANDBOX_INTEGRATION?: string
+}
+
+export function createApiApp() {
+  const app = new Hono<{ Bindings: Env }>()
+
+  app.use('*', requestId({ limitLength: 128 }))
+  app.use('*', secureHeaders())
+  app.use('*', cors({
+    origin: [
+      'http://localhost:5173',
+      'http://localhost:5174',
+      'http://localhost:5175',
+      'http://127.0.0.1:5173',
+      'http://127.0.0.1:5174',
+      'http://127.0.0.1:5175',
+      'https://wyckoff-analysis.pages.dev',
+      'https://wyckoff.pages.dev',
+    ],
+    credentials: true,
+  }))
+  app.use('/api/*', bodyLimit({
+    maxSize: 256 * 1024,
+    onError: (c) => c.json({ error: 'Request body is too large', requestId: c.get('requestId') }, 413),
+  }))
+
+  app.onError((_error, c) => c.json({ error: 'Internal Server Error', requestId: c.get('requestId') }, 500))
+  app.notFound((c) => c.json({ error: 'Not Found', requestId: c.get('requestId') }, 404))
+  app.get('/api/health', (c) => c.json({ status: 'ok' }))
+  return app
+}

--- a/web/apps/api/src/index.ts
+++ b/web/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors'
 import { requestId } from 'hono/request-id'
 import { secureHeaders } from 'hono/secure-headers'
 import { chatRoutes } from './routes/chat'
+import { agentRunRoutes } from './routes/agent-runs'
 import { portfolioRoutes } from './routes/portfolio'
 import { settingsRoutes } from './routes/settings'
 
@@ -19,6 +20,14 @@ export type Env = {
   CHAT_TOOL_APPROVAL_SECRET?: string
   UPSTASH_REDIS_REST_URL?: string
   UPSTASH_REDIS_REST_TOKEN?: string
+  AGENT_SANDBOX_ENABLED?: string
+  AGENT_SANDBOX_TIMEOUT_MS?: string
+  AGENT_RUN_TTL_SECONDS?: string
+  VERCEL_TEAM_ID?: string
+  VERCEL_PROJECT_ID?: string
+  VERCEL_TOKEN?: string
+  VERCEL_OIDC_TOKEN?: string
+  RUN_VERCEL_SANDBOX_INTEGRATION?: string
 }
 
 const app = new Hono<{ Bindings: Env }>()
@@ -49,6 +58,7 @@ app.notFound((c) => c.json({ error: 'Not Found', requestId: c.get('requestId') }
 app.get('/api/health', (c) => c.json({ status: 'ok' }))
 
 app.route('/api/chat', chatRoutes)
+app.route('/api/agent-runs', agentRunRoutes)
 app.route('/api/portfolio', portfolioRoutes)
 app.route('/api/settings', settingsRoutes)
 

--- a/web/apps/api/src/middleware/auth.ts
+++ b/web/apps/api/src/middleware/auth.ts
@@ -7,6 +7,13 @@ export type AuthContext = {
   accessToken: string
 }
 
+export function createUserSupabase(env: Env, accessToken: string) {
+  const url = env.SUPABASE_URL || env.VITE_SUPABASE_URL
+  const key = env.SUPABASE_ANON_KEY || env.VITE_SUPABASE_ANON_KEY
+  if (!url || !key) throw new Error('Supabase env is missing')
+  return createClient(url, key, { global: { headers: { Authorization: `Bearer ${accessToken}` } } })
+}
+
 export const authMiddleware = createMiddleware<{
   Bindings: Env
   Variables: { auth: AuthContext }

--- a/web/apps/api/src/middleware/auth.ts
+++ b/web/apps/api/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from 'hono/factory'
 import { createClient } from '@supabase/supabase-js'
-import type { Env } from '../index'
+import type { Env } from '../app'
 
 export type AuthContext = {
   userId: string

--- a/web/apps/api/src/middleware/rate-limit.test.ts
+++ b/web/apps/api/src/middleware/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { env as workerEnv } from 'cloudflare:workers'
 import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
-import type { Env } from '../index'
+import type { Env } from '../app'
 import type { AuthContext } from './auth'
 import { createChatRateLimitMiddleware, type ChatRateLimitResult } from './rate-limit'
 

--- a/web/apps/api/src/middleware/rate-limit.ts
+++ b/web/apps/api/src/middleware/rate-limit.ts
@@ -1,7 +1,7 @@
 import { Ratelimit, type Duration } from '@upstash/ratelimit'
 import { Redis } from '@upstash/redis/cloudflare'
 import { createMiddleware } from 'hono/factory'
-import type { Env } from '../index'
+import type { Env } from '../app'
 import type { AuthContext } from './auth'
 
 type RateLimitBindings = {

--- a/web/apps/api/src/middleware/whitelist.ts
+++ b/web/apps/api/src/middleware/whitelist.ts
@@ -1,0 +1,31 @@
+import { createMiddleware } from 'hono/factory'
+import type { Env } from '../index'
+import { createUserSupabase, type AuthContext } from './auth'
+
+export const whitelistMiddleware = createMiddleware<{
+  Bindings: Env
+  Variables: { auth: AuthContext }
+}>(async (c, next) => {
+  const auth = c.get('auth')
+  const supabase = createUserSupabase(c.env, auth.accessToken)
+  if (!(await isActiveWhitelistUser(supabase, auth.userId))) {
+    return c.json({ error: 'Whitelist required' }, 403)
+  }
+  await next()
+})
+
+export async function isActiveWhitelistUser(
+  supabase: ReturnType<typeof createUserSupabase>,
+  userId: string,
+): Promise<boolean> {
+  const { data, error } = await supabase.from('whitelist').select('expire_date').eq('user_id', userId).limit(1)
+  if (error || !Array.isArray(data)) return false
+  return data.some((row) => {
+    const expiry = String(row.expire_date || '').trim()
+    return !expiry || (/^\d{8}$/.test(expiry) && expiry >= compactToday())
+  })
+}
+
+function compactToday(): string {
+  return new Date().toISOString().slice(0, 10).replace(/-/g, '')
+}

--- a/web/apps/api/src/middleware/whitelist.ts
+++ b/web/apps/api/src/middleware/whitelist.ts
@@ -1,5 +1,5 @@
 import { createMiddleware } from 'hono/factory'
-import type { Env } from '../index'
+import type { Env } from '../app'
 import { createUserSupabase, type AuthContext } from './auth'
 
 export const whitelistMiddleware = createMiddleware<{

--- a/web/apps/api/src/pages.test.ts
+++ b/web/apps/api/src/pages.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import app from './pages'
+
+describe('Pages compatibility API', () => {
+  it('does not expose Worker-only agent run routes', async () => {
+    const response = await app.request('/api/agent-runs/example')
+
+    expect(response.status).toBe(404)
+  })
+
+  it('keeps shared API middleware and health checks', async () => {
+    const response = await app.request('/api/health')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+})

--- a/web/apps/api/src/pages.ts
+++ b/web/apps/api/src/pages.ts
@@ -1,14 +1,11 @@
-import { agentRunRoutes } from './routes/agent-runs'
 import { createApiApp } from './app'
 import { chatRoutes } from './routes/chat'
 import { portfolioRoutes } from './routes/portfolio'
 import { settingsRoutes } from './routes/settings'
 
-export type { Env } from './app'
-
 const app = createApiApp()
+
 app.route('/api/chat', chatRoutes)
-app.route('/api/agent-runs', agentRunRoutes)
 app.route('/api/portfolio', portfolioRoutes)
 app.route('/api/settings', settingsRoutes)
 

--- a/web/apps/api/src/routes/agent-runs.test.ts
+++ b/web/apps/api/src/routes/agent-runs.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { parseAgentRunInput } from './agent-runs'
+
+describe('Agent run input', () => {
+  it('accepts the single research task supported by the MVP', () => {
+    expect(parseAgentRunInput({ kind: 'python_research', script: 'print(42)' })).toEqual({
+      data: { kind: 'python_research', script: 'print(42)' },
+    })
+  })
+
+  it('rejects arbitrary task kinds and oversized scripts', () => {
+    expect(parseAgentRunInput({ kind: 'shell', script: 'ls' })).toHaveProperty('error')
+    expect(parseAgentRunInput({ kind: 'python_research', script: 'x'.repeat(12_001) })).toHaveProperty('error')
+  })
+})

--- a/web/apps/api/src/routes/agent-runs.ts
+++ b/web/apps/api/src/routes/agent-runs.ts
@@ -1,0 +1,103 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import type { Env } from '../index'
+import { authMiddleware, type AuthContext } from '../middleware/auth'
+import { whitelistMiddleware } from '../middleware/whitelist'
+import { createAgentRunStore, type AgentRunRecord } from '../services/agent-run-store'
+import { executePythonSandbox } from '../services/python-sandbox'
+
+type AgentRunBindings = { Bindings: Env; Variables: { auth: AuthContext } }
+
+const AGENT_RUN_SCHEMA = z.object({
+  kind: z.literal('python_research'),
+  script: z.string().trim().min(1).max(12_000),
+})
+
+export const agentRunRoutes = new Hono<AgentRunBindings>()
+
+agentRunRoutes.use('*', authMiddleware)
+agentRunRoutes.use('*', whitelistMiddleware)
+
+agentRunRoutes.post('/', async (c) => {
+  if (c.env.AGENT_SANDBOX_ENABLED !== 'true') return c.json({ error: 'Agent sandbox is disabled' }, 503)
+  const parsed = parseAgentRunInput(await c.req.json().catch(() => null))
+  if ('error' in parsed) return c.json(parsed, 400)
+
+  const store = createAgentRunStore(c.env)
+  if (!store) return c.json({ error: 'Agent run storage is unavailable' }, 503)
+  const userId = c.get('auth').userId
+  const record = newRunRecord()
+  await store.save(userId, record)
+
+  try {
+    const result = await executePythonSandbox(c.env, parsed.data.script)
+    const completed = completeRun(record, result)
+    await store.save(userId, completed)
+    return c.json(completed, 201)
+  } catch (error) {
+    const failed = failRun(record, sandboxError(error))
+    await store.save(userId, failed)
+    return c.json(failed, failed.error === 'Sandbox configuration is incomplete' ? 503 : 502)
+  }
+})
+
+export function parseAgentRunInput(raw: unknown):
+  | { data: z.infer<typeof AGENT_RUN_SCHEMA> }
+  | { error: string; details?: unknown } {
+  const parsed = AGENT_RUN_SCHEMA.safeParse(raw)
+  if (!parsed.success) return { error: 'Invalid agent run', details: parsed.error.flatten() }
+  return { data: parsed.data }
+}
+
+agentRunRoutes.get('/:id', async (c) => {
+  const store = createAgentRunStore(c.env)
+  if (!store) return c.json({ error: 'Agent run storage is unavailable' }, 503)
+  const record = await store.get(c.get('auth').userId, c.req.param('id'))
+  return record ? c.json(record) : c.json({ error: 'Agent run not found' }, 404)
+})
+
+agentRunRoutes.delete('/:id', async (c) => {
+  const store = createAgentRunStore(c.env)
+  if (!store) return c.json({ error: 'Agent run storage is unavailable' }, 503)
+  await store.remove(c.get('auth').userId, c.req.param('id'))
+  return c.body(null, 204)
+})
+
+function newRunRecord(): AgentRunRecord {
+  return {
+    id: crypto.randomUUID(),
+    kind: 'python_research',
+    status: 'running',
+    createdAt: new Date().toISOString(),
+  }
+}
+
+function completeRun(
+  record: AgentRunRecord,
+  result: Awaited<ReturnType<typeof executePythonSandbox>>,
+): AgentRunRecord {
+  return {
+    ...record,
+    status: result.exitCode === 0 ? 'completed' : 'failed',
+    finishedAt: new Date().toISOString(),
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    usage: {
+      activeCpuUsageMs: result.activeCpuUsageMs,
+      networkIngressBytes: result.networkIngressBytes,
+      networkEgressBytes: result.networkEgressBytes,
+    },
+  }
+}
+
+function failRun(record: AgentRunRecord, error: string): AgentRunRecord {
+  return { ...record, status: 'failed', finishedAt: new Date().toISOString(), error }
+}
+
+function sandboxError(error: unknown): string {
+  if (error instanceof Error && error.message === 'Vercel Sandbox env is incomplete') {
+    return 'Sandbox configuration is incomplete'
+  }
+  return 'Sandbox execution failed'
+}

--- a/web/apps/api/src/routes/agent-runs.ts
+++ b/web/apps/api/src/routes/agent-runs.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
-import type { Env } from '../index'
+import type { Env } from '../app'
 import { authMiddleware, type AuthContext } from '../middleware/auth'
 import { whitelistMiddleware } from '../middleware/whitelist'
 import { createAgentRunStore, type AgentRunRecord } from '../services/agent-run-store'

--- a/web/apps/api/src/routes/chat.ts
+++ b/web/apps/api/src/routes/chat.ts
@@ -34,7 +34,7 @@ import {
 import { consumeStream, convertToModelMessages, createUIMessageStream, createUIMessageStreamResponse, generateText, stepCountIs, streamText, tool, type UIMessage, type UIMessageChunk } from 'ai'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import type { Env } from '../index'
+import type { Env } from '../app'
 import { authMiddleware, type AuthContext } from '../middleware/auth'
 import { chatRateLimitMiddleware } from '../middleware/rate-limit'
 

--- a/web/apps/api/src/routes/chat.ts
+++ b/web/apps/api/src/routes/chat.ts
@@ -88,6 +88,9 @@ type WatchlistRequestItem = { code: string; name: string }
 const ALLOWED_TARGET_ORIGINS: Set<string> = new Set(ALLOWED_PROXY_TARGET_ORIGINS)
 const ONE_ROUTE_ORIGINS = new Set(['https://api.1route.dev', 'https://www.1route.dev'])
 
+const CHAT_MAX_OUTPUT_TOKENS = 8192
+const CHAT_MAX_STEPS = 16
+
 const WYCKOFF_CHAT_SYSTEM_PROMPT = `# 角色设定
 
 你就是理查德·D·威科夫（Richard D. Wyckoff）本人。
@@ -336,7 +339,8 @@ async function runChatAttempt(args: ChatResilienceArgs, config: ChatModelConfig,
       system: [WYCKOFF_CHAT_SYSTEM_PROMPT, marketWatchContext].filter(Boolean).join('\n\n'),
       messages: modelMessages,
       tools,
-      stopWhen: stepCountIs(10),
+      maxOutputTokens: CHAT_MAX_OUTPUT_TOKENS,
+      stopWhen: stepCountIs(CHAT_MAX_STEPS),
       abortSignal: args.signal,
       experimental_toolApprovalSecret: args.env.CHAT_TOOL_APPROVAL_SECRET || args.env.SUPABASE_SERVICE_ROLE_KEY,
       providerOptions: { openai: { parallelToolCalls: false } },
@@ -350,6 +354,10 @@ async function runChatAttempt(args: ChatResilienceArgs, config: ChatModelConfig,
         outputStarted = true
         flushChunks(args.writer, pending)
       }
+    }
+    const finishReason = await result.finishReason
+    if (finishReason === 'length') {
+      throw new Error(`模型输出达到 ${CHAT_MAX_OUTPUT_TOKENS} 个 token 上限，当前回答可能未完整结束。请点击“继续本轮”完成剩余分析。`)
     }
     flushChunks(args.writer, pending)
     succeeded = true

--- a/web/apps/api/src/routes/portfolio.ts
+++ b/web/apps/api/src/routes/portfolio.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import { authMiddleware, createUserSupabase, type AuthContext } from '../middleware/auth'
 import { isActiveWhitelistUser } from '../middleware/whitelist'
-import type { Env } from '../index'
+import type { Env } from '../app'
 
 type PortfolioBindings = { Bindings: Env; Variables: { auth: AuthContext } }
 

--- a/web/apps/api/src/routes/portfolio.ts
+++ b/web/apps/api/src/routes/portfolio.ts
@@ -1,7 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { authMiddleware, type AuthContext } from '../middleware/auth'
+import { authMiddleware, createUserSupabase, type AuthContext } from '../middleware/auth'
+import { isActiveWhitelistUser } from '../middleware/whitelist'
 import type { Env } from '../index'
 
 type PortfolioBindings = { Bindings: Env; Variables: { auth: AuthContext } }
@@ -62,26 +62,6 @@ export function parsePortfolioInput(raw: unknown):
   const codes = parsed.data.positions.map((item) => item.code.toUpperCase())
   if (new Set(codes).size !== codes.length) return { error: 'Duplicate position code' }
   return { data: parsed.data }
-}
-
-function createUserSupabase(env: Env, accessToken: string) {
-  const url = env.SUPABASE_URL || env.VITE_SUPABASE_URL
-  const key = env.SUPABASE_ANON_KEY || env.VITE_SUPABASE_ANON_KEY
-  if (!url || !key) throw new Error('Supabase env is missing')
-  return createClient(url, key, { global: { headers: { Authorization: `Bearer ${accessToken}` } } })
-}
-
-function compactToday(): string {
-  return new Date().toISOString().slice(0, 10).replace(/-/g, '')
-}
-
-async function isActiveWhitelistUser(supabase: ReturnType<typeof createUserSupabase>, userId: string): Promise<boolean> {
-  const { data, error } = await supabase.from('whitelist').select('expire_date').eq('user_id', userId).limit(1)
-  if (error || !Array.isArray(data)) return false
-  return data.some((row) => {
-    const expiry = String(row.expire_date || '').trim()
-    return !expiry || (/^\d{8}$/.test(expiry) && expiry >= compactToday())
-  })
 }
 
 async function loadPortfolio(supabase: ReturnType<typeof createUserSupabase>, userId: string) {

--- a/web/apps/api/src/routes/settings.ts
+++ b/web/apps/api/src/routes/settings.ts
@@ -11,7 +11,7 @@ import {
   type Provider,
 } from '@wyckoff/shared'
 import { authMiddleware, type AuthContext } from '../middleware/auth'
-import type { Env } from '../index'
+import type { Env } from '../app'
 
 type SettingsBindings = { Bindings: Env; Variables: { auth: AuthContext } }
 type ModelTestConfig = z.infer<typeof MODEL_TEST_SCHEMA>

--- a/web/apps/api/src/services/agent-run-store.test.ts
+++ b/web/apps/api/src/services/agent-run-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { AgentRunStore, type AgentRunRecord } from './agent-run-store'
+
+class FakeRedis {
+  readonly values = new Map<string, unknown>()
+
+  async set(key: string, value: AgentRunRecord): Promise<void> {
+    this.values.set(key, value)
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    return (this.values.get(key) as T | undefined) ?? null
+  }
+
+  async del(key: string): Promise<number> {
+    return this.values.delete(key) ? 1 : 0
+  }
+}
+
+const record: AgentRunRecord = {
+  id: 'run-1',
+  kind: 'python_research',
+  status: 'completed',
+  createdAt: '2026-07-18T00:00:00.000Z',
+}
+
+describe('Agent run store', () => {
+  it('isolates records by authenticated user', async () => {
+    const redis = new FakeRedis()
+    const store = new AgentRunStore(redis)
+    await store.save('user-a', record)
+
+    expect(await store.get('user-a', record.id)).toEqual(record)
+    expect(await store.get('user-b', record.id)).toBeNull()
+  })
+
+  it('removes only the current user record', async () => {
+    const redis = new FakeRedis()
+    const store = new AgentRunStore(redis)
+    await store.save('user-a', record)
+    await store.save('user-b', record)
+    await store.remove('user-a', record.id)
+
+    expect(await store.get('user-a', record.id)).toBeNull()
+    expect(await store.get('user-b', record.id)).toEqual(record)
+  })
+})

--- a/web/apps/api/src/services/agent-run-store.ts
+++ b/web/apps/api/src/services/agent-run-store.ts
@@ -1,5 +1,5 @@
 import { Redis } from '@upstash/redis/cloudflare'
-import type { Env } from '../index'
+import type { Env } from '../app'
 
 export type AgentRunStatus = 'running' | 'completed' | 'failed'
 

--- a/web/apps/api/src/services/agent-run-store.ts
+++ b/web/apps/api/src/services/agent-run-store.ts
@@ -1,0 +1,61 @@
+import { Redis } from '@upstash/redis/cloudflare'
+import type { Env } from '../index'
+
+export type AgentRunStatus = 'running' | 'completed' | 'failed'
+
+export type AgentRunRecord = {
+  id: string
+  kind: 'python_research'
+  status: AgentRunStatus
+  createdAt: string
+  finishedAt?: string
+  exitCode?: number
+  stdout?: string
+  stderr?: string
+  error?: string
+  usage?: {
+    activeCpuUsageMs: number
+    networkIngressBytes: number
+    networkEgressBytes: number
+  }
+}
+
+type RedisClient = {
+  set: (key: string, value: AgentRunRecord, options: { ex: number }) => Promise<unknown>
+  get: <T>(key: string) => Promise<T | null>
+  del: (key: string) => Promise<number>
+}
+
+export class AgentRunStore {
+  constructor(private readonly redis: RedisClient, private readonly ttlSeconds = 3600) {}
+
+  async save(userId: string, record: AgentRunRecord): Promise<void> {
+    await this.redis.set(runKey(userId, record.id), record, { ex: this.ttlSeconds })
+  }
+
+  get(userId: string, runId: string): Promise<AgentRunRecord | null> {
+    return this.redis.get<AgentRunRecord>(runKey(userId, runId))
+  }
+
+  async remove(userId: string, runId: string): Promise<void> {
+    await this.redis.del(runKey(userId, runId))
+  }
+}
+
+export function createAgentRunStore(env: Env): AgentRunStore | null {
+  const url = env.UPSTASH_REDIS_REST_URL?.trim()
+  const token = env.UPSTASH_REDIS_REST_TOKEN?.trim()
+  if (!url && !token) return null
+  if (!url || !token) throw new Error('Upstash Redis env is incomplete')
+  return new AgentRunStore(new Redis({ url, token }), runTtl(env.AGENT_RUN_TTL_SECONDS))
+}
+
+function runKey(userId: string, runId: string): string {
+  return `wyckoff:agent-run:${encodeURIComponent(userId)}:${encodeURIComponent(runId)}`
+}
+
+function runTtl(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 60) return 3600
+  return Math.min(Math.trunc(parsed), 86_400)
+}

--- a/web/apps/api/src/services/python-sandbox.integration.test.ts
+++ b/web/apps/api/src/services/python-sandbox.integration.test.ts
@@ -1,0 +1,16 @@
+import { env } from 'cloudflare:workers'
+import { describe, expect, it } from 'vitest'
+import type { Env } from '../index'
+import { executePythonSandbox } from './python-sandbox'
+
+const integrationEnv = env as Env
+const describeSandbox = integrationEnv.RUN_VERCEL_SANDBOX_INTEGRATION === '1' ? describe : describe.skip
+
+describeSandbox('Vercel Sandbox integration', () => {
+  it('executes Python with denied network access and deletes the microVM', async () => {
+    const result = await executePythonSandbox(integrationEnv, 'print("wyckoff-sandbox-ok")')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.trim()).toBe('wyckoff-sandbox-ok')
+    expect(result.networkEgressBytes).toBeGreaterThanOrEqual(0)
+  }, 120_000)
+})

--- a/web/apps/api/src/services/python-sandbox.integration.test.ts
+++ b/web/apps/api/src/services/python-sandbox.integration.test.ts
@@ -1,6 +1,6 @@
 import { env } from 'cloudflare:workers'
 import { describe, expect, it } from 'vitest'
-import type { Env } from '../index'
+import type { Env } from '../app'
 import { executePythonSandbox } from './python-sandbox'
 
 const integrationEnv = env as Env

--- a/web/apps/api/src/services/python-sandbox.test.ts
+++ b/web/apps/api/src/services/python-sandbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { Env } from '../index'
+import type { Env } from '../app'
 import { executePythonSandbox, type SandboxHandle } from './python-sandbox'
 
 function sandbox(overrides: Partial<SandboxHandle> = {}): SandboxHandle {

--- a/web/apps/api/src/services/python-sandbox.test.ts
+++ b/web/apps/api/src/services/python-sandbox.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Env } from '../index'
+import { executePythonSandbox, type SandboxHandle } from './python-sandbox'
+
+function sandbox(overrides: Partial<SandboxHandle> = {}): SandboxHandle {
+  return {
+    writeFiles: vi.fn(async () => undefined),
+    runCommand: vi.fn(async () => ({
+      exitCode: 0,
+      stdout: async () => 'research ok\n',
+      stderr: async () => '',
+    })),
+    stop: vi.fn(async () => ({
+      activeCpuUsageMs: 42,
+      networkTransfer: { ingress: 0, egress: 0 },
+    })),
+    delete: vi.fn(async () => undefined),
+    ...overrides,
+  }
+}
+
+describe('Python sandbox executor', () => {
+  it('runs a script without secrets and permanently deletes the sandbox', async () => {
+    const handle = sandbox()
+    const factory = vi.fn(async () => handle)
+    const result = await executePythonSandbox({ AGENT_SANDBOX_TIMEOUT_MS: '45000' }, 'print("ok")', factory)
+
+    expect(factory).toHaveBeenCalledWith(expect.any(Object), {
+      runtime: 'python3.13',
+      timeout: 45_000,
+      networkPolicy: 'deny-all',
+      persistent: false,
+      tags: { app: 'wyckoff', kind: 'python-research' },
+    })
+    expect(handle.writeFiles).toHaveBeenCalledWith([{ path: 'main.py', content: 'print("ok")' }])
+    expect(handle.runCommand).toHaveBeenCalledWith('sh', ['-c', expect.stringContaining('ulimit -f 64')])
+    expect(handle.stop).toHaveBeenCalledOnce()
+    expect(handle.delete).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({ exitCode: 0, stdout: 'research ok\n', activeCpuUsageMs: 42 })
+  })
+
+  it('deletes the sandbox when execution fails', async () => {
+    const handle = sandbox({ writeFiles: vi.fn(async () => { throw new Error('write failed') }) })
+    await expect(executePythonSandbox({} as Env, 'print(1)', async () => handle)).rejects.toThrow('write failed')
+    expect(handle.stop).not.toHaveBeenCalled()
+    expect(handle.delete).toHaveBeenCalledOnce()
+  })
+
+  it('caps command output returned to the API', async () => {
+    const handle = sandbox({
+      runCommand: vi.fn(async () => ({
+        exitCode: 0,
+        stdout: async () => 'x'.repeat(40_000),
+        stderr: async () => '',
+      })),
+    })
+    const result = await executePythonSandbox({} as Env, 'print(1)', async () => handle)
+    expect(result.stdout.length).toBeLessThan(40_000)
+    expect(result.stdout).toContain('...[truncated]')
+  })
+})

--- a/web/apps/api/src/services/python-sandbox.ts
+++ b/web/apps/api/src/services/python-sandbox.ts
@@ -1,0 +1,103 @@
+import type { Env } from '../index'
+
+const DEFAULT_TIMEOUT_MS = 60_000
+const MAX_TIMEOUT_MS = 120_000
+const MAX_OUTPUT_BYTES = 32 * 1024
+const RUN_PYTHON = 'ulimit -f 64; python3 main.py >stdout.txt 2>stderr.txt; code=$?; cat stdout.txt; cat stderr.txt >&2; exit $code'
+
+type CommandResult = {
+  exitCode: number
+  stdout: () => Promise<string>
+  stderr: () => Promise<string>
+}
+
+type SandboxUsage = {
+  activeCpuUsageMs: number
+  networkTransfer: { ingress: number; egress: number }
+}
+
+export type SandboxHandle = {
+  writeFiles: (files: Array<{ path: string; content: string }>) => Promise<void>
+  runCommand: (command: string, args: string[]) => Promise<CommandResult>
+  stop: () => Promise<SandboxUsage>
+  delete: () => Promise<void>
+}
+
+export type PythonSandboxOptions = {
+  runtime: 'python3.13'
+  timeout: number
+  networkPolicy: 'deny-all'
+  persistent: false
+  tags: { app: 'wyckoff'; kind: 'python-research' }
+}
+
+export type SandboxFactory = (env: Env, options: PythonSandboxOptions) => Promise<SandboxHandle>
+
+export type PythonSandboxResult = {
+  exitCode: number
+  stdout: string
+  stderr: string
+  activeCpuUsageMs: number
+  networkIngressBytes: number
+  networkEgressBytes: number
+}
+
+export async function executePythonSandbox(
+  env: Env,
+  script: string,
+  createSandbox: SandboxFactory = createVercelSandbox,
+): Promise<PythonSandboxResult> {
+  const sandbox = await createSandbox(env, sandboxOptions(env))
+  try {
+    await sandbox.writeFiles([{ path: 'main.py', content: script }])
+    const command = await sandbox.runCommand('sh', ['-c', RUN_PYTHON])
+    const [stdout, stderr] = await Promise.all([command.stdout(), command.stderr()])
+    const usage = await sandbox.stop()
+    return {
+      exitCode: command.exitCode,
+      stdout: limitOutput(stdout),
+      stderr: limitOutput(stderr),
+      activeCpuUsageMs: usage.activeCpuUsageMs,
+      networkIngressBytes: usage.networkTransfer.ingress,
+      networkEgressBytes: usage.networkTransfer.egress,
+    }
+  } finally {
+    await sandbox.delete().catch(() => undefined)
+  }
+}
+
+async function createVercelSandbox(env: Env, options: PythonSandboxOptions): Promise<SandboxHandle> {
+  const credentials = sandboxCredentials(env)
+  const { Sandbox } = await import('@vercel/sandbox')
+  return Sandbox.create({ ...credentials, ...options })
+}
+
+function sandboxOptions(env: Env): PythonSandboxOptions {
+  return {
+    runtime: 'python3.13',
+    timeout: sandboxTimeout(env.AGENT_SANDBOX_TIMEOUT_MS),
+    networkPolicy: 'deny-all',
+    persistent: false,
+    tags: { app: 'wyckoff', kind: 'python-research' },
+  }
+}
+
+function sandboxCredentials(env: Env) {
+  const token = env.VERCEL_OIDC_TOKEN?.trim() || env.VERCEL_TOKEN?.trim()
+  const teamId = env.VERCEL_TEAM_ID?.trim()
+  const projectId = env.VERCEL_PROJECT_ID?.trim()
+  if (!token || !teamId || !projectId) throw new Error('Vercel Sandbox env is incomplete')
+  return { token, teamId, projectId }
+}
+
+function sandboxTimeout(raw: string | undefined): number {
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 5_000) return DEFAULT_TIMEOUT_MS
+  return Math.min(Math.trunc(parsed), MAX_TIMEOUT_MS)
+}
+
+function limitOutput(value: string): string {
+  const encoded = new TextEncoder().encode(value)
+  if (encoded.length <= MAX_OUTPUT_BYTES) return value
+  return `${new TextDecoder().decode(encoded.slice(0, MAX_OUTPUT_BYTES))}\n...[truncated]`
+}

--- a/web/apps/api/src/services/python-sandbox.ts
+++ b/web/apps/api/src/services/python-sandbox.ts
@@ -1,4 +1,4 @@
-import type { Env } from '../index'
+import type { Env } from '../app'
 
 const DEFAULT_TIMEOUT_MS = 60_000
 const MAX_TIMEOUT_MS = 120_000

--- a/web/apps/api/vitest.config.ts
+++ b/web/apps/api/vitest.config.ts
@@ -2,6 +2,7 @@ import { cloudflareTest } from '@cloudflare/vitest-pool-workers'
 import { defineConfig } from 'vitest/config'
 
 const runUpstashIntegration = process.env.RUN_UPSTASH_INTEGRATION === '1'
+const runSandboxIntegration = process.env.RUN_VERCEL_SANDBOX_INTEGRATION === '1'
 
 export default defineConfig({
   plugins: [cloudflareTest({
@@ -15,6 +16,14 @@ export default defineConfig({
           RUN_UPSTASH_INTEGRATION: '1',
           UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL || '',
           UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN || '',
+        } : {}),
+        ...(runSandboxIntegration ? {
+          RUN_VERCEL_SANDBOX_INTEGRATION: '1',
+          VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID || '',
+          VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID || '',
+          VERCEL_TOKEN: process.env.VERCEL_TOKEN || '',
+          VERCEL_OIDC_TOKEN: process.env.VERCEL_OIDC_TOKEN || '',
+          AGENT_SANDBOX_TIMEOUT_MS: '60000',
         } : {}),
       },
     },

--- a/web/apps/api/wrangler.toml
+++ b/web/apps/api/wrangler.toml
@@ -1,8 +1,12 @@
 name = "wyckoff-api"
 main = "src/index.ts"
 compatibility_date = "2024-12-18"
+compatibility_flags = ["nodejs_compat"]
 
 [vars]
 ENVIRONMENT = "production"
 CHAT_DAILY_LIMIT_PER_USER = "80"
 CHAT_MIN_INTERVAL_MS = "2500"
+AGENT_SANDBOX_ENABLED = "false"
+AGENT_SANDBOX_TIMEOUT_MS = "60000"
+AGENT_RUN_TTL_SECONDS = "3600"

--- a/web/functions/api/chat/[[path]].ts
+++ b/web/functions/api/chat/[[path]].ts
@@ -1,4 +1,4 @@
-import app from '../../../apps/api/src/index'
+import app from '../../../apps/api/src/pages'
 
 export const onRequest: PagesFunction = (context) => {
   return app.fetch(context.request, context.env)

--- a/web/functions/api/portfolio/[[path]].ts
+++ b/web/functions/api/portfolio/[[path]].ts
@@ -1,4 +1,4 @@
-import app from '../../../apps/api/src/index'
+import app from '../../../apps/api/src/pages'
 
 export const onRequest: PagesFunction = (context) => {
   return app.fetch(context.request, context.env)

--- a/web/functions/api/settings/[[path]].ts
+++ b/web/functions/api/settings/[[path]].ts
@@ -1,4 +1,4 @@
-import app from '../../../apps/api/src/index'
+import app from '../../../apps/api/src/pages'
 
 export const onRequest: PagesFunction = (context) => {
   return app.fetch(context.request, context.env)

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.38.0
         version: 1.38.0
+      '@vercel/sandbox':
+        specifier: 2.7.0
+        version: 2.7.0
       '@wyckoff/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1185,6 +1188,9 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
+  '@vercel/sandbox@2.7.0':
+    resolution: {integrity: sha512-gVBJZsA803R6ZyBXu0Ha0YT7UfPurKD+5zgBHJ0Lz64sunJPrAnY0T2sm2zSZ5wXt3h2xUVLBZL9ulDOxuatQA==}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1220,6 +1226,9 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1243,12 +1252,31 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   baseline-browser-mapping@2.10.25:
     resolution: {integrity: sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==}
@@ -1419,6 +1447,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
@@ -1435,6 +1466,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -1555,6 +1589,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1579,6 +1616,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1848,6 +1888,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1936,6 +1980,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rollup@4.62.0:
     resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1984,6 +2032,9 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -2008,6 +2059,12 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -2232,6 +2289,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2253,6 +2318,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -3133,6 +3201,23 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vercel/sandbox@2.7.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.28.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.6
@@ -3186,6 +3271,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -3209,9 +3296,17 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
 
   baseline-browser-mapping@2.10.25: {}
 
@@ -3406,6 +3501,12 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.0.8: {}
 
   expect-type@1.3.0: {}
@@ -3415,6 +3516,8 @@ snapshots:
   fancy-canvas@2.1.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -3520,6 +3623,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
@@ -3533,6 +3638,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonlines@0.1.1: {}
 
   keyv@4.5.4:
     dependencies:
@@ -3997,6 +4104,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-paths@4.4.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -4108,6 +4217,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  retry@0.13.1: {}
+
   rollup@4.62.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -4194,6 +4305,15 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -4218,6 +4338,21 @@ snapshots:
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   throttleit@2.1.0: {}
 
@@ -4406,6 +4541,14 @@ snapshots:
 
   ws@8.21.0: {}
 
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
@@ -4428,6 +4571,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:


### PR DESCRIPTION
## Summary

- add an authenticated, whitelist-only `/api/agent-runs` contract for bounded Python research tasks
- execute code in a deny-all, non-persistent Vercel Sandbox and permanently delete it after collecting usage
- keep short-lived per-user run results in Upstash Redis with GET/DELETE isolation
- share the whitelist boundary with portfolio routes and document every runtime variable
- keep Worker-only sandbox routes out of the legacy Pages compatibility app
- add opt-in real Upstash and Vercel integration paths while default tests remain offline

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python scripts/quality_gate.py --ci`
- `.venv/bin/python -m pytest tests/ -q` — 2192 passed
- `pnpm -r exec tsc --noEmit`
- frontend tests — 142 passed
- API tests — 19 passed, 2 opt-in tests skipped
- production Web build
- real Upstash integration — 4 passed
- Worker dry-run — 871.02 KiB gzip
- Pages Functions build under Cloudflare Wrangler 3 — passed without bundling `@vercel/sandbox`
- Cloudflare preview deployment — passed

## Boundaries

- `AGENT_SANDBOX_ENABLED` defaults to false; deployment cannot create a sandbox until explicitly enabled
- the MVP is synchronous and is not described as a durable queue or cancellable workflow
- sandbox egress and persistence are disabled, no business secrets enter the VM, stdout/stderr are capped, and deletion runs in `finally`
- `/api/agent-runs` is available only on the independent Worker, not the legacy Pages compatibility app
- real Vercel creation remains opt-in until team, project, and token bindings are configured