### PR TITLE
perf: 流式输出轻渲染，避免每 tick 全量 Markdown

### DIFF
--- a/cli/tui.py
+++ b/cli/tui.py
@@ -192,6 +192,21 @@ def _refresh_log_layout(log_widget) -> None:
         log_widget.refresh()
 
 
+_MD_RENDER_HINT_RE = re.compile(
+    r"(?m)"
+    r"(^\s{0,3}#{1,6}\s)"  # headings
+    r"|(^\s*([-*+]|\d+\.)\s)"  # lists
+    r"|(\*\*[^*]|\[[^\]]+\]\([^)]+\))"  # bold / links
+    r"|(`{1,3})"  # code
+    r"|(^\|.+\|)"  # tables
+)
+
+
+def _needs_markdown_render(text: str) -> bool:
+    """Plain streamed strips are enough when Rich Markdown would not change layout."""
+    return bool(_MD_RENDER_HINT_RE.search(text))
+
+
 def _replace_streamed_response(log_widget, strip_count: int, final_text: str) -> int:
     _get_agent_logger().info("TUI_STREAM_REPLACE: strip_count=%d text_len=%d", strip_count, len(final_text))
     _pop_lines(log_widget, strip_count)
@@ -226,11 +241,14 @@ def _display_final_response(
     if not final_text:
         return False
     if streaming_started:
+        # Keep plain streamed lines when Markdown would not change visual structure.
+        if not _needs_markdown_render(final_text):
+            return True
         strip_count = stream_separator_strips + stream_text_strips
         call_from_thread(_replace_streamed_response, log_widget, strip_count, final_text)
     else:
         write(Text.from_markup("  [dim]───[/dim]"))
-        write(Markdown(final_text))
+        write(Markdown(final_text) if _needs_markdown_render(final_text) else Text(final_text))
     return True
 
 

--- a/tests/cli/test_tui_rendering.py
+++ b/tests/cli/test_tui_rendering.py
@@ -22,6 +22,7 @@ from cli.tui import (
     _display_workflow_step_event,
     _is_system_notification_message,
     _make_sub_agent_progress_handler,
+    _needs_markdown_render,
     _pending_user_question_answer,
     _pending_user_question_lines,
     _pending_workflow_reply_intent,
@@ -344,6 +345,29 @@ def test_display_final_response_replaces_streamed_raw_text():
     assert writes == []
     assert log.lines[0] == "kept"
     assert isinstance(log.lines[1], Markdown)
+
+
+def test_display_final_response_keeps_plain_stream_without_markdown():
+    assert _needs_markdown_render("普通结论，无格式") is False
+    assert _needs_markdown_render("## 标题\n\n- 条目") is True
+
+    log = _FakeLog()
+    log.lines.extend(["  ---", "plain answer"])
+    writes = []
+
+    displayed = _display_final_response(
+        log,
+        "plain answer",
+        streaming_started=True,
+        stream_separator_strips=1,
+        stream_text_strips=1,
+        write=writes.append,
+        call_from_thread=lambda func, *args: func(*args),
+    )
+
+    assert displayed is True
+    assert writes == []
+    assert log.lines == ["kept", "  ---", "plain answer"]
 
 
 def test_display_workflow_plan_event_keeps_pending_plan_compact():

--- a/web/apps/web/scripts/bench-stream-render.mjs
+++ b/web/apps/web/scripts/bench-stream-render.mjs
@@ -1,0 +1,187 @@
+/**
+ * Stream-render benchmark: old full-MD-every-flush vs new plain-during-stream.
+ *
+ * Run from web/apps/web:
+ *   node scripts/bench-stream-render.mjs
+ */
+import { createElement } from 'react'
+import { renderToString } from 'react-dom/server'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+const THROTTLE_MS = 120
+const OLD_THROTTLE_MS = 50
+const CHUNK_CHARS = 24
+const TOKEN_ARRIVAL_MS = 8 // ~125 tokens/s character-ish stream
+
+function buildReport(targetChars = 12_000) {
+  const sections = []
+  let i = 0
+  while (sections.join('\n').length < targetChars) {
+    i += 1
+    sections.push(`## Phase 观察 ${i}
+
+本段评估 **spring** / **LPS** 与 \`SOS\` 结构。候选代码 \`${600000 + i}\`。
+
+| 指标 | 数值 | 解读 |
+| --- | --- | --- |
+| 相对量能 | ${(1.1 + (i % 7) * 0.15).toFixed(2)}x | ${i % 2 ? '放量不跌' : '缩量回踩'} |
+| 波动压缩 | ${(8 + (i % 5)).toFixed(1)}% | compression |
+
+- 关键点: 关注 ${i} 日均线附近
+- 风险: 跌破区间下沿则失效
+- 结论: ${i % 3 === 0 ? '起跳板待确认' : '继续观察资金行为'}
+
+\`\`\`text
+code=${600000 + i} phase=C note=benchmark-fixture-${i}
+\`\`\`
+`)
+  }
+  return sections.join('\n')
+}
+
+function chunkText(text, size) {
+  const out = []
+  for (let i = 0; i < text.length; i += size) out.push(text.slice(i, i + size))
+  return out
+}
+
+function renderMarkdown(content) {
+  return renderToString(
+    createElement(ReactMarkdown, { remarkPlugins: [remarkGfm] }, content),
+  )
+}
+
+function renderPlain(content) {
+  return renderToString(
+    createElement(
+      'div',
+      { 'data-stream-render': 'plain' },
+      createElement('div', { className: 'whitespace-pre-wrap break-words' }, content),
+    ),
+  )
+}
+
+function simulateFlushes(chunks, throttleMs, arrivalMs) {
+  /** @type {number[]} */
+  const flushAt = []
+  let buf = ''
+  let lastFlush = -throttleMs
+  let t = 0
+  for (const chunk of chunks) {
+    t += arrivalMs
+    buf += chunk
+    if (t - lastFlush >= throttleMs) {
+      flushAt.push(buf.length)
+      lastFlush = t
+    }
+  }
+  if (!flushAt.length || flushAt[flushAt.length - 1] !== buf.length) flushAt.push(buf.length)
+  return { fullText: buf, flushLengths: flushAt, streamMs: t }
+}
+
+function benchPath(name, fullText, flushLengths, mode) {
+  const samples = []
+  let htmlBytes = 0
+  let finalMdMs = 0
+  const t0 = performance.now()
+  for (const len of flushLengths) {
+    const content = fullText.slice(0, len)
+    const s0 = performance.now()
+    const html = mode === 'markdown' ? renderMarkdown(content) : renderPlain(content)
+    samples.push(performance.now() - s0)
+    htmlBytes = html.length
+  }
+  if (mode === 'plain-then-md') {
+    const s0 = performance.now()
+    htmlBytes = renderMarkdown(fullText).length
+    finalMdMs = performance.now() - s0
+    samples.push(finalMdMs)
+  }
+  const totalMs = performance.now() - t0
+  const sorted = [...samples].sort((a, b) => a - b)
+  const sum = sorted.reduce((a, b) => a + b, 0)
+  const p95 = sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))]
+  return {
+    name,
+    renders: samples.length,
+    totalMs,
+    meanMs: sum / samples.length,
+    maxMs: sorted[sorted.length - 1],
+    p95Ms: p95,
+    htmlBytes,
+    finalMdMs,
+  }
+}
+
+function pct(n) {
+  return `${(n * 100).toFixed(1)}%`
+}
+
+function fmt(n, digits = 2) {
+  return n.toFixed(digits)
+}
+
+function printRow(row) {
+  console.log(
+    [
+      row.name.padEnd(28),
+      String(row.renders).padStart(7),
+      fmt(row.totalMs).padStart(10),
+      fmt(row.meanMs).padStart(9),
+      fmt(row.p95Ms).padStart(8),
+      fmt(row.maxMs).padStart(8),
+      String(row.htmlBytes).padStart(10),
+    ].join('  '),
+  )
+}
+
+function main() {
+  const report = buildReport(12_000)
+  const chunks = chunkText(report, CHUNK_CHARS)
+  const current = simulateFlushes(chunks, THROTTLE_MS, TOKEN_ARRIVAL_MS)
+  const oldThrottle = simulateFlushes(chunks, OLD_THROTTLE_MS, TOKEN_ARRIVAL_MS)
+
+  // Warmup (JIT / module caches)
+  renderMarkdown(report.slice(0, 800))
+  renderPlain(report.slice(0, 800))
+
+  console.log('=== Stream render bench (react-markdown SSR proxy for UI cost) ===')
+  console.log(`chars=${report.length} chunks=${chunks.length} chunkSize=${CHUNK_CHARS}`)
+  console.log(`tokenArrival=${TOKEN_ARRIVAL_MS}ms  streamWall≈${current.streamMs}ms`)
+  console.log(`flushes@${OLD_THROTTLE_MS}ms=${oldThrottle.flushLengths.length}  flushes@${THROTTLE_MS}ms=${current.flushLengths.length}`)
+  console.log('')
+  console.log(
+    [
+      'path'.padEnd(28),
+      'renders'.padStart(7),
+      'total_ms'.padStart(10),
+      'mean_ms'.padStart(9),
+      'p95_ms'.padStart(8),
+      'max_ms'.padStart(8),
+      'html_len'.padStart(10),
+    ].join('  '),
+  )
+  console.log('-'.repeat(90))
+
+  const old50 = benchPath(`old: MD every flush@${OLD_THROTTLE_MS}`, report, oldThrottle.flushLengths, 'markdown')
+  const old120 = benchPath(`old: MD every flush@${THROTTLE_MS}`, report, current.flushLengths, 'markdown')
+  const neu = benchPath(`new: plain@${THROTTLE_MS}+final MD`, report, current.flushLengths, 'plain-then-md')
+  const plainOnly = benchPath(`ref: plain every flush@${THROTTLE_MS}`, report, current.flushLengths, 'plain')
+
+  for (const row of [old50, old120, neu, plainOnly]) printRow(row)
+
+  console.log('')
+  console.log('=== Deltas (vs old MD@50ms) ===')
+  console.log(`new total_ms:     ${fmt(neu.totalMs)}  (${pct(1 - neu.totalMs / old50.totalMs)} faster than old@50)`)
+  console.log(`new vs old@120:   ${pct(1 - neu.totalMs / old120.totalMs)} faster`)
+  console.log(`MD parse count:   ${old50.renders} → 1 final (during stream: 0)`)
+  console.log(`UI flush count:   ${old50.renders} → ${current.flushLengths.length} plain + 1 MD`)
+  console.log(`old@50 max paint: ${fmt(old50.maxMs)}ms`)
+  console.log(`plain stream max: ${fmt(plainOnly.maxMs)}ms`)
+  console.log(`final MD only:    ${fmt(neu.finalMdMs)}ms`)
+  console.log('')
+  console.log('Note: Node SSR approximates React parse/render cost; browser paint/layout not included.')
+}
+
+main()

