### PR TITLE
fix: keep chat route within quality limit

### DIFF
--- a/web/apps/web/src/features/reading-room/chat-state.ts
+++ b/web/apps/web/src/features/reading-room/chat-state.ts
@@ -254,6 +254,27 @@ export function useAgentRunPolling(
   return useMemo(() => ({ records, cancel }), [cancel, records])
 }
 
+export function useAgentRunInterpretation(
+  chat: ReadingRoomChat,
+  queue: MessageQueue,
+  loading: boolean,
+  setLocalError: (value: string) => void,
+  t: (key: TranslationKey) => string,
+): (runId: string) => void {
+  return useCallback((runId: string) => {
+    const prompt = `请根据本轮已完成的隔离 Python 研究计算结果（runId: ${runId}）给出简明解读：说明结果、计算局限，以及它不构成投资建议。不要重新执行沙箱。`
+    if (loading) {
+      queue.enqueue(prompt)
+      return
+    }
+    setLocalError('')
+    chat.clearError()
+    void chat.sendMessage({ text: prompt }).catch((error: unknown) => {
+      setLocalError(normalizeClientError(error, t))
+    })
+  }, [chat, loading, queue, setLocalError, t])
+}
+
 export function useChatConfig(
   token: string | undefined,
   t: (key: TranslationKey, vars?: Record<string, string>) => string,

--- a/web/apps/web/src/routes/chat.tsx
+++ b/web/apps/web/src/routes/chat.tsx
@@ -5,6 +5,7 @@ import { usePreferences } from '@/lib/preferences'
 import {
   CONVERSATION_SIDEBAR_STORAGE_KEY,
   useAutoScroll,
+  useAgentRunInterpretation,
   useChatConfig,
   useMessageQueue,
   useAgentRunPolling,
@@ -132,18 +133,7 @@ export function ChatPage() {
       setRunCheckpoint(null)
     }
   }, [activeConversationRef, setRunCheckpoint])
-  const handleInterpretAgentRun = useCallback((runId: string) => {
-    const prompt = `请根据本轮已完成的隔离 Python 研究计算结果（runId: ${runId}）给出简明解读：说明结果、计算局限，以及它不构成投资建议。不要重新执行沙箱。`
-    if (loading) {
-      queue.enqueue(prompt)
-      return
-    }
-    setLocalError('')
-    chat.clearError()
-    void chat.sendMessage({ text: prompt }).catch((error: unknown) => {
-      setLocalError(error instanceof Error ? error.message : t('chat.requestFailed'))
-    })
-  }, [chat, loading, queue, setLocalError, t])
+  const handleInterpretAgentRun = useAgentRunInterpretation(chat, queue, loading, setLocalError, t)
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden" data-reading-room-streaming={loading ? 'true' : 'false'}>


### PR DESCRIPTION
## Summary

- Extract the sandbox-result interpretation callback from `ChatPage` into the Reading Room chat-state module.
- Keep the route below the enforced 120-line hard limit without changing the chat, sandbox, or API contract.

## Why

PR #165 added the sandbox-result loop but pushed `ChatPage()` to 131 lines, causing the repository quality gate to fail after merge.

## Validation

- `python scripts/quality_gate.py --ci`
- `pnpm --filter @wyckoff/web lint`
- `pnpm --filter @wyckoff/web test` (151 tests)
- `pnpm --filter @wyckoff/web build`
- `pnpm --filter @wyckoff/api test` (38 passed, 2 skipped)
- `pnpm --filter @wyckoff/api build` (Worker dry run)
- `pnpm -r exec tsc --noEmit`