### PR TITLE
fix: restore recommendation context attribution coverage

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -51,7 +51,8 @@
 | **confirmed 分数校准** | 不再把不同 Wyckoff 触发器的原始分数直接横比；研究组 I 用信号族历史先验与封顶后的形态强度合成可比分数，避免极高原始分主导 Top1 |
 | **Treatment exposure** | 消融组相对参照组实际改变的交易键，包括 `(signal_date, code)`、仓位倍率和退出日期；零暴露表示规则没有改变真实成交，不能据此评价收益贡献 |
 | **实际成交亏损归因** | 只统计现金组合真正成交的记录，按信号、水温和退出原因汇总成交数、胜率、平均单笔、总盈亏与资本盈亏率；不把未成交信号的纸面收益混进策略结论 |
-| **结果上下文切片** | Outcome Context Slices | 推荐事件与同日 observation 对齐后，按水温、信号、行业和轨道拆分成熟样本的命中率、收盘收益、MFE/MAE；多信号候选可进入多个切片，只用于归因，不直接放行交易 |
+| **结果上下文切片** | Outcome Context Slices | 推荐事件优先与同日 observation 对齐，缺失时使用 recommendation tracking 自带的水温、信号、行业和轨道；同时输出单维度及“水温 × 信号/行业”成熟样本。多信号候选可进入多个切片，只用于归因，不直接放行交易 |
+| **上下文覆盖率** | Context Coverage | 推荐事件成功取得 observation 或 tracking 上下文的比例；报告区分 observation 命中、tracking fallback、当日有 observation 但候选不在观察宇宙、查询失败，并单列水温、信号、行业、轨道和交叉切片的全量/成熟样本覆盖率 |
 | **SOW (Sign of Weakness)** | 放量下跌，确认派发结束、下跌开始的信号 |
 
 ---

--- a/README_STRATEGY.md
+++ b/README_STRATEGY.md
@@ -51,6 +51,10 @@ A 股主漏斗先写观察样本，盘后 feedback 再计算 outcomes，下一�
 [docs/ITERATION_STRATEGY.md](docs/ITERATION_STRATEGY.md) 维护。这里仅保留策略边界：Shadow 不改变真实推荐，
 `on` 也不能绕过 `formal_dynamic_allowed`、跨周期回测和人工复核。
 
+推荐事件 evaluator 会分页读取 `signal_observations`，并使用 `recommendation_tracking` 自带字段补足同日
+上下文；报告同时展示覆盖率和“水温 × 信号/行业”切片。切片达到 10 个成熟样本仅进入 watch，达到 30 个
+才可评价，仍不能直接改变正式候选、AI 排序或 OMS。
+
 ### 外部观察验证
 
 人工关注、社区反馈或其它系统给出的股票可以通过 `external_seeds` 加入观察池。它们不属于正式候选来源，不会进入 AI 推荐池，只记录在 `external_seed_observations`：

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -672,6 +672,10 @@ TTL：SOS 2 天、Spring 3 天、LPS 3 天、EVR 2 天、Compression 3 天。
 规则统一见 [`SIGNAL_FEEDBACK_LOOP.md`](SIGNAL_FEEDBACK_LOOP.md)，研究证据门槛见
 [`ITERATION_STRATEGY.md`](ITERATION_STRATEGY.md)。
 
+`workflows/recommendation_event_eval.py` 对 `signal_observations` 做稳定排序分页，避免 PostgREST 1000 行上限
+把已有上下文误报为 `unknown`。推荐事件优先使用 observation，缺失时降级到 tracking 行内的水温、信号、
+行业和轨道；覆盖状态与成熟样本覆盖率显式进入报告，查询失败不能伪装成历史缺口。
+
 ## 持仓诊断
 
 `core/holding_diagnostic.py` + `scripts/holding_diagnosis_job.py`

--- a/docs/ITERATION_STRATEGY.md
+++ b/docs/ITERATION_STRATEGY.md
@@ -24,7 +24,7 @@ alpha，再谈怎么接。
 | 短线事件 | 未来 5 日命中、MFE、MAE 与 Top-K lift | 只读评估，不回写生产推荐 |
 | 主题轮动 | `rotation_watch` 的短周期动量和宽度 | Shadow 提示，不改变主线确认或 OMS |
 | 基本面质量 Overlay | 公告日前可见财报的 point-in-time 历史回放 | 0/3 周期通过，回测脚本已下线；仅作为读盘室按需查询工具（`analyze_stock mode=fundamental`），不接入 A股漏斗/Shadow/生产排序 |
-| A股实证入场 | 弱水温仓位与 NEUTRAL Spring 缩仓 | 默认回测 A/M/P，未验证前不改变生产漏斗；Q 广度确认实验实现已删除 |
+| A股实证入场 | 弱水温仓位与 NEUTRAL Spring 缩仓 | A/M/P 及 Q/R/S/T 均未晋级；默认网格不再复跑，只有 `run_strategy_compare=true` 时手动复现 |
 | L4 形态信号边际 | 五窗口约 9000 笔的无障碍毛漂移与日期配对 alpha | alpha≈0，四层已排除；停止形态参数迭代 |
 
 ### 基本面质量 Overlay 本地结论（2026-07-18）