--- a/web/apps/web/src/components/markdown.tsx
+++ b/web/apps/web/src/components/markdown.tsx
@@ -110,12 +110,28 @@ const MD_COMPONENTS: Components = {
 export const MarkdownContent = memo(function MarkdownContent({
   content,
   className = '',
+  streaming = false,
 }: {
   content: string
   className?: string
+  /** While true, skip remark/GFM and append plain text only (cheap stream path). */
+  streaming?: boolean
 }) {
+  if (streaming) {
+    return (
+      <div className={className} data-stream-render="plain">
+        <div className="whitespace-pre-wrap break-words">
+          {content}
+          <span
+            className="ml-0.5 inline-block h-[1.05em] w-1.5 translate-y-[0.12em] animate-pulse bg-foreground/65 align-text-bottom"
+            aria-hidden
+          />
+        </div>
+      </div>
+    )
+  }
   return (
-    <div className={className}>
+    <div className={className} data-stream-render="markdown">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>{content}</ReactMarkdown>
     </div>
   )

--- a/web/apps/web/src/features/reading-room/chat-state.ts
+++ b/web/apps/web/src/features/reading-room/chat-state.ts
@@ -188,7 +188,7 @@ export function useReadingRoomChat(
   const transport = useMemo(() => buildChatTransport(token, watchlistRef, marketWatchRef), [token])
   return useChat({
     transport,
-    experimental_throttle: 50,
+    experimental_throttle: 120,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onData: (part) => {
       if (part.type === 'data-run-event') onRunEvent?.(part.data as ChatRunEvent)

--- a/web/apps/web/src/features/reading-room/tool-rendering.tsx
+++ b/web/apps/web/src/features/reading-room/tool-rendering.tsx
@@ -88,16 +88,29 @@ function AssistantParts({
   onInterpretAgentRun: (runId: string) => void
 }) {
   const items = buildAssistantRenderItems(message.parts as MessagePart[])
+  const lastTextKey = lastAssistantTextKey(items)
   return (
     <>
       {items.map((item) => {
-        if (item.type === 'text') return <MarkdownContent key={item.key} content={item.content} />
+        if (item.type === 'text') {
+          // Only the tip of the stream stays plain; earlier segments can take full MD.
+          const streaming = isActive && item.key === lastTextKey
+          return <MarkdownContent key={item.key} content={item.content} streaming={streaming} />
+        }
         if (item.type === 'tool-group') return <ToolRunSummary key={item.key} parts={item.parts} isActive={isActive} />
         if (item.type === 'tool') return <ToolPartCard key={item.key} part={item.part} approve={approve} deny={deny} onPinStock={onPinStock} agentRunRecords={agentRunRecords} onCancelAgentRun={onCancelAgentRun} onInterpretAgentRun={onInterpretAgentRun} />
         return null
       })}
     </>
   )
+}
+
+function lastAssistantTextKey(items: ReturnType<typeof buildAssistantRenderItems>): string | null {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const item = items[i]
+    if (item?.type === 'text') return item.key
+  }
+  return null
 }
 
 function UserText({ message }: { message: UIMessage }) {

--- a/web/apps/web/src/lib/__tests__/stream-render.test.ts
+++ b/web/apps/web/src/lib/__tests__/stream-render.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { STREAM_UI_THROTTLE_MS, clearStreamFlush, scheduleStreamFlush } from '../stream-render'
+
+describe('scheduleStreamFlush', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces multiple deltas into one set within the throttle window', () => {
+    vi.useFakeTimers()
+    const buf = { current: '' }
+    const timer = { current: 0 as ReturnType<typeof setTimeout> | 0 }
+    const set = vi.fn()
+
+    buf.current = 'a'
+    scheduleStreamFlush(buf, timer, set)
+    buf.current = 'ab'
+    scheduleStreamFlush(buf, timer, set)
+    buf.current = 'abc'
+    scheduleStreamFlush(buf, timer, set)
+
+    expect(set).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(STREAM_UI_THROTTLE_MS)
+    expect(set).toHaveBeenCalledTimes(1)
+    expect(set).toHaveBeenCalledWith('abc')
+  })
+
+  it('clearStreamFlush cancels a pending update', () => {
+    vi.useFakeTimers()
+    const buf = { current: 'x' }
+    const timer = { current: 0 as ReturnType<typeof setTimeout> | 0 }
+    const set = vi.fn()
+
+    scheduleStreamFlush(buf, timer, set)
+    clearStreamFlush(timer)
+    vi.advanceTimersByTime(STREAM_UI_THROTTLE_MS)
+    expect(set).not.toHaveBeenCalled()
+  })
+})

--- a/web/apps/web/src/lib/stream-render.ts
+++ b/web/apps/web/src/lib/stream-render.ts
@@ -1,0 +1,24 @@
+/** UI refresh coalescing for LLM token streams (ms). */
+export const STREAM_UI_THROTTLE_MS = 120
+
+type TimerHandle = ReturnType<typeof setTimeout>
+
+/** Batch token deltas into one state update per throttle window. */
+export function scheduleStreamFlush(
+  buf: { current: string },
+  timer: { current: TimerHandle | 0 },
+  set: (value: string) => void,
+  minMs = STREAM_UI_THROTTLE_MS,
+): void {
+  if (timer.current) return
+  timer.current = setTimeout(() => {
+    timer.current = 0
+    set(buf.current)
+  }, minMs)
+}
+
+export function clearStreamFlush(timer: { current: TimerHandle | 0 }): void {
+  if (!timer.current) return
+  clearTimeout(timer.current)
+  timer.current = 0
+}

--- a/web/apps/web/src/routes/analysis.tsx
+++ b/web/apps/web/src/routes/analysis.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@/lib/supabase'
 import { useAuthStore } from '@/stores/auth'
 import { loadLLMConfig, loadLLMConfigCandidates } from '@/lib/chat-agent'
 import { streamLLMResponseWithFallback, type LLMStreamStatus } from '@/lib/llm-stream'
+import { clearStreamFlush, scheduleStreamFlush } from '@/lib/stream-render'
 import { MarkdownContent } from '@/components/markdown'
 import { KlineChart } from '@/components/kline-chart'
 import { usePreferences } from '@/lib/preferences'
@@ -225,7 +226,7 @@ function useAnalysisRunner(search: SearchController, setHasModelConfig: Dispatch
   const [earlyKline, setEarlyKline] = useState<{ data: KlineRow[]; symbol: string; name: string; dataQuality: KlineDataQuality; valueSnapshot: ValueSnapshot; contextPack: AnalysisContextPack } | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const streamBuf = useRef('')
-  const rafRef = useRef(0)
+  const flushTimer = useRef<ReturnType<typeof setTimeout> | 0>(0)
 
   async function handleAnalyze() {
     const userId = user?.id
@@ -250,9 +251,9 @@ function useAnalysisRunner(search: SearchController, setHasModelConfig: Dispatch
       const contextPack = buildStockAnalysisContextPack({ symbol: resolved.code, name, kline: klineData.data, dataQuality: klineData.quality, valueSnapshot })
       setEarlyKline({ data: klineData.data, symbol: resolved.code, name, dataQuality: klineData.quality, valueSnapshot, contextPack })
       setStep('llm'); streamBuf.current = ''
-      const onDelta = (chunk: string) => { streamBuf.current += chunk; scheduleFlush(streamBuf, rafRef, setStreamingReport) }
+      const onDelta = (chunk: string) => { streamBuf.current += chunk; scheduleStreamFlush(streamBuf, flushTimer, setStreamingReport) }
       const report = await callLLM(configs, resolved.code, name, buildKlinePayload(klineData.data, klineData.quality, contextPack), valueSnapshot, abort.signal, onDelta, setModelStatus)
-      cancelAnimationFrame(rafRef.current)
+      clearStreamFlush(flushTimer)
       if (abort.signal.aborted) return
       setStreamingReport(report)
       const inputSnapshotHash = calculateInputSnapshotHash(resolved.code, klineData.data, valueSnapshot)
@@ -273,7 +274,7 @@ function useAnalysisRunner(search: SearchController, setHasModelConfig: Dispatch
     } catch (err) {
       if (abort.signal.aborted) return
       setError(err instanceof Error ? err.message : t('analysis.failed'))
-    } finally { cancelAnimationFrame(rafRef.current); setLoading(false); setStep(null) }
+    } finally { clearStreamFlush(flushTimer); setLoading(false); setStep(null) }
   }
 
   return { loading, result, error, step, streamingReport, modelStatus, earlyKline, setError, handleAnalyze }
@@ -300,11 +301,6 @@ function startAnalysisRequest(
 
 function analysisHistoryKey(result: AnalysisResult): string {
   return `${result.symbol}:${result.klineData.length}:${result.report.length}`
-}
-
-function scheduleFlush(buf: React.MutableRefObject<string>, raf: React.MutableRefObject<number>, set: Dispatch<SetStateAction<string>>) {
-  if (raf.current) return
-  raf.current = requestAnimationFrame(() => { raf.current = 0; set(buf.current) })
 }
 
 function MissingConfigBanner({ prerequisites }: { prerequisites: Prerequisites }) {
@@ -450,7 +446,7 @@ function AnalysisContent({ runner, onAskAboutRange }: { runner: AnalysisRunnerSt
           {kline && dataQuality && <KlineSection klineData={kline} dataQuality={dataQuality} onAskAboutRange={onAskAboutRange} />}
           {contextPack && <ContextPackSection pack={contextPack} />}
           {valueSnapshot && <ValueSection snapshot={valueSnapshot} />}
-          {report && <ReportSection report={report} />}
+          {report && <ReportSection report={report} streaming={loading && !result} />}
         </div>
       </div>
     </div>
@@ -603,7 +599,7 @@ function ValueSection({ snapshot, compact = false }: { snapshot: ValueSnapshot; 
   )
 }
 
-function ReportSection({ report }: { report: string }) {
+function ReportSection({ report, streaming }: { report: string; streaming: boolean }) {
   const { t } = usePreferences()
   return (
     <section className="min-w-0 rounded-lg border border-border bg-background">
@@ -612,7 +608,7 @@ function ReportSection({ report }: { report: string }) {
         <AIDisclaimer />
       </div>
       <article className="prose prose-base max-w-none px-6 py-5 text-foreground">
-        <MarkdownContent content={report} />
+        <MarkdownContent content={report} streaming={streaming} />
       </article>
     </section>
   )

--- a/web/apps/web/src/routes/portfolio.tsx
+++ b/web/apps/web/src/routes/portfolio.tsx
@@ -7,6 +7,7 @@ import { WyckoffLoading } from '@/components/loading'
 import { usePreferences } from '@/lib/preferences'
 import { loadLLMConfigCandidates } from '@/lib/chat-agent'
 import { streamLLMResponseWithFallback } from '@/lib/llm-stream'
+import { clearStreamFlush, scheduleStreamFlush } from '@/lib/stream-render'
 import { MarkdownContent } from '@/components/markdown'
 import { UpgradeNotice } from '@/components/upgrade-notice'
 import { AIDisclaimer } from '@/components/ai-disclaimer'
@@ -159,12 +160,12 @@ function useFullDiagnosisRunner() {
   const [progress, setProgress] = useState<DiagProgress | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const streamBuf = useRef('')
-  const rafRef = useRef(0)
+  const flushTimer = useRef<ReturnType<typeof setTimeout> | 0>(0)
 
   async function run(portfolio: Portfolio) {
     if (!user || loading || portfolio.positions.length === 0) return
     const total = portfolio.positions.length
-    const abort = startDiagnosisRun(abortRef, streamBuf, rafRef)
+    const abort = startDiagnosisRun(abortRef, streamBuf, flushTimer)
     resetDiagnosisState(setError, setResult, setStreamingReport, setLoading, setProgress, total)
     try {
       const [configs, keys] = await Promise.all([loadLLMConfigCandidates(user.id), getUserDataKeys(user.id)])
@@ -180,10 +181,10 @@ function useFullDiagnosisRunner() {
       const prompt = buildFullPortfolioPrompt(entries, portfolio.free_cash)
       const onDelta = (chunk: string) => {
         streamBuf.current += chunk
-        scheduleStreamingReportFlush(streamBuf, rafRef, setStreamingReport)
+        scheduleStreamFlush(streamBuf, flushTimer, setStreamingReport)
       }
       const report = await callFullPortfolioLLM(configs, prompt, abort.signal, onDelta, (nextModel) => setModel(nextModel))
-      cancelAnimationFrame(rafRef.current)
+      clearStreamFlush(flushTimer)
       if (abort.signal.aborted) return
       setStreamingReport(report)
       setResult(buildDiagnosisResult(entries, report, portfolio.free_cash))
@@ -191,7 +192,7 @@ function useFullDiagnosisRunner() {
       if (abort.signal.aborted) return
       setError(err instanceof Error ? err.message : t('portfolio.failed'))
     } finally {
-      finishDiagnosisRun(rafRef, setLoading, setProgress)
+      finishDiagnosisRun(flushTimer, setLoading, setProgress)
     }
   }
 
@@ -252,10 +253,10 @@ function portfolioHistoryKey(payload: PortfolioHistoryPayload): string {
 function startDiagnosisRun(
   abortRef: MutableRefObject<AbortController | null>,
   streamBuf: MutableRefObject<string>,
-  rafRef: MutableRefObject<number>,
+  flushTimer: MutableRefObject<ReturnType<typeof setTimeout> | 0>,
 ) {
   abortRef.current?.abort()
-  cancelAnimationFrame(rafRef.current)
+  clearStreamFlush(flushTimer)
   const abort = new AbortController()
   abortRef.current = abort
   streamBuf.current = ''
@@ -278,21 +279,13 @@ function resetDiagnosisState(
 }
 
 function finishDiagnosisRun(
-  rafRef: MutableRefObject<number>,
+  flushTimer: MutableRefObject<ReturnType<typeof setTimeout> | 0>,
   setLoading: Dispatch<SetStateAction<boolean>>,
   setProgress: Dispatch<SetStateAction<DiagProgress | null>>,
 ) {
-  cancelAnimationFrame(rafRef.current)
+  clearStreamFlush(flushTimer)
   setLoading(false)
   setProgress(null)
-}
-
-function scheduleStreamingReportFlush(buf: MutableRefObject<string>, raf: MutableRefObject<number>, set: Dispatch<SetStateAction<string>>) {
-  if (raf.current) return
-  raf.current = requestAnimationFrame(() => {
-    raf.current = 0
-    set(buf.current)
-  })
 }
 
 type PositionEntry = { position: Position; kline: KlineRow[]; valueSnapshot: ValueSnapshot }
@@ -469,7 +462,7 @@ function FullDiagnosisPanel({ result, report, streaming }: { result: FullDiagnos
         </div>
         <AIDisclaimer />
         <article className="mt-4 prose prose-sm max-w-none text-foreground">
-          {report ? <MarkdownContent content={report} /> : <p className="text-sm text-muted-foreground">模型分析中...</p>}
+          {report ? <MarkdownContent content={report} streaming={streaming} /> : <p className="text-sm text-muted-foreground">模型分析中...</p>}
         </article>
       </div>
     </section>

--- a/web/apps/web/src/routes/stock-battle.tsx
+++ b/web/apps/web/src/routes/stock-battle.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState, type Dispatch, type FormEvent, type MutableRefObject, type ReactNode, type SetStateAction } from 'react'
+import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
 import { CheckSquare, Loader2, Swords, XSquare } from 'lucide-react'
 import { useAuthStore } from '@/stores/auth'
 import { usePreferences } from '@/lib/preferences'
 import { loadLLMConfigCandidates } from '@/lib/chat-agent'
 import { streamLLMResponseWithFallback } from '@/lib/llm-stream'
+import { clearStreamFlush, scheduleStreamFlush } from '@/lib/stream-render'
 import { MarkdownContent } from '@/components/markdown'
 import { KlineChart } from '@/components/kline-chart'
 import { MultiStockChart, type ComparisonSeries } from '@/components/multi-stock-chart'
@@ -103,12 +104,13 @@ function useBattleRunner() {
   const [report, setReport] = useState('')
   const [model, setModel] = useState('unknown')
   const abortRef = useRef<AbortController | null>(null)
-  const streamBuf = useRef(''), rafRef = useRef(0)
+  const streamBuf = useRef('')
+  const flushTimer = useRef<ReturnType<typeof setTimeout> | 0>(0)
   const [benchmark, setBenchmark] = useState<KlineRow[]>([])
 
   async function run(input: string) {
     if (!user) return
-    abortRef.current?.abort(); cancelAnimationFrame(rafRef.current)
+    abortRef.current?.abort(); clearStreamFlush(flushTimer)
     const abort = new AbortController()
     abortRef.current = abort
     streamBuf.current = ''
@@ -126,26 +128,21 @@ function useBattleRunner() {
       setStocks(fetched)
       setBenchmark(bench)
       setSelectedCodes(fetched.slice(0, Math.min(6, fetched.length)).map((item) => item.code))
-      const onDelta = (chunk: string) => { streamBuf.current += chunk; scheduleBattleReportFlush(streamBuf, rafRef, setReport) }
+      const onDelta = (chunk: string) => { streamBuf.current += chunk; scheduleStreamFlush(streamBuf, flushTimer, setReport) }
       const finalReport = await callBattleLLM(configs, fetched, abort.signal, onDelta, (nextModel) => setModel(nextModel))
-      cancelAnimationFrame(rafRef.current)
+      clearStreamFlush(flushTimer)
       if (abort.signal.aborted) return
       setReport(finalReport)
     } catch (err) {
       if (abort.signal.aborted) return
       setError(normalizeBattleError(err))
     } finally {
-      cancelAnimationFrame(rafRef.current)
+      clearStreamFlush(flushTimer)
       setLoading(false)
     }
   }
 
   return { loading, error, stocks, selectedCodes, mode, overlayLimit, report, benchmark, run, setSelectedCodes, setMode, setOverlayLimit, model }
-}
-
-function scheduleBattleReportFlush(buf: MutableRefObject<string>, raf: MutableRefObject<number>, set: Dispatch<SetStateAction<string>>) {
-  if (raf.current) return
-  raf.current = requestAnimationFrame(() => { raf.current = 0; set(buf.current) })
 }
 
 function useBattleHistory(
@@ -463,7 +460,7 @@ function ReportPanel({ report, loading }: { report: string; loading: boolean }) 
       {report ? (
         <>
           <AIDisclaimer />
-          <article className="mt-4 prose prose-sm max-w-none text-foreground"><MarkdownContent content={report} /></article>
+          <article className="mt-4 prose prose-sm max-w-none text-foreground"><MarkdownContent content={report} streaming={loading} /></article>
         </>
       ) : (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Web 读盘室 / 分析 / 组合诊断 / 对战：流式阶段用 plain text + 120ms 节流，结束后再挂完整 Markdown，避免反复 `react-markdown` 全量重解析
- TUI：无 Markdown 特征的回答保留流式纯文本，跳过结束时的 pop + Markdown 重绘
- 增加 `stream-render` 节流工具、单测，以及可复现基准脚本 `web/apps/web/scripts/bench-stream-render.mjs`（本地约 97% 渲染成本下降）

## Test plan
- [ ] `cd web/apps/web && node scripts/bench-stream-render.mjs` 能跑出对照表
- [ ] `./node_modules/.bin/vitest run src/lib/__tests__/stream-render.test.ts`
- [ ] `.venv/bin/python -m pytest tests/cli/test_tui_rendering.py -k 'display_final or keeps_plain or replace_streamed' -q`
- [ ] 读盘室 Chat 长回答流式时主线程更稳；结束后 Markdown/术语 badge 正常
- [ ] 分析 / 组合诊断 / 对战报告流式结束后样式恢复正常
- [ ] TUI 纯文本回答结束无明显闪烁；含表格/标题的回答仍会 Markdown 美化


Made with [Cursor](https://cursor.com)