### PR TITLE
feat: push agent run status over Durable Object WebSocket with polling fallback

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ Worker 负责鉴权、输入校验、队列控制面和 HMAC 签名。Vercel Nod
 
 每个实际执行都会复用 API 的 `requestId` 并生成独立 `runId`；Worker 用两个 ID 调 bridge，bridge 在 Vercel Runtime Logs 中输出同一对 ID，因此两侧能按 ID 关联。Worker 日志事件为 `sandbox_run.queued|started|retrying|finished|failed|cancelled`，bridge 事件为 `sandbox_bridge.started|finished|rejected|failed`；只包含状态、尝试次数、耗时、退出码、脚本字节数和 CPU/网络用量，不记录 Python 源码、stdout/stderr、HMAC、Token 或原始用户 ID。实时排查可在 `web/apps/api/` 运行 `pnpm exec wrangler tail wyckoff-api --format pretty`，或在 `web/apps/sandbox-bridge/` 运行 `pnpm exec vercel logs https://wyckoff-agent-sandbox.vercel.app --json`；历史 Vercel 日志在项目 Deployment 的 Functions Logs 中查看。
 
-读盘室仅在沙箱显式开启且当前用户在有效白名单内时，才向模型注册 `run_python_research` 工具；非白名单用户在模型侧看不到该能力，不会出现“审批后才失败”的体验。工具仅在用户明确提出计算需求后使用，且 Vercel AI SDK 必须取得用户确认才会执行。确认后，聊天卡片以当前登录令牌轮询 Worker 的 `GET /api/agent-runs/:id`：它只读取该用户的记录，并在任务进入终态时把最终 stdout、stderr、退出码和用量回填到原工具调用。轮询覆盖当前浏览器保存的各个对话；终态先写入所属对话的本地存储，再在该对话仍处于前台时同步 live chat，避免切走对话时只更新内存态而丢掉结果。因此刷新或切走对话不会遗失未终态任务，终态会回写到其原来的对话。若记录已超过 Redis 保存期（轮询收到 404），前端把该任务落定为“结果已过期”的失败终态并停止轮询，而不是无限重试。用户可在 `queued` 时取消，完成后点“解读结果”才向模型发送基于该终态输出的后续请求；这避免把尚未完成的队列确认误当作研究结论。执行时再次校验当前用户的白名单，复用与 REST 端点完全相同的 Redis 记录、超时和删除流程；未开启沙箱或未在白名单中的用户不能经聊天路径绕过这道边界。
+读盘室仅在沙箱显式开启且当前用户在有效白名单内时，才向模型注册 `run_python_research` 工具；非白名单用户在模型侧看不到该能力，不会出现“审批后才失败”的体验。工具仅在用户明确提出计算需求后使用，且 Vercel AI SDK 必须取得用户确认才会执行。确认后，状态回传以推送为主、轮询兜底：前端在存在未终态任务时向 `GET /api/agent-runs/ws` 发起 WebSocket 连接（浏览器无法在升级请求上带 Authorization 头，登录令牌经 `Sec-WebSocket-Protocol` 子协议传递，Worker 验证令牌与白名单后才转交按用户命名的 `AgentRunNotifier` Durable Object），队列消费者在任务进入 `running` 或终态时把记录 POST 给该 DO 广播到用户所有打开的标签页。DO 使用 WebSocket Hibernation API，空闲连接不消耗免费套餐的 DO 时长；推送是尽力而为，投递失败不影响任务状态。推送通道在线时轮询间隔放宽到 15 秒，通道断开或不可用时回落到 2 秒轮询 `GET /api/agent-runs/:id`：它只读取该用户的记录，并在任务进入终态时把最终 stdout、stderr、退出码和用量回填到原工具调用。轮询覆盖当前浏览器保存的各个对话；终态先写入所属对话的本地存储，再在该对话仍处于前台时同步 live chat，避免切走对话时只更新内存态而丢掉结果。因此刷新或切走对话不会遗失未终态任务，终态会回写到其原来的对话。若记录已超过 Redis 保存期（轮询收到 404），前端把该任务落定为“结果已过期”的失败终态并停止轮询，而不是无限重试。用户可在 `queued` 时取消，完成后点“解读结果”才向模型发送基于该终态输出的后续请求；这避免把尚未完成的队列确认误当作研究结论。执行时再次校验当前用户的白名单，复用与 REST 端点完全相同的 Redis 记录、超时和删除流程；未开启沙箱或未在白名单中的用户不能经聊天路径绕过这道边界。
 
 | Worker 变量 | 默认值 | 作用 |
 |---|---:|---|