@@ -111,12 +111,16 @@ LPS（7 笔、约 −4900）与 SOS（60 笔、约 −4863）。Spring 缩至四
 run [30704303455](https://github.com/YoungCan-Wang/WyckoffTradingAgent/actions/runs/30704303455) 进一步固定 P 的
 Top-N，用不补位方式分别禁止 NEUTRAL Spring、LPS、NEUTRAL EVR 和 CAUTION SOS。四组均未达到晋级门槛：
 Q/S/T 跨窗口不稳；R 虽在 4/5 窗口改善、平均相对 P 增益 +2.82pp 且未恶化最大回撤，但 P 组直接成交的
-LPS 只有 8 笔。独立的最近 90 个推荐日事件样本又显示 33 条已成熟 LPS 的 5 日平均收盘收益为 +0.79%，
-方向与小样本回测相反。因此不禁止生产 LPS，也不继续组合这些形态门控；实验 PR 关闭，证据保留在 Actions。
+LPS 只有 8 笔。修复 observation 分页与 tracking fallback 后，最近 90 个推荐日事件中成熟 LPS 扩为 67 条，
+5 日平均收盘收益 −2.79%，但仍好于全样本 −4.92%；NEUTRAL × LPS 的 40 条成熟样本为 −1.52%。因此证据
+仍不支持生产全局禁用 LPS，也不继续组合这些形态门控；实验 PR 关闭，证据保留在 Actions。
 
-同一批推荐事件共 637 条、492 条标签成熟。候选影子排序相对原漏斗分在 Top1/3/5 的命中率均无提升，
+同一批推荐事件共 703 条、492 条标签成熟。候选影子排序相对原漏斗分在 Top1/3/5 的命中率均无提升，
 平均收盘收益与 MAE 也未改善；AI 优先排序同样不增益。当前实现保持 `score_only`，后续 evaluator 改为从
-同日 observation 带回水温、信号、行业和轨道，先回答亏损集中在哪个上下文，不再把同一规则盲目套全市场。
+同日 observation 带回水温、信号、行业和轨道，并用 tracking 字段补缺。分页修复后总上下文覆盖率为
+654/703（93.03%），成熟样本覆盖率为 443/492（90.04%）。当前可评价的组合中 NEUTRAL × SOS 为 −4.40%、
+NEUTRAL × EVR 为 −4.45%、CRASH × crash_resilience_watch 为 −5.19%，都没有形成可晋级的正收益规则；
+NEUTRAL × wyckoff_structure 虽为 +1.29%，只有 12 条成熟样本，保持 watch，不新开生产消融。
 
 `pending_mode=only` 的报告必须把成交触发器显示为实际 confirmed 信号族；同一股票当日还命中更高分的
 未确认形态时，可以保留更高数值供归因，但不能把标签降级成裸 `spring` / `sos`。`both` 研究模式仍按

--- a/docs/SIGNAL_FEEDBACK_LOOP.md
+++ b/docs/SIGNAL_FEEDBACK_LOOP.md
@@ -188,11 +188,17 @@ registry 只负责控制动态策略是否使用信号；原始 observations 仍
 
 `strategy_attribution_report.py` 会把 `candidate_shadow_score.grade` 聚合进 `score_bucket_stats_json._candidate_shadow_grade`，Web 端策略归因页展示 S/A/B/C/D 各档在不同持有周期下的胜率、平均收益、大涨率、大跌率和平均回撤。`evaluate_recommendation_events.py` 也会只读 join 同日 observation，把候选影子分档输出到 `summary.candidate_shadow_grade`，并在 `summary.top_k_by_strategy.candidate_shadow_then_score` 对照“按候选影子分排序”的 5 日冲刺命中率、MFE 和 MAE；`summary.top_k_lift_vs_score_only.candidate_shadow_then_score` 会直接给出相对原漏斗分排序的差值，`summary.ranking_decision` 进一步用样本量、命中率 lift、MFE lift 和 MAE 恶化门槛判断它是否只是观察项，还是可以进入下一步排序接入候选。2026-08-02 的 90 个推荐日复核中，候选影子 Top1/3/5 均未产生正 lift，因此继续使用 `score_only`，不得把影子分升级为正式排序。
 
-同一 evaluator 还从 observation 带回 `regime`、`signal_type`、`industry` 和 `track`，分别写入
-`summary.outcome_context`。Markdown 的 `Outcome Context Slices` 展示各切片的成熟样本、命中率、5 日收盘
-收益、MFE 和 MAE；同一候选若同时有多个信号，会进入多个信号切片。该结果用于发现“哪类市场/行业/信号
-需要单独建模”，不会直接生成买入许可。缺失同日 observation 的历史推荐明确落入 `unknown`，不能用有上下文
-的小样本替代全量结论。
+同一 evaluator 还从 observation 带回 `regime`、`signal_type`、`industry` 和 `track`；没有同日 observation
+时，使用 recommendation tracking 行内的 `market_regime / signal_types / primary_signal / industry /
+signal_track` 补足。读取 observation 必须按 `id` 稳定分页，不能被 PostgREST 1000 行上限静默截断。
+
+`metadata.observation_context` 与 `summary.context_coverage` 输出总覆盖率、成熟样本覆盖率、可观察日期范围、
+各字段及交叉切片覆盖率和
+`matched_observation / tracking_fallback / not_in_observation_universe / query_failed` 状态计数。
+`summary.outcome_context` 除单独水温、信号、行业和轨道外，还包含 `regime_signal` 与
+`regime_industry` 交叉切片。10-29 个成熟样本标为 `watch`，至少 30 个才标为 `evaluable`；这只是防止
+小样本过度解释，不是自动晋级阈值。同一候选若同时有多个信号，会进入多个归因切片，任何切片都不会直接
+生成买入许可。
 
 ## Entry Quality
 

--- a/tests/workflows/test_recommendation_event_eval.py
+++ b/tests/workflows/test_recommendation_event_eval.py
@@ -4,7 +4,11 @@ from core.candidate_guards import policy_candidate_guard_summary
 from workflows.recommendation_event_eval import (
     _build_summary,
     _context_markdown,
+    _fetch_observation_rows,
+    _observation_context_status,
+    _observation_coverage,
     _observation_feature_map,
+    _ObservationFeatureIndex,
     _policy_selection,
     _policy_selection_markdown,
     _quality_feature_fields,
@@ -342,9 +346,13 @@ def test_event_summary_groups_observation_context_without_dropping_multi_signal_
     assert context["signal_type"]["spring"]["rows_total"] == 1
     assert context["industry"]["电子"]["hit_rate_pct"] == 100.0
     assert context["track"]["unknown"]["rows_total"] == 2
+    assert context["regime_signal"]["NEUTRAL × spring"]["rows_total"] == 1
+    assert context["regime_signal"]["NEUTRAL × sos"]["evidence_status"] == "insufficient_sample"
+    assert context["regime_industry"]["CAUTION × 医药生物"]["rows_total"] == 1
     markdown = "\n".join(_context_markdown(context))
     assert "### Market regime" in markdown
     assert "| sos | 2/2 | 50.0%" in markdown
+    assert "### Regime × signal" in markdown
 
 
 def test_quality_feature_fields_merge_observation_and_row_features() -> None:
@@ -353,10 +361,15 @@ def test_quality_feature_fields_merge_observation_and_row_features() -> None:
         "entry_quality": {"score": 76, "grade": "A", "risk_flags": ["缩量不足"]},
     }
     row = {
+        "market_regime": "NEUTRAL",
+        "signal_types": ["lps"],
+        "primary_signal": "sos",
+        "industry": "电子",
+        "signal_track": "Accum",
         "features_json": (
             '{"candidate_shadow_score":{"score":42,"grade":"D"},'
             '"entry_quality":{"score":"nan","grade":"Z","risk_flags":"追高延展"}}'
-        )
+        ),
     }
 
     fields = _quality_feature_fields(row, observed)
