### PR TITLE
feat: recover sandbox runs across conversations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ Worker 负责鉴权、输入校验、队列控制面和 HMAC 签名。Vercel Nod
 
 每个实际执行都会复用 API 的 `requestId` 并生成独立 `runId`；Worker 用两个 ID 调 bridge，bridge 在 Vercel Runtime Logs 中输出同一对 ID，因此两侧能按 ID 关联。Worker 日志事件为 `sandbox_run.queued|started|retrying|finished|failed|cancelled`，bridge 事件为 `sandbox_bridge.started|finished|rejected|failed`；只包含状态、尝试次数、耗时、退出码、脚本字节数和 CPU/网络用量，不记录 Python 源码、stdout/stderr、HMAC、Token 或原始用户 ID。实时排查可在 `web/apps/api/` 运行 `pnpm exec wrangler tail wyckoff-api --format pretty`，或在 `web/apps/sandbox-bridge/` 运行 `pnpm exec vercel logs https://wyckoff-agent-sandbox.vercel.app --json`；历史 Vercel 日志在项目 Deployment 的 Functions Logs 中查看。
 
-读盘室在沙箱显式开启时会向模型提供 `run_python_research` 工具，但仅在用户明确提出计算需求后使用，且 Vercel AI SDK 必须取得用户确认才会执行。确认后，聊天卡片以当前登录令牌轮询 Worker 的 `GET /api/agent-runs/:id`：它只读取该用户的记录，并在任务进入终态时把最终 stdout、stderr、退出码和用量回填到原工具调用。用户可在 `queued` 时取消，完成后点“解读结果”才向模型发送基于该终态输出的后续请求；这避免把尚未完成的队列确认误当作研究结论。执行时再次校验当前用户的白名单，复用与 REST 端点完全相同的 Redis 记录、超时和删除流程；未开启沙箱或未在白名单中的用户不能经聊天路径绕过这道边界。
+读盘室在沙箱显式开启时会向模型提供 `run_python_research` 工具，但仅在用户明确提出计算需求后使用，且 Vercel AI SDK 必须取得用户确认才会执行。确认后，聊天卡片以当前登录令牌轮询 Worker 的 `GET /api/agent-runs/:id`：它只读取该用户的记录，并在任务进入终态时把最终 stdout、stderr、退出码和用量回填到原工具调用。轮询覆盖当前浏览器保存的各个对话；因此刷新或切走对话不会遗失未终态任务，终态会回写到其原来的对话。用户可在 `queued` 时取消，完成后点“解读结果”才向模型发送基于该终态输出的后续请求；这避免把尚未完成的队列确认误当作研究结论。执行时再次校验当前用户的白名单，复用与 REST 端点完全相同的 Redis 记录、超时和删除流程；未开启沙箱或未在白名单中的用户不能经聊天路径绕过这道边界。
 
 | Worker 变量 | 默认值 | 作用 |
 |---|---:|---|

--- a/web/apps/web/src/features/reading-room/chat-state.ts
+++ b/web/apps/web/src/features/reading-room/chat-state.ts
@@ -23,6 +23,7 @@ import {
   fetchAgentRun,
   isAgentRunTerminal,
   type AgentRunRecord,
+  type SandboxRunTool,
 } from './agent-runs'
 import type { ReadingRoomConversations } from './conversations'
 import { scrollToMessage } from './run-records'
@@ -45,6 +46,8 @@ export interface AgentRunController {
   records: Record<string, AgentRunRecord>
   cancel: (runId: string) => Promise<void>
 }