@@ -95,6 +95,7 @@ Worker 负责鉴权、输入校验、队列控制面和 HMAC 签名。Vercel Nod
 | `AGENT_RUN_DAILY_LIMIT_PER_USER` | `20` | 每个用户每天允许创建的沙箱任务数；REST 与聊天工具共用 |
 | `AGENT_RUN_MIN_INTERVAL_MS` | `10000` | 同一用户两次沙箱任务提交的最小间隔 |
 | `AGENT_RUN_QUEUE` | Cloudflare Queue binding | `wyckoff-agent-runs` 的生产者绑定；不是密钥，声明在 `wrangler.toml` |
+| `AGENT_RUN_NOTIFIER` | Durable Object binding | 按用户命名的 `AgentRunNotifier` 推送通道；SQLite-backed 类（免费套餐唯一可用形态），迁移声明在 `wrangler.toml` |
 | `SANDBOX_BRIDGE_URL` | 未设置 | Vercel Node bridge 的 HTTPS `/api/sandbox-run` 地址；可作为普通 Worker 变量 |
 | `SANDBOX_BRIDGE_SECRET` | Worker secret | 与 Vercel 项目环境变量同值的 HMAC 密钥；不进 git、不回传浏览器或沙箱 |
 

--- a/web/apps/api/src/app.ts
+++ b/web/apps/api/src/app.ts
@@ -23,6 +23,7 @@ export type Env = {
   AGENT_RUN_DAILY_LIMIT_PER_USER?: string
   AGENT_RUN_MIN_INTERVAL_MS?: string
   AGENT_RUN_QUEUE?: Queue<AgentRunMessage>
+  AGENT_RUN_NOTIFIER?: DurableObjectNamespace
   SANDBOX_BRIDGE_URL?: string
   SANDBOX_BRIDGE_SECRET?: string
 }

--- a/web/apps/api/src/durable/agent-run-notifier.test.ts
+++ b/web/apps/api/src/durable/agent-run-notifier.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AgentRunNotifier } from './agent-run-notifier'
+
+type FakeSocket = { send: (data: string) => void }
+
+function createNotifier(sockets: FakeSocket[] = []) {
+  const accepted: WebSocket[] = []
+  const ctx = {
+    acceptWebSocket: (socket: WebSocket) => accepted.push(socket),
+    getWebSockets: () => sockets,
+  } as unknown as DurableObjectState
+  return { notifier: new AgentRunNotifier(ctx), accepted }
+}
+
+describe('AgentRunNotifier', () => {
+  it('rejects a connect without a WebSocket upgrade', async () => {
+    const { notifier } = createNotifier()
+    const response = await notifier.fetch(new Request('https://agent-run-notifier/connect'))
+    expect(response.status).toBe(426)
+  })
+
+  it('accepts an upgrade through the hibernation API and echoes the subprotocol', async () => {
+    const { notifier, accepted } = createNotifier()
+    const response = await notifier.fetch(new Request('https://agent-run-notifier/connect', {
+      headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'bearer, jwt-token' },
+    }))
+    expect(response.status).toBe(101)
+    expect(response.headers.get('Sec-WebSocket-Protocol')).toBe('bearer')
+    expect(response.webSocket).toBeTruthy()
+    expect(accepted).toHaveLength(1)
+  })
+
+  it('broadcasts a notification to every open socket and skips broken ones', async () => {
+    const healthy = { send: vi.fn() }
+    const broken = { send: vi.fn(() => { throw new Error('socket closed') }) }
+    const { notifier } = createNotifier([broken, healthy])
+
+    const response = await notifier.fetch(new Request('https://agent-run-notifier/notify', {
+      method: 'POST',
+      body: '{"id":"run-1","status":"completed"}',
+    }))
+
+    expect(await response.json()).toEqual({ delivered: 1 })
+    expect(healthy.send).toHaveBeenCalledWith('{"id":"run-1","status":"completed"}')
+  })
+
+  it('returns 404 for unknown paths', async () => {
+    const { notifier } = createNotifier()
+    const response = await notifier.fetch(new Request('https://agent-run-notifier/other'))
+    expect(response.status).toBe(404)
+  })
+})

