### PR TITLE
feat: verify web deployment health

### DIFF
--- a/.github/workflows/web_deployment_health.yml
+++ b/.github/workflows/web_deployment_health.yml
@@ -1,0 +1,42 @@
+name: Web deployment health
+
+on:
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: web-deployment-health-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      API_HEALTH_URL: https://wyckoff-api.yongkai-wang.workers.dev/api/health
+      CHAT_URL: https://wyckoff-analysis.pages.dev/chat
+    steps:
+      - name: Wait for production endpoints
+        shell: bash
+        run: |
+          for attempt in {1..8}; do
+            api_body="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "$API_HEALTH_URL" || true)"
+            chat_body="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "$CHAT_URL" || true)"
+            if jq --exit-status '.status == "ok"' <<<"$api_body" >/dev/null && grep --quiet '<div id="root"' <<<"$chat_body"; then
+              echo "Production Worker and Pages chat entry are healthy."
+              exit 0
+            fi
+            echo "Attempt $attempt/8: production deployment is not ready yet."
+            sleep 15
+          done
+          echo "Production endpoints did not pass health checks within the retry window." >&2
+          exit 1

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,8 @@ Worker 负责鉴权、输入校验、队列控制面和 HMAC 签名。Vercel Nod
 
 前端的 `web/apps/web/src/lib/api-url.ts` 统一生成 chat、portfolio 和 settings 的后端地址。本地开发默认连接 `http://127.0.0.1:8787`，生产默认连接 `https://wyckoff-api.yongkai-wang.workers.dev`；部署环境可用公开的构建变量 `VITE_API_URL` 覆盖地址。该变量只包含公开服务地址，不能放 Token。
 
+每次 `main` 上的 CI 成功后，`Web deployment health` 工作流会从 GitHub runner 轮询 Worker 的公开 `/api/health` 与 Pages 的 `/chat`，直到两者同时通过；也可在 Actions 页面手动运行。它只验证部署可达性，不会调用需要登录的聊天、持仓或沙箱端点，也不会创建沙箱。
+
 本地开发可复制 `web/apps/api/.dev.vars.example` 为 `.dev.vars`。首次部署异步 Agent 前，先在 `web/apps/api/` 创建两个队列，再部署 Worker：`pnpm exec wrangler queues create wyckoff-agent-runs`、`pnpm exec wrangler queues create wyckoff-agent-runs-dlq`、`pnpm run deploy`。部署时不要把密钥写入 `wrangler.toml`：在 Vercel 项目将 `SANDBOX_BRIDGE_SECRET` 写入 production 环境变量，并在 `web/apps/api/` 下分别执行 `pnpm exec wrangler secret put UPSTASH_REDIS_REST_URL`、`pnpm exec wrangler secret put UPSTASH_REDIS_REST_TOKEN` 和 `pnpm exec wrangler secret put SANDBOX_BRIDGE_SECRET`。Vercel bridge 在生产环境由平台 OIDC 自动获取短期 Sandbox 凭据，Cloudflare Worker 不再保留 Vercel Access Token。
 
 **零成本执行面（Hobby）**：系统控制面继续跑在 Cloudflare Workers/Pages + Upstash 免费额度；Vercel 只用于按需 microVM。Hobby 套餐每月包含 Sandbox 额度（约 5 小时 Active CPU、420 GB-hour 内存、5,000 次创建、20 GB 传输），超限后创建会被暂停而不是自动扣费。为压低用量，当前实现固定 `resources.vcpus=1`、`networkPolicy=deny-all`、`persistent=false`、60s 超时，并在结束后 `stop` + `delete`。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -687,6 +687,7 @@ TTL：SOS 2 天、Spring 3 天、LPS 3 天、EVR 2 天、Compression 3 天。
 | 工作流 | 时间（北京） | 说明 |
 |-------|-------------|------|
 | **CI** (`ci.yml`) | push/PR | 单次 coverage-instrumented pytest + Python compile + TypeScript check + Web/API tests + dry-run；同一次 Python 测试生成覆盖率 artifact，不重复执行全量套件 |
+| **Web 部署健康检查** (`web_deployment_health.yml`) | main CI 成功后 / 手动 | 从 GitHub runner 轮询 Worker `/api/health` 与 Pages `/chat`；不调用认证接口或创建沙箱 |
 | **盘前风控** (`premarket_risk.yml`) | 周一-周五 08:20 | Codex Automation 调用 `workflow_dispatch`；A50 + VIX 预警，Actions 可手动补跑 |
 | **港股漏斗筛选** (`wyckoff_funnel_hk.yml`) | 周一-周五 16:35 | `market_funnel_job.py --market hk` |
 | **A 股漏斗筛选 + AI 研报 + 决策** (`wyckoff_funnel.yml`) | 周日-周四 17:17 | `daily_job.py` Step2→3→4；周日正常为周一实盘准备候选，若次日非 A 股交易日才跳过，日频写入 `theme_radar_snapshot` |


### PR DESCRIPTION
## 目标
- 在 `main` 的 CI 成功后，从 GitHub runner 验证独立 Worker 的 `/api/health` 与 Pages 的 `/chat`。
- 支持手动触发；只读公开健康端点，不调用认证接口或创建沙箱。
- 同步更新部署验收说明。

## 验证
- `scripts/check_workflow_hygiene.py`
- YAML 解析与工作流触发/端点断言
- `ruff check .`、`ruff format --check .`、质量门
- 递归 TypeScript 严格检查
- Web 153 项测试、API 38 项测试（2 skipped）
- `pnpm build`（Worker dry-run + Web production build）

## 说明
本机网络无法访问任意 `*.workers.dev` 主机，因此不把本机 curl 结果作为生产故障结论；合并后的 GitHub runner 会提供独立网络路径的真实部署验证。