+
+type ConversationSandboxRunTool = SandboxRunTool & { conversationId: string }
 
 interface SubmitHandlerArgs {
   chat: ReadingRoomChat
@@ -201,11 +204,15 @@ export function useReadingRoomChat(
 
 export function useAgentRunPolling(
   chat: ReadingRoomChat,
+  conversations: ReadingRoomConversations,
   token: string | undefined,
   setLocalError: (value: string) => void,
 ): AgentRunController {
   const [records, setRecords] = useState<Record<string, AgentRunRecord>>({})
-  const tools = useMemo(() => collectSandboxRunTools(chat.messages), [chat.messages])
+  const tools = useMemo(
+    () => collectConversationSandboxRunTools(chat.messages, conversations),
+    [chat.messages, conversations],
+  )
   const activeTools = useMemo(() => tools.filter((tool) => !isAgentRunTerminal(records[tool.runId] || tool.record)), [records, tools])
 
   useEffect(() => {
@@ -236,10 +243,14 @@ export function useAgentRunPolling(
     for (const tool of tools) {
       const record = records[tool.runId]
       if (record && isAgentRunTerminal(record) && !isAgentRunTerminal(tool.record)) {
-        void chat.addToolOutput({ tool: 'run_python_research', toolCallId: tool.toolCallId, output: record })
+        if (tool.conversationId === conversations.activeId) {
+          void chat.addToolOutput({ tool: 'run_python_research', toolCallId: tool.toolCallId, output: record })
+        } else {
+          conversations.replaceToolOutput(tool.conversationId, tool.toolCallId, record)
+        }
       }
     }
-  }, [chat, records, tools])
+  }, [chat, conversations, records, tools])
 
   const cancel = useCallback(async (runId: string) => {
     if (!token) return
@@ -252,6 +263,26 @@ export function useAgentRunPolling(
   }, [setLocalError, token])
 
   return useMemo(() => ({ records, cancel }), [cancel, records])
+}
+
+function collectConversationSandboxRunTools(
+  messages: UIMessage[],
+  conversations: ReadingRoomConversations,
+): ConversationSandboxRunTool[] {
+  const activeTools = collectSandboxRunTools(messages).map((tool) => ({ ...tool, conversationId: conversations.activeId }))
+  const storedTools = conversations.items
+    .filter((conversation) => conversation.id !== conversations.activeId)
+    .flatMap((conversation) => collectSandboxRunTools(conversation.messages).map((tool) => ({ ...tool, conversationId: conversation.id })))
+  return deduplicateConversationSandboxRunTools([...activeTools, ...storedTools])
+}
+
+function deduplicateConversationSandboxRunTools(tools: ConversationSandboxRunTool[]): ConversationSandboxRunTool[] {
+  const runIds = new Set<string>()
+  return tools.filter((tool) => {
+    if (runIds.has(tool.runId)) return false
+    runIds.add(tool.runId)
+    return true
+  })
 }
 
 export function useAgentRunInterpretation(

--- a/web/apps/web/src/features/reading-room/conversations.test.ts
+++ b/web/apps/web/src/features/reading-room/conversations.test.ts
@@ -1,0 +1,49 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+import { replaceConversationToolOutput } from './conversations'
+
+const queuedOutput = {
+  id: 'run-1',
+  kind: 'python_research',
+  status: 'queued',
+  attempts: 0,
+  createdAt: '2026-07-25T00:00:00.000Z',
+}
+
+const completedOutput = {
+  ...queuedOutput,
+  status: 'completed',
+  finishedAt: '2026-07-25T00:00:01.000Z',
+  exitCode: 0,
+  stdout: '5050\n',
+}
+
+const messages = [{
+  id: 'assistant-tool',
+  role: 'assistant',
+  parts: [{
+    type: 'tool-run_python_research',
+    toolCallId: 'tool-1',
+    state: 'output-available',
+    output: queuedOutput,
+  }],
+}, {
+  id: 'assistant-text',
+  role: 'assistant',
+  parts: [{ type: 'text', text: '任务已排队。' }],
+}] as UIMessage[]
+
+describe('conversation sandbox result recovery', () => {
+  it('replaces only the original tool result in a stored conversation', () => {
+    const updated = replaceConversationToolOutput(messages, 'tool-1', completedOutput)
+
+    expect(updated).not.toBe(messages)
+    expect(updated[0]?.parts[0]).toMatchObject({ state: 'output-available', output: completedOutput })
+    expect(updated[1]).toBe(messages[1])
+    expect(messages[0]?.parts[0]).toMatchObject({ output: queuedOutput })
+  })
+
+  it('keeps the saved conversation unchanged when the tool call is absent', () => {
+    expect(replaceConversationToolOutput(messages, 'missing-tool', completedOutput)).toBe(messages)
+  })
+})

--- a/web/apps/web/src/features/reading-room/conversations.ts
+++ b/web/apps/web/src/features/reading-room/conversations.ts
@@ -24,6 +24,7 @@ export interface ReadingRoomConversations {
   select: (id: string) => void
   remove: (id: string) => void
   rename: (id: string, title: string) => void
+  replaceToolOutput: (conversationId: string, toolCallId: string, output: unknown) => void
 }
 
 type SetConversations = React.Dispatch<React.SetStateAction<ReadingRoomConversation[]>>
@@ -46,8 +47,9 @@ export function useReadingRoomConversations(
   const select = useSelectConversationAction(items, setActiveId, setMessages, skipNextSaveRef)
   const remove = useRemoveConversationAction(storageKey, activeId, setItems, setActiveId, setMessages, skipNextSaveRef)
   const rename = useRenameConversationAction(storageKey, setItems)
+  const replaceToolOutput = useReplaceToolOutput(storageKey, setItems)
 
-  return useMemo(() => ({ items, activeId, create, select, remove, rename }), [activeId, create, items, remove, rename, select])
+  return useMemo(() => ({ items, activeId, create, select, remove, rename, replaceToolOutput }), [activeId, create, items, remove, rename, replaceToolOutput, select])
 }
 
 function useConversationLoader(
@@ -151,6 +153,23 @@ function useRenameConversationAction(storageKey: string, setItems: SetConversati
   }, [setItems, storageKey])
 }
 
+function useReplaceToolOutput(storageKey: string, setItems: SetConversations) {
+  return useCallback((conversationId: string, toolCallId: string, output: unknown) => {
+    setItems((current) => {
+      let changed = false
+      const next = current.map((conversation) => {
+        if (conversation.id !== conversationId) return conversation
+        const messages = replaceConversationToolOutput(conversation.messages, toolCallId, output)
+        if (messages === conversation.messages) return conversation
+        changed = true
+        return updateConversationMessages(conversation, messages)
+      })
+      if (changed) writeConversations(storageKey, next)
+      return changed ? next : current
+    })
+  }, [setItems, storageKey])
+}
+
 function activateConversation(
   conversation: ReadingRoomConversation,
   setActiveId: (id: string) => void,
@@ -186,6 +205,27 @@ function updateConversationMessages(conversation: ReadingRoomConversation, messa
     updatedAt: savedMessages.length > 0 ? new Date().toISOString() : conversation.updatedAt,
     messages: savedMessages,
   }
+}
+
+export function replaceConversationToolOutput(
+  messages: UIMessage[],
+  toolCallId: string,
+  output: unknown,
+): UIMessage[] {
+  let changed = false
+  const next = messages.map((message) => {
+    if (message.role !== 'assistant') return message
+    let messageChanged = false
+    const parts = message.parts.map((part) => {
+      const tool = part as MessagePart
+      if (!isToolPart(tool) || tool.toolCallId !== toolCallId) return part
+      changed = true
+      messageChanged = true
+      return { ...tool, state: 'output-available' as const, output, errorText: undefined } as MessagePart
+    })
+    return messageChanged ? { ...message, parts } as UIMessage : message
+  })
+  return changed ? next : messages
 }
 
 function readConversations(key: string): ReadingRoomConversation[] {

--- a/web/apps/web/src/routes/chat.tsx
+++ b/web/apps/web/src/routes/chat.tsx
@@ -81,10 +81,10 @@ export function ChatPage() {
   const { marketWatch, requestItems, updateMarketWatch } = useMarketWatch(user?.id, watchlist.items)
   const chat = useReadingRoomChat(token, setLocalError, t, setModelStatus, requestItems, marketWatch, updateMarketWatch, onRunEvent, onRunFinish, onRunError)
   const loading = chat.status === 'submitted' || chat.status === 'streaming'
-  const agentRuns = useAgentRunPolling(chat, token, setLocalError)
   const changeActiveTab = useCallback((tab: ReadingRoomTab) => { setActiveTab(tab); writeActiveTab(tab) }, [])
   const queue = useMessageQueue(chat, loading, token, config.configured, setLocalError, t)
   const conversations = useReadingRoomConversations(user?.id, chat.messages, chat.setMessages)
+  const agentRuns = useAgentRunPolling(chat, conversations, token, setLocalError)
   useEffect(() => {
     activeConversationRef.current = conversations.activeId
     setRunCheckpoint(readRunCheckpoint(conversations.activeId))


### PR DESCRIPTION
## Summary

- Poll unfinished sandbox runs from every locally saved Reading Room conversation for the current browser user.
- Write a terminal result back into the originating inactive conversation, so reopening it shows stdout/stderr and the interpretation action immediately.
- Preserve the existing active-conversation AI SDK tool-output path and add recovery regression tests.

## Why

Sandbox polling previously stopped when the user switched conversations; completion was only discovered after returning to the original chat. This closes the refresh and conversation-switch recovery gap without adding a resident backend service.

## Validation

- `python scripts/quality_gate.py --ci`
- `pnpm --filter @wyckoff/web lint`
- `pnpm --filter @wyckoff/web test` (153 tests)
- `pnpm --filter @wyckoff/web build`
- `pnpm --filter @wyckoff/api test` (38 passed, 2 skipped)
- `pnpm --filter @wyckoff/api build` (Worker dry run)
- `pnpm -r exec tsc --noEmit`