--- a/web/apps/api/src/durable/agent-run-notifier.ts
+++ b/web/apps/api/src/durable/agent-run-notifier.ts
@@ -1,0 +1,45 @@
+// Per-user push channel for agent run status. The Worker routes an authenticated WebSocket
+// upgrade to /connect, and the queue consumer POSTs status records to /notify, which are
+// broadcast to every socket the user has open (multiple tabs included).
+// Deliberately not extending DurableObject from cloudflare:workers: the base constructor
+// requires a real DurableObjectState, which blocks unit-testing with a fake context.
+export class AgentRunNotifier {
+  constructor(private readonly ctx: DurableObjectState) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+    if (url.pathname === '/connect') return this.upgrade(request)
+    if (url.pathname === '/notify' && request.method === 'POST') return this.notify(await request.text())
+    return new Response('Not Found', { status: 404 })
+  }
+
+  private upgrade(request: Request): Response {
+    if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket') {
+      return new Response('Expected a WebSocket upgrade', { status: 426 })
+    }
+    const pair = new WebSocketPair()
+    // Hibernation API: idle sockets are evicted from memory without dropping the connection,
+    // so an open tab does not consume Durable Object duration on the free plan.
+    this.ctx.acceptWebSocket(pair[1])
+    return new Response(null, { status: 101, webSocket: pair[0], headers: acceptedProtocol(request) })
+  }
+
+  private notify(payload: string): Response {
+    let delivered = 0
+    for (const socket of this.ctx.getWebSockets()) {
+      try {
+        socket.send(payload)
+        delivered += 1
+      } catch {
+        // Stale sockets are reclaimed by the runtime; the frontend keeps polling as fallback.
+      }
+    }
+    return Response.json({ delivered })
+  }
+}
+
+// Browsers abort the handshake unless the server echoes one of the requested subprotocols.
+function acceptedProtocol(request: Request): Record<string, string> {
+  const requested = request.headers.get('Sec-WebSocket-Protocol')?.split(',')[0]?.trim()
+  return requested ? { 'Sec-WebSocket-Protocol': requested } : {}
+}

--- a/web/apps/api/src/index.ts
+++ b/web/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import type { AgentRunMessage } from './services/agent-run'
 import type { Env } from './app'
 
 export type { Env } from './app'
+export { AgentRunNotifier } from './durable/agent-run-notifier'
 
 export const app = createApiApp()
 app.route('/api/chat', workerChatRoutes)

--- a/web/apps/api/src/middleware/auth.ts
+++ b/web/apps/api/src/middleware/auth.ts
@@ -14,6 +14,15 @@ export function createUserSupabase(env: Env, accessToken: string) {
   return createClient(url, key, { global: { headers: { Authorization: `Bearer ${accessToken}` } } })
 }
 
+export async function resolveUserId(env: Env, accessToken: string): Promise<string | null> {
+  const url = env.SUPABASE_URL || env.VITE_SUPABASE_URL
+  const anonKey = env.SUPABASE_ANON_KEY || env.VITE_SUPABASE_ANON_KEY
+  if (!url || !anonKey) throw new Error('Supabase env is missing')
+  const supabase = createClient(url, anonKey)
+  const { data, error } = await supabase.auth.getUser(accessToken)
+  return error || !data.user ? null : data.user.id
+}
+
 export const authMiddleware = createMiddleware<{
   Bindings: Env
   Variables: { auth: AuthContext }
@@ -24,16 +33,14 @@ export const authMiddleware = createMiddleware<{
   }
 
   const token = authHeader.slice(7)
-  const url = c.env.SUPABASE_URL || c.env.VITE_SUPABASE_URL
-  const anonKey = c.env.SUPABASE_ANON_KEY || c.env.VITE_SUPABASE_ANON_KEY
-  if (!url || !anonKey) return c.json({ error: 'Supabase env is missing' }, 500)
-  const supabase = createClient(url, anonKey)
-
-  const { data: { user }, error } = await supabase.auth.getUser(token)
-  if (error || !user) {
-    return c.json({ error: 'Invalid token' }, 401)
+  let userId: string | null
+  try {
+    userId = await resolveUserId(c.env, token)
+  } catch {
+    return c.json({ error: 'Supabase env is missing' }, 500)
   }
+  if (!userId) return c.json({ error: 'Invalid token' }, 401)
 
-  c.set('auth', { userId: user.id, accessToken: token })
+  c.set('auth', { userId, accessToken: token })
   await next()
 })