@@ -366,6 +379,10 @@ def test_quality_feature_fields_merge_observation_and_row_features() -> None:
     assert fields["entry_quality_score"] is None
     assert fields["entry_quality_grade"] == "unknown"
     assert fields["entry_quality_risk_flags"] == ["追高延展"]
+    assert fields["observation_regimes"] == ["NEUTRAL"]
+    assert fields["observation_signal_types"] == ["lps", "sos"]
+    assert fields["observation_industries"] == ["电子"]
+    assert fields["observation_tracks"] == ["Accum"]
 
 
 def test_observation_feature_map_merges_same_day_features() -> None:
@@ -417,6 +434,93 @@ def test_observation_feature_map_keeps_cross_market_code_shape() -> None:
 
     assert ("00700", "20260515") in features
     assert ("000700", "20260515") not in features
+
+
+def test_fetch_observation_rows_paginates_past_postgrest_cap() -> None:
+    pages = {
+        0: [{"id": value, "trade_date": "2026-05-15", "code": str(value)} for value in range(1000)],
+        1000: [{"id": 1000, "trade_date": "2026-05-15", "code": "1000"}],
+    }
+
+    class Query:
+        start = 0
+
+        def table(self, _name):
+            return self
+
+        def select(self, _columns):
+            return self
+
+        def eq(self, _column, _value):
+            return self
+
+        def in_(self, _column, _values):
+            return self
+
+        def order(self, _column, *, desc=False):
+            return self
+
+        def range(self, start, _stop):
+            self.start = start
+            return self
+
+        def execute(self):
+            return type("Response", (), {"data": pages[self.start]})()
+
+    rows = _fetch_observation_rows(Query(), "cn", ["2026-05-15"])
+
+    assert len(rows) == 1001
+    assert rows[-1]["id"] == 1000
+
+
+def test_observation_coverage_separates_legacy_gap_from_unmatched_candidate() -> None:
+    index = _ObservationFeatureIndex(
+        {("000001", "20260515"): {"outcome_context": {"observation_regimes": ["NEUTRAL"]}}},
+        frozenset({"20260515"}),
+        "ok",
+    )
+    matched = _observation_context_status(("000001", "20260515"), index.features[("000001", "20260515")], {}, index)
+    fallback = _observation_context_status(("000002", "20260515"), {}, {"observation_signal_types": ["lps"]}, index)
+    unmatched = _observation_context_status(("000003", "20260515"), {}, {}, index)
+    legacy = _observation_context_status(("000004", "20260514"), {}, {}, index)
+    events = [
+        {
+            "recommend_date": 20260515,
+            "label_ready": True,
+            "observation_context_status": matched,
+            "observation_regimes": ["NEUTRAL"],
+            "observation_signal_types": ["sos"],
+            "observation_industries": ["电子"],
+            "observation_tracks": ["Trend"],
+        },
+        {
+            "recommend_date": 20260515,
+            "label_ready": True,
+            "observation_context_status": fallback,
+            "observation_signal_types": ["lps"],
+        },
+        {"recommend_date": 20260515, "label_ready": True, "observation_context_status": unmatched},
+        {"recommend_date": 20260514, "label_ready": True, "observation_context_status": legacy},
+    ]
+
+    coverage = _observation_coverage(events, index)
+
+    assert matched == "matched_observation"
+    assert fallback == "tracking_fallback"
+    assert unmatched == "not_in_observation_universe"
+    assert legacy == "no_observation_for_date"
+    assert coverage["coverage_pct"] == 50.0
+    assert coverage["observed_date_coverage_pct"] == 66.67
+    assert coverage["ready_observed_date_coverage_pct"] == 66.67
+    assert coverage["field_coverage"]["regime"]["coverage_pct"] == 25.0
+    assert coverage["field_coverage"]["signal_type"]["coverage_pct"] == 50.0
+    assert coverage["field_coverage"]["regime_signal"]["coverage_pct"] == 25.0
+    assert coverage["status_counts"] == {
+        "matched_observation": 1,
+        "no_observation_for_date": 1,
+        "not_in_observation_universe": 1,
+        "tracking_fallback": 1,
+    }
 
 
 def _event(

--- a/tests/workflows/test_recommendation_event_eval_summary.py
+++ b/tests/workflows/test_recommendation_event_eval_summary.py
@@ -1,0 +1,25 @@
+from workflows.recommendation_event_eval_summary import recommendation_event_eval_result_summary
+
+
+def test_result_summary_surfaces_context_coverage() -> None:
+    result = {
+        "summary": {
+            "all": {"rows_ready": 492, "rows_total": 703, "hit_rate_pct": 18.5},
+            "ranking_decision": {"status": "watch", "watch_strategy": "recommend_count"},
+            "context_coverage": {
+                "rows_total": 703,
+                "rows_matched": 654,
+                "coverage_pct": 93.03,
+                "ready_rows_on_observed_dates": 492,
+                "ready_rows_matched_on_observed_dates": 443,
+                "ready_observed_date_coverage_pct": 90.04,
+                "status_counts": {"matched_observation": 555, "tracking_fallback": 99},
+            },
+        }
+    }
+
+    summary = recommendation_event_eval_result_summary(result)
+
+    assert "上下文覆盖: 654/703 (93.03%)" in summary
+    assert "成熟=443/492 (90.04%)" in summary
+    assert "observation=555, tracking_fallback=99" in summary

--- a/workflows/recommendation_event_eval.py
+++ b/workflows/recommendation_event_eval.py
@@ -51,6 +51,9 @@ _DECISION_MIN_READY_ROWS = 10
 _DECISION_MIN_HIT_LIFT_PCT = 5.0
 _DECISION_MIN_MFE_LIFT_PCT = 0.0
 _DECISION_MAX_MAE_WORSE_PCT = -1.0
+_CONTEXT_MIN_READY_ROWS = 30
+_CONTEXT_WATCH_READY_ROWS = 10
+_OBSERVATION_PAGE_SIZE = 1000
 _OBSERVATION_CONTEXT_FIELDS = {
     "regime": "observation_regimes",
     "signal_type": "observation_signal_types",
@@ -68,6 +71,14 @@ class RecommendationEventEvalRequest:
     kline_count: int = 160
     output_dir: str = "artifacts/recommendation_event_eval"
     top_k: tuple[int, ...] = (1, 3, 5)
+
+
+@dataclass(frozen=True)
+class _ObservationFeatureIndex:
+    features: dict[tuple[str, str], dict[str, Any]]
+    observed_dates: frozenset[str]
+    fetch_status: str
+    row_count: int = 0
 
 
 def run_recommendation_event_eval(request: RecommendationEventEvalRequest) -> int:
@@ -97,13 +108,15 @@ def build_recommendation_event_eval(request: RecommendationEventEvalRequest) -> 
 
     market = resolve_tracking_market(request.market)
     records = _fetch_records(market, request.max_dates)
-    feature_map = _fetch_observation_feature_map(market, records)
+    observation_index = _fetch_observation_feature_index(market, records)
     grouped = group_records_by_market_code(records, market)
     hist_by_code = _fetch_hist_by_code(api_key, sorted(grouped), market, request.kline_count)
-    events = _build_events(grouped, hist_by_code, request, feature_map)
+    events = _build_events(grouped, hist_by_code, request, observation_index)
     events_by_date = _events_by_date(events)
     ranked_by_strategy = _ranked_events_by_strategy(events_by_date)
     summary = _build_summary(events, request.top_k, events_by_date, ranked_by_strategy)
+    context_coverage = _observation_coverage(events, observation_index)
+    summary["context_coverage"] = context_coverage
     policy_selection = _policy_selection(
         events,
         summary.get("ranking_decision") or {},
@@ -111,7 +124,7 @@ def build_recommendation_event_eval(request: RecommendationEventEvalRequest) -> 
         ranked_by_strategy,
     )
     result = {
-        "metadata": _metadata(request, market, records, grouped),
+        "metadata": _metadata(request, market, records, grouped, context_coverage),
         "summary": summary,
         "daily": _daily_summary(events_by_date),
         "policy_selection": policy_selection,
@@ -136,29 +149,43 @@ def _fetch_records(market: str, max_dates: int) -> list[dict[str, Any]]:
         start += 1000
 
 
-def _fetch_observation_feature_map(
+def _fetch_observation_feature_index(
     market: str,
     records: list[dict[str, Any]],
-) -> dict[tuple[str, str], dict[str, Any]]:
+) -> _ObservationFeatureIndex:
     dates = sorted({_date_iso(recommend_date_to_yyyymmdd(row.get("recommend_date"))) for row in records})
     dates = [day for day in dates if day]
     if not dates:
-        return {}
+        return _ObservationFeatureIndex({}, frozenset(), "empty_input")
     client = create_admin_client()
-    rows: list[dict[str, Any]] = []
     try:
-        for batch in chunked(dates, 100):
-            resp = (
+        rows = _fetch_observation_rows(client, market, dates)
+    except Exception:
+        return _ObservationFeatureIndex({}, frozenset(), "query_failed")
+    observed_dates = frozenset(_date_compact(row.get("trade_date")) for row in rows if row.get("trade_date"))
+    return _ObservationFeatureIndex(_observation_feature_map(rows, market), observed_dates, "ok", len(rows))
+
+
+def _fetch_observation_rows(client: Any, market: str, dates: list[str]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for date_batch in chunked(dates, 100):
+        start = 0
+        while True:
+            response = (
                 client.table(TABLE_SIGNAL_OBSERVATIONS)
-                .select("trade_date,code,regime,signal_type,industry,track,features_json")
+                .select("id,trade_date,code,regime,signal_type,industry,track,features_json")
                 .eq("market", market)
-                .in_("trade_date", batch)
+                .in_("trade_date", date_batch)
+                .order("id", desc=False)
+                .range(start, start + _OBSERVATION_PAGE_SIZE - 1)
                 .execute()
             )
-            rows.extend(resp.data or [])
-    except Exception:
-        return {}
-    return _observation_feature_map(rows, market)
+            page = response.data or []
+            rows.extend(page)
+            if len(page) < _OBSERVATION_PAGE_SIZE:
+                break
+            start += _OBSERVATION_PAGE_SIZE
+    return rows
 
 
 def _observation_feature_map(rows: list[dict[str, Any]], market: str = "cn") -> dict[tuple[str, str], dict[str, Any]]:
@@ -220,13 +247,13 @@ def _build_events(
     grouped: dict[str, list[dict[str, Any]]],
     hist_by_code: dict[str, pd.DataFrame | None],
     request: RecommendationEventEvalRequest,
-    feature_map: dict[tuple[str, str], dict[str, Any]] | None = None,
+    observation_index: _ObservationFeatureIndex | None = None,
 ) -> list[dict[str, Any]]:
     events: list[dict[str, Any]] = []
-    feature_map = feature_map or {}
+    observation_index = observation_index or _ObservationFeatureIndex({}, frozenset(), "not_requested")
     for code, rows in sorted(grouped.items()):
         ohlc = ohlc_map_from_tickflow_hist(hist_by_code.get(code))
-        events.extend(_event_with_quality(row, code, ohlc, request, feature_map) for row in rows)
+        events.extend(_event_with_quality(row, code, ohlc, request, observation_index) for row in rows)
     return sorted(events, key=lambda item: (item.get("recommend_date") or 0, str(item.get("code") or "")))
 
 
@@ -235,11 +262,34 @@ def _event_with_quality(
     code: str,
     ohlc: dict[str, dict[str, float]],
     request: RecommendationEventEvalRequest,
-    feature_map: dict[tuple[str, str], dict[str, Any]],
+    observation_index: _ObservationFeatureIndex,
 ) -> dict[str, Any]:
     event = build_horizon_event(row, ohlc, horizon_days=request.horizon_days, target_pct=request.target_pct)
     key = (_code_key(code, resolve_tracking_market(request.market)), _date_compact(row.get("recommend_date")))
-    return {**event, **_quality_feature_fields(row, feature_map.get(key, {}))}
+    observed = observation_index.features.get(key, {})
+    quality_fields = _quality_feature_fields(row, observed)
+    return {
+        **event,
+        **quality_fields,
+        "observation_context_status": _observation_context_status(key, observed, quality_fields, observation_index),
+    }
+
+
+def _observation_context_status(
+    key: tuple[str, str],
+    observed: dict[str, Any],
+    quality_fields: dict[str, Any],
+    index: _ObservationFeatureIndex,
+) -> str:
+    if observed:
+        return "matched_observation"
+    if any(quality_fields.get(field) for field in _OBSERVATION_CONTEXT_FIELDS.values()):
+        return "tracking_fallback"
+    if index.fetch_status == "query_failed":
+        return "query_failed"
+    if key[1] in index.observed_dates:
+        return "not_in_observation_universe"
+    return "no_observation_for_date"
 
 
 def _build_summary(
@@ -272,6 +322,12 @@ def _build_summary(
             )
         },
     }
+    summary["outcome_context"]["regime_signal"] = _paired_context_summary(
+        events, "observation_regimes", "observation_signal_types"
+    )
+    summary["outcome_context"]["regime_industry"] = _paired_context_summary(
+        events, "observation_regimes", "observation_industries"
+    )
     return summary
 
 
@@ -289,13 +345,37 @@ def _context_summary(events: list[dict[str, Any]], field: str) -> dict[str, Any]
         labels = _str_list(event.get(field)) or ["unknown"]
         for label in dict.fromkeys(labels):
             groups[label].append(event)
-    summaries = {label: summarize_horizon_events(rows) for label, rows in groups.items()}
+    summaries = {label: _context_evidence_summary(rows) for label, rows in groups.items()}
     return dict(
         sorted(
             summaries.items(),
             key=lambda item: (-int(item[1].get("rows_ready") or 0), -int(item[1].get("rows_total") or 0), item[0]),
         )
     )
+
+
+def _paired_context_summary(events: list[dict[str, Any]], left_field: str, right_field: str) -> dict[str, Any]:
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for event in events:
+        left_values = _str_list(event.get(left_field))
+        right_values = _str_list(event.get(right_field))
+        for left in dict.fromkeys(left_values):
+            for right in dict.fromkeys(right_values):
+                groups[f"{left} × {right}"].append(event)
+    summaries = {label: _context_evidence_summary(rows) for label, rows in groups.items()}
+    return dict(sorted(summaries.items(), key=lambda item: (-int(item[1].get("rows_ready") or 0), item[0])))
+
+
+def _context_evidence_summary(events: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = summarize_horizon_events(events)
+    ready = int(summary.get("rows_ready") or 0)
+    if ready >= _CONTEXT_MIN_READY_ROWS:
+        status = "evaluable"
+    elif ready >= _CONTEXT_WATCH_READY_ROWS:
+        status = "watch"
+    else:
+        status = "insufficient_sample"
+    return {**summary, "evidence_status": status}
 
 
 def _top_k_by_strategy(
@@ -692,6 +772,7 @@ def _metadata(
     market: str,
     records: list[dict[str, Any]],
     grouped: dict[str, list[dict[str, Any]]],
+    context_coverage: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "generated_at": datetime.now(UTC).isoformat(),
@@ -702,7 +783,77 @@ def _metadata(
         "kline_count": request.kline_count,
         "records": len(records),
         "codes": len(grouped),
+        "observation_context": context_coverage,
     }
+
+
+def _observation_coverage(
+    events: list[dict[str, Any]],
+    index: _ObservationFeatureIndex,
+) -> dict[str, Any]:
+    status_counts: dict[str, int] = defaultdict(int)
+    ready_status_counts: dict[str, int] = defaultdict(int)
+    for event in events:
+        status = str(event.get("observation_context_status") or "unknown")
+        status_counts[status] += 1
+        if event.get("label_ready"):
+            ready_status_counts[status] += 1
+    matched_statuses = {"matched_observation", "tracking_fallback"}
+    matched = sum(count for status, count in status_counts.items() if status in matched_statuses)
+    ready_matched = sum(count for status, count in ready_status_counts.items() if status in matched_statuses)
+    observed_events = [event for event in events if _date_compact(event.get("recommend_date")) in index.observed_dates]
+    observed_matched = sum(
+        1 for event in observed_events if event.get("observation_context_status") in matched_statuses
+    )
+    ready_observed_events = [event for event in observed_events if event.get("label_ready")]
+    ready_observed_matched = sum(
+        1 for event in ready_observed_events if event.get("observation_context_status") in matched_statuses
+    )
+    dates = sorted(index.observed_dates)
+    return {
+        "fetch_status": index.fetch_status,
+        "observation_rows_fetched": index.row_count,
+        "observed_dates": len(dates),
+        "first_observation_date": dates[0] if dates else None,
+        "last_observation_date": dates[-1] if dates else None,
+        "rows_total": len(events),
+        "rows_matched": matched,
+        "coverage_pct": _percentage(matched, len(events)),
+        "rows_on_observed_dates": len(observed_events),
+        "rows_matched_on_observed_dates": observed_matched,
+        "observed_date_coverage_pct": _percentage(observed_matched, len(observed_events)),
+        "ready_rows_on_observed_dates": len(ready_observed_events),
+        "ready_rows_matched": ready_matched,
+        "ready_rows_matched_on_observed_dates": ready_observed_matched,
+        "ready_observed_date_coverage_pct": _percentage(ready_observed_matched, len(ready_observed_events)),
+        "field_coverage": _context_field_coverage(events),
+        "status_counts": dict(sorted(status_counts.items())),
+        "ready_status_counts": dict(sorted(ready_status_counts.items())),
+    }
+
+
+def _context_field_coverage(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    fields = {
+        **{source: (target,) for source, target in _OBSERVATION_CONTEXT_FIELDS.items()},
+        "regime_signal": ("observation_regimes", "observation_signal_types"),
+        "regime_industry": ("observation_regimes", "observation_industries"),
+    }
+    ready_events = [event for event in events if event.get("label_ready")]
+    coverage: dict[str, dict[str, Any]] = {}
+    for name, required in fields.items():
+        matched = sum(1 for event in events if all(_str_list(event.get(field)) for field in required))
+        ready_matched = sum(1 for event in ready_events if all(_str_list(event.get(field)) for field in required))
+        coverage[name] = {
+            "rows_matched": matched,
+            "coverage_pct": _percentage(matched, len(events)),
+            "ready_rows_matched": ready_matched,
+            "ready_coverage_pct": _percentage(ready_matched, len(ready_events)),
+        }
+    return coverage
+
+
+def _percentage(numerator: int, denominator: int) -> float | None:
+    return round(numerator / denominator * 100.0, 2) if denominator > 0 else None
 
 
 def _write_markdown(path: Path, result: dict[str, Any]) -> None:
@@ -713,10 +864,15 @@ def _write_markdown(path: Path, result: dict[str, Any]) -> None:
         f"- Market: `{meta['market']}`",
         f"- Target: `{meta['target_pct']}%` within `{meta['horizon_days']}` future trading days",
         f"- Records: `{meta['records']}` rows / `{meta['codes']}` codes",
-        "",
-        "| Slice | Ready | Hit rate | Close win | Avg close | Payoff | Avg MFE | Avg MAE |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
+    lines.extend(_coverage_markdown(meta.get("observation_context") or {}))
+    lines.extend(
+        [
+            "",
+            "| Slice | Ready | Hit rate | Close win | Avg close | Payoff | Avg MFE | Avg MAE |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
     lines.extend(_summary_markdown_rows(result["summary"]))
     lines.extend(_strategy_markdown(result["summary"]["top_k_by_strategy"]))
     lines.extend(_strategy_lift_markdown(result["summary"].get("top_k_lift_vs_score_only") or {}))
@@ -725,6 +881,39 @@ def _write_markdown(path: Path, result: dict[str, Any]) -> None:
     lines.extend(_quality_markdown(result["summary"]))
     lines.extend(_context_markdown(result["summary"].get("outcome_context") or {}))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _coverage_markdown(coverage: dict[str, Any]) -> list[str]:
+    counts = coverage.get("status_counts") if isinstance(coverage.get("status_counts"), dict) else {}
+    rows = [
+        "",
+        "## Observation Context Coverage",
+        "",
+        f"- Fetch status: `{coverage.get('fetch_status', 'unknown')}`",
+        f"- Observation rows fetched: `{coverage.get('observation_rows_fetched', 0)}`",
+        f"- Observation dates: `{coverage.get('observed_dates', 0)}` "
+        f"(`{coverage.get('first_observation_date') or 'n/a'}` to `{coverage.get('last_observation_date') or 'n/a'}`)",
+        f"- Overall matched: `{coverage.get('rows_matched', 0)}/{coverage.get('rows_total', 0)}` "
+        f"(`{_fmt(coverage.get('coverage_pct'))}%`)",
+        f"- Matched on observed dates: `{coverage.get('rows_matched_on_observed_dates', 0)}/"
+        f"{coverage.get('rows_on_observed_dates', 0)}` "
+        f"(`{_fmt(coverage.get('observed_date_coverage_pct'))}%`)",
+        f"- Mature matched on observed dates: `{coverage.get('ready_rows_matched_on_observed_dates', 0)}/"
+        f"{coverage.get('ready_rows_on_observed_dates', 0)}` "
+        f"(`{_fmt(coverage.get('ready_observed_date_coverage_pct'))}%`)",
+        f"- Status counts: `{json.dumps(counts, ensure_ascii=False, sort_keys=True)}`",
+        "",
+        "| Context field | All coverage | Mature coverage |",
+        "|---|---:|---:|",
+    ]
+    for name, item in (coverage.get("field_coverage") or {}).items():
+        rows.append(
+            f"| {name} | {item.get('rows_matched', 0)}/{coverage.get('rows_total', 0)} "
+            f"({_fmt(item.get('coverage_pct'))}%) | "
+            f"{item.get('ready_rows_matched', 0)}/{coverage.get('ready_rows_on_observed_dates', 0)} "
+            f"({_fmt(item.get('ready_coverage_pct'))}%) |"
+        )
+    return rows
 
 
 def _summary_markdown_rows(summary: dict[str, Any]) -> list[str]:
@@ -873,6 +1062,8 @@ def _context_markdown(context: dict[str, Any]) -> list[str]:
         ("Signal type", "signal_type", 0),
         ("Industry", "industry", 20),
         ("Track", "track", 0),
+        ("Regime × signal", "regime_signal", 0),
+        ("Regime × industry", "regime_industry", 30),
     ):
         rows.extend(_context_table(title, context.get(key) or {}, limit))
     return rows
@@ -883,13 +1074,18 @@ def _context_table(title: str, groups: dict[str, Any], limit: int) -> list[str]:
         "",
         f"### {title}",
         "",
-        "| Value | Ready | Hit rate | Close win | Avg close | Payoff | Avg MFE | Avg MAE |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|",
+        "| Value | Ready | Hit rate | Close win | Avg close | Payoff | Avg MFE | Avg MAE | Evidence |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     items = list(groups.items())[: limit or None]
     if not items:
-        return [*rows, "| n/a | 0/0 | n/a | n/a | n/a | n/a | n/a | n/a |"]
-    return [*rows, *(_summary_row(label, item) for label, item in items)]
+        return [*rows, "| n/a | 0/0 | n/a | n/a | n/a | n/a | n/a | n/a | insufficient_sample |"]
+    return [*rows, *(_context_summary_row(label, item) for label, item in items)]
+
+
+def _context_summary_row(label: str, row: dict[str, Any]) -> str:
+    summary = _summary_row(label, row).removesuffix("|").rstrip()
+    return f"{summary} | {row.get('evidence_status', 'insufficient_sample')} |"
 
 
 def _quality_table(title: str, grade_rows: dict[str, Any]) -> list[str]:
@@ -948,7 +1144,7 @@ def _quality_feature_fields(row: dict[str, Any], observed_features: dict[str, An
     features = _merge_quality_features(_json_map(observed_features), _json_map(row.get("features_json")))
     shadow = _json_map(features.get("candidate_shadow_score"))
     entry = _json_map(features.get("entry_quality"))
-    context = _json_map(features.get("outcome_context"))
+    context = _tracking_outcome_context(row, _json_map(features.get("outcome_context")))
     return {
         "candidate_shadow_score": _optional_number(shadow.get("score")),
         "candidate_shadow_grade": _grade(shadow.get("grade")),
@@ -965,7 +1161,33 @@ def _merge_quality_features(base: dict[str, Any], overlay: dict[str, Any]) -> di
         value = _json_map(overlay.get(key))
         if value:
             merged[key] = value
+    base_context = _json_map(merged.get("outcome_context"))
+    overlay_context = _json_map(overlay.get("outcome_context"))
+    context = {
+        target: sorted({*_str_list(base_context.get(target)), *_str_list(overlay_context.get(target))})
+        for target in _OBSERVATION_CONTEXT_FIELDS.values()
+    }
+    if any(context.values()):
+        merged["outcome_context"] = context
     return merged
+
+
+def _tracking_outcome_context(row: dict[str, Any], base: dict[str, Any]) -> dict[str, Any]:
+    sources = {
+        "observation_regimes": _str_list(row.get("market_regime")),
+        "observation_signal_types": [
+            *_str_list(row.get("signal_types")),
+            *_str_list(row.get("primary_signal")),
+        ],
+        "observation_industries": _str_list(row.get("industry")),
+        "observation_tracks": _str_list(row.get("signal_track")),
+    }
+    context: dict[str, Any] = {}
+    for target, values in sources.items():
+        selected = _str_list(base.get(target)) or values
+        if selected:
+            context[target] = sorted(set(selected))
+    return context
 
 
 def _grade(raw: Any) -> str:

--- a/workflows/recommendation_event_eval_summary.py
+++ b/workflows/recommendation_event_eval_summary.py
@@ -18,12 +18,32 @@ def recommendation_event_eval_result_summary(result: dict[str, Any]) -> str:
         f"推荐事件评估: ready={ready}, hit={_summary_pct(all_rows.get('hit_rate_pct'))}%, ranking_decision={status}",
         _ranking_decision_line(status, strategy, top_k),
     ]
+    if coverage_line := _context_coverage_line(summary.get("context_coverage")):
+        lines.append(coverage_line)
     if pick_line := _policy_selection_summary_line(selection):
         lines.append(pick_line)
     reason = str(decision.get("reason") or "").strip()
     if reason:
         lines.append(f"reason: {reason}")
     return "\n".join(line for line in lines if line)
+
+
+def _context_coverage_line(raw: Any) -> str:
+    coverage = raw if isinstance(raw, dict) else {}
+    total = int(coverage.get("rows_total") or 0)
+    if total <= 0:
+        return ""
+    matched = int(coverage.get("rows_matched") or 0)
+    ready_total = int(coverage.get("ready_rows_on_observed_dates") or 0)
+    ready_matched = int(coverage.get("ready_rows_matched_on_observed_dates") or 0)
+    counts = coverage.get("status_counts") if isinstance(coverage.get("status_counts"), dict) else {}
+    return (
+        f"上下文覆盖: {matched}/{total} ({_summary_pct(coverage.get('coverage_pct'))}%), "
+        f"成熟={ready_matched}/{ready_total} "
+        f"({_summary_pct(coverage.get('ready_observed_date_coverage_pct'))}%), "
+        f"observation={int(counts.get('matched_observation') or 0)}, "
+        f"tracking_fallback={int(counts.get('tracking_fallback') or 0)}"
+    )
 
 
 def _ranking_decision_line(status: str, strategy: str, top_k: Any) -> str:


### PR DESCRIPTION
## Summary

- paginate signal_observations past the PostgREST 1000-row cap
- fall back to recommendation tracking context when the same-day observation is absent
- report overall, mature, per-field, regime-signal, and regime-industry context coverage
- classify context slices as insufficient, watch, or evaluable without changing production gates
- correct the LPS and context-attribution evidence in strategy documentation

## Evidence

- live read-only evaluation fetched 3753 observation rows instead of the previous 1000-row truncation
- context coverage is 654/703 (93.03%); mature coverage is 443/492 (90.04%)
- mature LPS is 67 rows at -2.79% five-day average close versus -4.92% for all events, so a global LPS veto remains unsupported
- no regime-signal slice with at least 30 mature rows has positive average close return

## Validation

- 2339 pytest tests passed
- ruff check and format passed
- function and LOC quality gate passed
- live read-only 90-date recommendation event evaluation completed successfully