--- a/web/apps/api/src/routes/agent-runs.test.ts
+++ b/web/apps/api/src/routes/agent-runs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseAgentRunInput } from './agent-runs'
+import { agentRunRoutes, parseAgentRunInput, websocketBearerToken } from './agent-runs'
 
 describe('Agent run input', () => {
   it('accepts the single research task supported by the MVP', () => {
@@ -11,5 +11,33 @@ describe('Agent run input', () => {
   it('rejects arbitrary task kinds and oversized scripts', () => {
     expect(parseAgentRunInput({ kind: 'shell', script: 'ls' })).toHaveProperty('error')
     expect(parseAgentRunInput({ kind: 'python_research', script: 'x'.repeat(12_001) })).toHaveProperty('error')
+  })
+})
+
+describe('Agent run websocket endpoint', () => {
+  it('extracts the access token from the bearer subprotocol', () => {
+    expect(websocketBearerToken('bearer, jwt-token')).toBe('jwt-token')
+    expect(websocketBearerToken('bearer')).toBeNull()
+    expect(websocketBearerToken('basic, jwt-token')).toBeNull()
+    expect(websocketBearerToken(undefined)).toBeNull()
+  })
+
+  it('rejects plain HTTP requests before authenticating', async () => {
+    const response = await agentRunRoutes.request('/ws', {}, {})
+    expect(response.status).toBe(426)
+  })
+
+  it('reports unavailability when the notifier binding is missing', async () => {
+    const response = await agentRunRoutes.request('/ws', { headers: { Upgrade: 'websocket' } }, {})
+    expect(response.status).toBe(503)
+  })
+
+  it('rejects an upgrade without a bearer token before touching the notifier', async () => {
+    const response = await agentRunRoutes.request(
+      '/ws',
+      { headers: { Upgrade: 'websocket' } },
+      { AGENT_RUN_NOTIFIER: {} as DurableObjectNamespace },
+    )
+    expect(response.status).toBe(401)
   })
 })

--- a/web/apps/api/src/routes/agent-runs.ts
+++ b/web/apps/api/src/routes/agent-runs.ts
@@ -1,19 +1,45 @@
 import { Hono } from 'hono'
 import type { Env } from '../app'
-import { authMiddleware, type AuthContext } from '../middleware/auth'
-import { whitelistMiddleware } from '../middleware/whitelist'
+import { authMiddleware, createUserSupabase, resolveUserId, type AuthContext } from '../middleware/auth'
+import { isActiveWhitelistUser, whitelistMiddleware } from '../middleware/whitelist'
 import {
   AGENT_RUN_INPUT_SCHEMA,
   AgentRunServiceError,
   type AgentRunInput,
   enqueuePythonResearch,
 } from '../services/agent-run'
+import { notifyAgentRun } from '../services/agent-run-notify'
 import { createAgentRunStore } from '../services/agent-run-store'
 import { logSandboxRun, safeRequestId } from '../services/sandbox-observability'
 
 type AgentRunBindings = { Bindings: Env; Variables: { auth: AuthContext } }
 
 export const agentRunRoutes = new Hono<AgentRunBindings>()
+
+// Browsers cannot attach an Authorization header to a WebSocket upgrade, so the access token
+// travels as the second Sec-WebSocket-Protocol entry ("bearer, <jwt>"). This route therefore
+// authenticates by hand and must stay registered before the shared middleware below.
+agentRunRoutes.get('/ws', async (c) => {
+  if (c.req.header('Upgrade')?.toLowerCase() !== 'websocket') {
+    return c.json({ error: 'Expected a WebSocket upgrade' }, 426)
+  }
+  const namespace = c.env.AGENT_RUN_NOTIFIER
+  if (!namespace) return c.json({ error: 'Agent run push is unavailable' }, 503)
+  const token = websocketBearerToken(c.req.header('Sec-WebSocket-Protocol'))
+  if (!token) return c.json({ error: 'Unauthorized' }, 401)
+  const userId = await resolveUserId(c.env, token)
+  if (!userId) return c.json({ error: 'Invalid token' }, 401)
+  if (!(await isActiveWhitelistUser(createUserSupabase(c.env, token), userId))) {
+    return c.json({ error: 'Whitelist required' }, 403)
+  }
+  const stub = namespace.get(namespace.idFromName(userId))
+  return stub.fetch(new Request('https://agent-run-notifier/connect', c.req.raw))
+})
+
+export function websocketBearerToken(header: string | undefined): string | null {
+  const [scheme, token] = (header || '').split(',').map((value) => value.trim())
+  return scheme === 'bearer' && token ? token : null
+}
 
 agentRunRoutes.use('*', authMiddleware)
 agentRunRoutes.use('*', whitelistMiddleware)
@@ -61,6 +87,7 @@ agentRunRoutes.post('/:id/cancel', async (c) => {
   if (existing.status !== 'queued') return c.json({ error: 'Only queued agent runs can be cancelled' }, 409)
   const record = await store.cancel(userId, runId)
   if (!record) return c.json({ error: 'Agent run is no longer queued' }, 409)
+  await notifyAgentRun(c.env, userId, record)
   logSandboxRun('cancelled', {
     requestId: safeRequestId(c.get('requestId')),
     runId,

--- a/web/apps/api/src/services/agent-run-notify.test.ts
+++ b/web/apps/api/src/services/agent-run-notify.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Env } from '../app'
+import { notifyAgentRun } from './agent-run-notify'
+import type { AgentRunRecord } from './agent-run-store'
+
+const record: AgentRunRecord = {
+  id: 'run-1',
+  kind: 'python_research',
+  status: 'completed',
+  attempts: 1,
+  createdAt: '2026-07-27T00:00:00.000Z',
+}
+
+function fakeNamespace(fetchImpl: () => Promise<Response>) {
+  const idFromName = vi.fn((name: string) => name)
+  const stubFetch = vi.fn(fetchImpl)
+  const namespace = { idFromName, get: () => ({ fetch: stubFetch }) } as unknown as DurableObjectNamespace
+  return { namespace, idFromName, stubFetch }
+}
+
+describe('notifyAgentRun', () => {
+  it('does nothing without the notifier binding', async () => {
+    await expect(notifyAgentRun({} as Env, 'user-1', record)).resolves.toBeUndefined()
+  })
+
+  it('posts the record to the per-user notifier object', async () => {
+    const { namespace, idFromName, stubFetch } = fakeNamespace(async () => Response.json({ delivered: 1 }))
+
+    await notifyAgentRun({ AGENT_RUN_NOTIFIER: namespace }, 'user-1', record)
+
+    expect(idFromName).toHaveBeenCalledWith('user-1')
+    expect(stubFetch).toHaveBeenCalledWith('https://agent-run-notifier/notify', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify(record),
+    }))
+  })
+
+  it('swallows delivery failures so run state is never affected', async () => {
+    const { namespace } = fakeNamespace(async () => { throw new Error('durable object unavailable') })
+    await expect(notifyAgentRun({ AGENT_RUN_NOTIFIER: namespace }, 'user-1', record)).resolves.toBeUndefined()
+  })
+})

--- a/web/apps/api/src/services/agent-run-notify.ts
+++ b/web/apps/api/src/services/agent-run-notify.ts
@@ -1,0 +1,21 @@
+import type { Env } from '../app'
+import type { AgentRunRecord } from './agent-run-store'
+
+export type AgentRunNotify = (env: Env, userId: string, record: AgentRunRecord) => Promise<void>
+
+// Best-effort push: a failed delivery must never affect run state, because the
+// frontend still recovers through its polling fallback.
+export const notifyAgentRun: AgentRunNotify = async (env, userId, record) => {
+  const namespace = env.AGENT_RUN_NOTIFIER
+  if (!namespace) return
+  try {
+    const stub = namespace.get(namespace.idFromName(userId))
+    await stub.fetch('https://agent-run-notifier/notify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record),
+    })
+  } catch {
+    // Swallowed by design; see above.
+  }
+}

--- a/web/apps/api/src/services/agent-run.test.ts
+++ b/web/apps/api/src/services/agent-run.test.ts
@@ -199,6 +199,19 @@ describe('Agent run service', () => {
     }))
   })
 
+  it('pushes running and terminal status updates while consuming a message', async () => {
+    const notify = vi.fn(async () => undefined)
+
+    await expect(consumePythonResearch(
+      { AGENT_SANDBOX_ENABLED: 'true' },
+      runMessage(),
+      { createStore: () => testStore(), executeSandbox: async () => successfulResult, notify },
+    )).resolves.toBe('ack')
+
+    expect(notify).toHaveBeenNthCalledWith(1, expect.anything(), 'user-1', expect.objectContaining({ status: 'running' }))
+    expect(notify).toHaveBeenNthCalledWith(2, expect.anything(), 'user-1', expect.objectContaining({ status: 'completed' }))
+  })
+
   it('marks a dead-lettered run as a visible terminal failure', async () => {
     const fail = vi.fn(async (_userId, record: AgentRunRecord, error: string) => ({
       ...record,
@@ -206,11 +219,13 @@ describe('Agent run service', () => {
       error,
     }))
     const log = vi.fn()
+    const notify = vi.fn(async () => undefined)
     const store = testStore({ get: vi.fn(async () => queuedRecord), fail })
 
-    await failDeadLetterAgentRun({} as Env, runMessage(), { createStore: () => store, log })
+    await failDeadLetterAgentRun({} as Env, runMessage(), { createStore: () => store, log, notify })
 
     expect(fail).toHaveBeenCalledWith('user-1', queuedRecord, 'Agent run exhausted retries')
+    expect(notify).toHaveBeenCalledWith(expect.anything(), 'user-1', expect.objectContaining({ status: 'failed' }))
     expect(log).toHaveBeenCalledWith('failed', expect.objectContaining({
       errorCode: 'retry_exhausted',
       status: 'failed',

--- a/web/apps/api/src/services/agent-run.ts
+++ b/web/apps/api/src/services/agent-run.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import type { Env } from '../app'
 import { checkAgentRunQuota, type RateLimitResult } from '../middleware/rate-limit'
+import { notifyAgentRun, type AgentRunNotify } from './agent-run-notify'
 import { createAgentRunStore, type AgentRunRecord, type AgentRunStore } from './agent-run-store'
 import { executePythonSandbox, type PythonSandboxResult } from './python-sandbox'
 import {
@@ -39,6 +40,7 @@ export type AgentRunDependencies = {
   queue?: AgentRunQueue
   requestId?: string
   checkQuota?: (env: Env, userId: string) => Promise<RateLimitResult | null>
+  notify?: AgentRunNotify
 }
 
 export class AgentRunServiceError extends Error {
@@ -92,6 +94,7 @@ export async function consumePythonResearch(
 ): Promise<AgentRunOutcome> {
   const store = storeFor(env, dependencies)
   const log = dependencies.log || logSandboxRun
+  const notify = dependencies.notify || notifyAgentRun
   const context = { requestId: safeRequestId(message.requestId), runId: message.runId }
   if (!(await store.acquireLease(message.userId, message.runId))) return 'retry'
 
@@ -99,10 +102,11 @@ export async function consumePythonResearch(
     const record = await store.claim(message.userId, message.runId)
     if (!record) return 'ack'
     if (env.AGENT_SANDBOX_ENABLED !== 'true') {
-      await failConfiguration(store, message.userId, record, context, log, 'Agent sandbox is disabled', Date.now(), 'sandbox_disabled')
+      const failed = await failConfiguration(store, message.userId, record, context, log, 'Agent sandbox is disabled', Date.now(), 'sandbox_disabled')
+      await notify(env, message.userId, failed)
       return 'ack'
     }
-    return await executeQueuedRun(store, message, record, env, context, log, dependencies.executeSandbox || executePythonSandbox)
+    return await executeQueuedRun(store, message, record, env, context, log, dependencies.executeSandbox || executePythonSandbox, notify)
   } finally {
     await store.releaseLease(message.userId, message.runId)
   }
@@ -118,7 +122,9 @@ export async function failDeadLetterAgentRun(
   if (!record || isTerminal(record)) return
   const context = { requestId: safeRequestId(message.requestId), runId: message.runId }
   const failed = await store.fail(message.userId, record, 'Agent run exhausted retries')
-  if (failed) (dependencies.log || logSandboxRun)('failed', {
+  if (!failed) return
+  await (dependencies.notify || notifyAgentRun)(env, message.userId, failed)
+  ;(dependencies.log || logSandboxRun)('failed', {
     ...context,
     attempts: failed.attempts,
     errorCode: 'retry_exhausted',
@@ -157,13 +163,16 @@ async function executeQueuedRun(
   context: SandboxExecutionContext,
   log: SandboxRunLogger,
   executeSandbox: SandboxExecutor,
+  notify: AgentRunNotify,
 ): Promise<AgentRunOutcome> {
   const startedAt = Date.now()
   log('started', { ...context, attempts: record.attempts })
+  await notify(env, message.userId, record)
   try {
     const result = await executeSandbox(env, message.script, context)
     const completed = completeRun(record, result)
     await store.save(message.userId, completed)
+    await notify(env, message.userId, completed)
     log('finished', {
       ...context,
       durationMs: Date.now() - startedAt,
@@ -175,7 +184,8 @@ async function executeQueuedRun(
     return 'ack'
   } catch (error) {
     if (isConfigurationError(error)) {
-      await failConfiguration(store, message.userId, record, context, log, 'Sandbox configuration is incomplete', startedAt)
+      const failed = await failConfiguration(store, message.userId, record, context, log, 'Sandbox configuration is incomplete', startedAt)
+      await notify(env, message.userId, failed)
       return 'ack'
     }
     const requeued = await store.requeue(message.userId, record, 'Sandbox execution failed')
@@ -200,7 +210,7 @@ async function failConfiguration(
   error: string,
   startedAt = Date.now(),
   errorCode: 'bridge_configuration_incomplete' | 'sandbox_disabled' = 'bridge_configuration_incomplete',
-): Promise<void> {
+): Promise<AgentRunRecord> {
   const failed = await store.fail(userId, record, error)
   if (!failed) throw new Error('Agent run state transition failed')
   log('failed', {
@@ -210,6 +220,7 @@ async function failConfiguration(
     errorCode,
     status: 'failed',
   })
+  return failed
 }
 
 function storeFor(env: Env, dependencies: AgentRunDependencies): AgentRunStore {

--- a/web/apps/api/wrangler.toml
+++ b/web/apps/api/wrangler.toml
@@ -14,6 +14,15 @@ AGENT_RUN_DAILY_LIMIT_PER_USER = "20"
 AGENT_RUN_MIN_INTERVAL_MS = "10000"
 SANDBOX_BRIDGE_URL = "https://wyckoff-agent-sandbox.vercel.app/api/sandbox-run"
 
+[[durable_objects.bindings]]
+name = "AGENT_RUN_NOTIFIER"
+class_name = "AgentRunNotifier"
+
+# SQLite-backed classes are the only Durable Objects available on the free plan.
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["AgentRunNotifier"]
+
 [[queues.producers]]
 queue = "wyckoff-agent-runs"
 binding = "AGENT_RUN_QUEUE"

--- a/web/apps/web/src/features/reading-room/agent-run-socket.test.ts
+++ b/web/apps/web/src/features/reading-room/agent-run-socket.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { agentRunSocketUrl, parseAgentRunPush } from './agent-run-socket'
+
+describe('agent run push channel', () => {
+  it('derives a ws(s) URL from the API base', () => {
+    expect(agentRunSocketUrl()).toMatch(/^wss?:\/\/.+\/api\/agent-runs\/ws$/)
+  })
+
+  it('parses a pushed record and rejects malformed payloads', () => {
+    const record = {
+      id: 'run-1',
+      kind: 'python_research',
+      status: 'completed',
+      attempts: 1,
+      createdAt: '2026-07-27T00:00:00.000Z',
+    }
+    expect(parseAgentRunPush(JSON.stringify(record))).toMatchObject({ id: 'run-1', status: 'completed' })
+    expect(parseAgentRunPush('not json')).toBeNull()
+    expect(parseAgentRunPush(JSON.stringify({ hello: 'world' }))).toBeNull()
+    expect(parseAgentRunPush(new ArrayBuffer(4))).toBeNull()
+  })
+})

--- a/web/apps/web/src/features/reading-room/agent-run-socket.ts
+++ b/web/apps/web/src/features/reading-room/agent-run-socket.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react'
+import { apiUrl } from '@/lib/api-url'
+import { parseAgentRunRecord, type AgentRunRecord } from './agent-runs'
+
+export function agentRunSocketUrl(): string {
+  return apiUrl('/api/agent-runs/ws').replace(/^http/, 'ws')
+}
+
+export function parseAgentRunPush(data: unknown): AgentRunRecord | null {
+  if (typeof data !== 'string') return null
+  try {
+    return parseAgentRunRecord(JSON.parse(data))
+  } catch {
+    return null
+  }
+}
+
+// Opens a push channel for agent run status while runs are active. Returns whether the
+// socket is currently connected so the caller can relax its polling fallback. A dropped
+// socket is not re-dialed: polling covers the gap until the next active period.
+export function useAgentRunSocket(
+  token: string | undefined,
+  active: boolean,
+  onRecord: (record: AgentRunRecord) => void,
+): boolean {
+  const [connected, setConnected] = useState(false)
+  const onRecordRef = useRef(onRecord)
+  useEffect(() => { onRecordRef.current = onRecord }, [onRecord])
+
+  useEffect(() => {
+    if (!token || !active) return
+    let socket: WebSocket
+    try {
+      // The browser WebSocket API cannot send Authorization headers, so the token rides
+      // along as a subprotocol; the Worker validates it before upgrading.
+      socket = new WebSocket(agentRunSocketUrl(), ['bearer', token])
+    } catch {
+      return
+    }
+    socket.onopen = () => setConnected(true)
+    socket.onmessage = (event) => {
+      const record = parseAgentRunPush(event.data)
+      if (record) onRecordRef.current(record)
+    }
+    socket.onclose = () => setConnected(false)
+    socket.onerror = () => setConnected(false)
+    return () => {
+      setConnected(false)
+      socket.onopen = null
+      socket.onmessage = null
+      socket.onclose = null
+      socket.onerror = null
+      socket.close()
+    }
+  }, [active, token])
+
+  return connected
+}

--- a/web/apps/web/src/features/reading-room/chat-state.ts
+++ b/web/apps/web/src/features/reading-room/chat-state.ts
@@ -17,6 +17,7 @@ import {
 import { useChat } from '@ai-sdk/react'
 import { apiUrl } from '@/lib/api-url'
 import type { TranslationKey } from '@/lib/preferences'
+import { useAgentRunSocket } from './agent-run-socket'
 import {
   cancelAgentRun,
   expiredAgentRun,
@@ -221,6 +222,11 @@ export function useAgentRunPolling(
     setRecords((current) => mergeAgentRunRecords(current, tools.map((tool) => tool.record)))
   }, [tools])
 
+  const applyPushedRecord = useCallback((record: AgentRunRecord) => {
+    setRecords((current) => mergeAgentRunRecords(current, [record]))
+  }, [])
+  const pushConnected = useAgentRunSocket(token, activeTools.length > 0, applyPushedRecord)
+
   useEffect(() => {
     if (!token || activeTools.length === 0) return
     let cancelled = false
@@ -239,9 +245,10 @@ export function useAgentRunPolling(
       if (failure?.status === 'rejected') setLocalError(failure.reason instanceof Error ? failure.reason.message : '隔离任务状态读取失败')
     }
     void poll()
-    const interval = window.setInterval(() => { void poll() }, 2_000)
+    // With a live push channel, polling is only a safety net against missed messages.
+    const interval = window.setInterval(() => { void poll() }, pushConnected ? 15_000 : 2_000)
     return () => { cancelled = true; window.clearInterval(interval) }
-  }, [activeTools, setLocalError, token])
+  }, [activeTools, pushConnected, setLocalError, token])
 
   useEffect(() => {
     for (const tool of tools) {


### PR DESCRIPTION
## Summary
- 新增按用户命名的 `AgentRunNotifier` Durable Object（SQLite-backed，免费套餐可用；WebSocket Hibernation API，空闲连接不计 DO 时长），队列消费者在任务进入 `running`/终态、取消端点在取消成功后把记录 POST 给它广播到用户所有标签页
- Worker 新增 `GET /api/agent-runs/ws`：浏览器无法在升级请求带 Authorization 头，登录令牌经 `Sec-WebSocket-Protocol` 子协议传递，验证 Supabase 令牌与白名单后才转交 DO；Pages 兼容 app 不挂载该路由
- 前端在存在未终态沙箱任务时订阅推送，推送在线时轮询从 2 秒放宽到 15 秒兜底，断开自动回落 2 秒轮询；推送尽力而为，投递失败不影响任务状态
- 同步 `docs/ARCHITECTURE.md`（推送链路描述 + `AGENT_RUN_NOTIFIER` 绑定表项）

## Test plan
- [x] `web/apps/api`：`tsc --noEmit` + `vitest run`（13 文件 56 通过，含 DO 广播/升级、ws 路由鉴权、消费者通知、notify 容错新用例）
- [x] `web/apps/web`：`tsc --noEmit` + `vitest run`（27 文件 158 通过，含推送解析/URL 推导新用例）
- [x] `wrangler deploy --dry-run` 确认 DO 绑定与迁移配置有效
- [x] ruff + quality gate 通过

Made with [Cursor](https://cursor.com)