### PR TITLE
fix(tui): 修掉升级提示静默失效、思维链无声截断、启动卡死与硬编码黑底

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -69,6 +70,21 @@ def _get_version() -> str:
         return "dev"
 
 
+def _version_sort_key(value: str) -> tuple[int, ...]:
+    """把版本号转成可比较的整数元组，无法解析时返回空元组。
+
+    原先直接对每一段做 int()，PyPI 一旦出现 1.0.0rc1 / 0.9.235.post1 这类非纯数字版本就抛
+    ValueError，被外层 except 吞掉——升级提示从此静默失效，且正好在最需要提示的大版本上失效。
+    """
+    parts: list[int] = []
+    for chunk in str(value).strip().split("."):
+        match = re.match(r"^\d+", chunk)
+        if not match:
+            break
+        parts.append(int(match.group()))
+    return tuple(parts)
+
+
 def _check_update_async() -> None:
     """后台检查 PyPI 最新版本，有新版则打印提示。"""
     import threading
@@ -87,8 +103,10 @@ def _check_update_async() -> None:
             latest = data.get("info", {}).get("version", "")
             if not latest or latest == local_ver:
                 return
-            local_parts = tuple(int(x) for x in local_ver.split("."))
-            latest_parts = tuple(int(x) for x in latest.split("."))
+            local_parts = _version_sort_key(local_ver)
+            latest_parts = _version_sort_key(latest)
+            if not local_parts or not latest_parts:
+                return
             if latest_parts > local_parts:
                 print(f"\033[33m⬆ 新版本可用: {latest}（当前 {local_ver}），运行 wyckoff update 升级\033[0m")
         except Exception:

--- a/cli/dashboard_html.py
+++ b/cli/dashboard_html.py
@@ -650,7 +650,7 @@ async function renderChatSession(c,sid){
   const fullMessages=meta.messages||[];
   const systemPrompt=meta.system_prompt||'';
   const toolSchemas=meta.tools||[];
-  const thinkingRounds=(meta.rounds_detail||[]).filter(r=>r&&r.thinking).map(r=>({round:r.round,thinking:r.thinking}));
+  const thinkingRounds=(meta.rounds_detail||[]).filter(r=>r&&r.thinking).map(r=>({round:r.round,thinking:r.thinking,truncated:!!r.thinking_truncated}));
   const inputBrief={role:selTrace?.user?.role||'user',content:selTrace?.user?.content||''};
   const outputBrief={role:'assistant',content:(selTrace?.assistant?.content||'').slice(0,500),model:selLog?.model||'',tokens_in:selLog?.tokens_in||0,tokens_out:selLog?.tokens_out||0};
   c.innerHTML=`<div class="fade-in" style="display:flex;height:calc(100vh - 120px);gap:0;border:1px solid var(--border);border-radius:8px;overflow:hidden;background:var(--bg2)">
@@ -728,7 +728,7 @@ async function renderChatSession(c,sid){
       ${thinkingRounds.length?`<details style="margin-bottom:12px"><summary class="summary-row"><span>Thinking (${thinkingRounds.length})</span></summary>
         <div style="padding:12px 0">${thinkingRounds.map(r=>`<div style="margin-bottom:8px">
           <div style="font-size:10px;color:var(--text-dim);margin-bottom:4px">round ${r.round}</div>
-          <pre class="code-panel" style="font-size:11px;color:var(--text2);max-height:240px;white-space:pre-wrap">${escHtml(r.thinking)}</pre>
+          <pre class="code-panel" style="font-size:11px;color:var(--text2);max-height:240px;white-space:pre-wrap">${escHtml(r.thinking)}${r.truncated?'\n… (已截断)':''}</pre>
         </div>`).join('')}</div></details>`:''}
       ${toolSpans.length?`<details open style="margin-bottom:12px"><summary class="summary-row"><span>Spans (${toolSpans.length})</span></summary>
         <div style="padding:12px 0">${toolSpans.map(sp=>{

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -1429,6 +1429,9 @@ def _build_rounds_detail(
         }
         if thinking := (round_thinking or {}).get(round_number, ""):
             detail["thinking"] = thinking[:_PERSISTED_THINKING_MAX_CHARS]
+            # 与工具结果一致地标注截断：思维链被无声切断时，读者会把残句当成模型的真实结论。
+            if len(thinking) > _PERSISTED_THINKING_MAX_CHARS:
+                detail["thinking_truncated"] = True
         details.append(detail)
     return details
 
@@ -1885,10 +1888,12 @@ def detect_os_dark_mode() -> bool:
         try:
             import subprocess
 
+            # 必须带 timeout：这是启动路径上的同步调用，defaults 卡住会把整个 TUI 挂在黑屏上
             res = subprocess.run(
                 ["defaults", "read", "-g", "AppleInterfaceStyle"],
                 capture_output=True,
                 text=True,
+                timeout=2,
             )
             return "Dark" in res.stdout
         except Exception:
@@ -1999,6 +2004,65 @@ class WyckoffTUI(App):
             )
         yield StatusBar(self._build_status_text(), id="status-bar")
 
+    def _update_console_markdown_theme(self, name: str) -> None:
+        """动态适配 Markdown 渲染样式，绝不在透明/浅色模式下硬加纯黑底色框。"""
+        from rich.style import Style
+        from rich.theme import Theme
+
+        name_lower = name.strip().lower()
+
+        if name_lower in ("transparent", "terminal"):
+            md_styles = {
+                "markdown.h1": Style(color="cyan", bold=True),
+                "markdown.h2": Style(color="cyan", bold=True),
+                "markdown.h3": Style(color="cyan", bold=True),
+                "markdown.h4": Style(color="cyan", bold=True),
+                "markdown.h5": Style(color="cyan", bold=True),
+                "markdown.h6": Style(color="cyan", bold=True),
+                "markdown.link": Style(color="blue", underline=True),
+                "markdown.code": Style(color="magenta", bold=True),
+                "markdown.block_quote": Style(dim=True, italic=True),
+                "markdown.hr": Style(dim=True),
+                "markdown.item.bullet": Style(color="cyan"),
+            }
+        elif name_lower in ("solarized-light", "atom-one-light", "light", "github-light"):
+            md_styles = {
+                "markdown.h1": Style(color="#0550ae", bold=True),
+                "markdown.h2": Style(color="#0550ae", bold=True),
+                "markdown.h3": Style(color="#0550ae", bold=True),
+                "markdown.h4": Style(color="#0550ae", bold=True),
+                "markdown.h5": Style(color="#0550ae", bold=True),
+                "markdown.h6": Style(color="#0550ae", bold=True),
+                "markdown.link": Style(color="#0969da", underline=True),
+                "markdown.code": Style(color="#cf222e", bold=True),
+                "markdown.block_quote": Style(color="#57606a", italic=True),
+                "markdown.hr": Style(color="#d0d7de"),
+                "markdown.item.bullet": Style(color="#0550ae"),
+            }
+        else:
+            md_styles = {
+                "markdown.h1": Style(color="#8aa4ff", bold=True),
+                "markdown.h2": Style(color="#8aa4ff", bold=True),
+                "markdown.h3": Style(color="#8aa4ff", bold=True),
+                "markdown.h4": Style(color="#8aa4ff", bold=True),
+                "markdown.h5": Style(color="#8aa4ff", bold=True),
+                "markdown.h6": Style(color="#8aa4ff", bold=True),
+                "markdown.link": Style(color="#58a6ff", underline=True),
+                "markdown.code": Style(color="#e06c75", bold=True),
+                "markdown.block_quote": Style(color="#8b949e", italic=True),
+                "markdown.hr": Style(color="#30363d"),
+                "markdown.item.bullet": Style(color="#8aa4ff"),
+            }
+
+        with contextlib.suppress(Exception):
+            # 先弹掉上一次压入的：push_theme 是压栈而非替换，每切一次主题栈就长一层，
+            # 反复切主题会把这些字典一直留在 console 上。
+            if getattr(self, "_md_theme_pushed", False):
+                self.console.pop_theme()
+                self._md_theme_pushed = False
+            self.console.push_theme(Theme(md_styles))
+            self._md_theme_pushed = True
+
     def apply_theme_setting(self, name: str) -> str:
         """根据主题名称生效对应的色彩与 CSS 类。"""
         normalized = name.strip().lower()
@@ -2012,10 +2076,11 @@ class WyckoffTUI(App):
             with contextlib.suppress(Exception):
                 self.screen.remove_class(cls_name)
 
+        res = ""
         if normalized in ("transparent", "terminal"):
             self.theme = "textual-dark"
             _add_cls("transparent")
-            return "transparent"
+            res = "transparent"
         elif normalized == "auto":
             is_dark = detect_os_dark_mode()
             target = "transparent" if is_dark else "solarized-light"
@@ -2024,16 +2089,19 @@ class WyckoffTUI(App):
             _rm_cls("transparent")
             if normalized in self.available_themes:
                 self.theme = normalized
-                return normalized
+                res = normalized
             elif normalized in ("light", "github-light"):
                 self.theme = "solarized-light"
-                return "solarized-light"
+                res = "solarized-light"
             elif normalized in ("dark", "black"):
                 self.theme = "textual-dark"
-                return "textual-dark"
+                res = "textual-dark"
             else:
                 self.theme = "textual-dark"
-                return "textual-dark"
+                res = "textual-dark"
+
+        self._update_console_markdown_theme(res)
+        return res
 
     def on_mount(self) -> None:
         # 加载保存的主题
@@ -2046,26 +2114,6 @@ class WyckoffTUI(App):
         except Exception:
             logger.debug("load saved theme failed", exc_info=True)
 
-        # Override console theme to make Markdown clean and beautiful
-        from rich.style import Style
-        from rich.theme import Theme
-
-        custom_theme = Theme(
-            {
-                "markdown.h1": Style(color="#8aa4ff", bold=True),
-                "markdown.h2": Style(color="#8aa4ff", bold=True),
-                "markdown.h3": Style(color="#8aa4ff", bold=True),
-                "markdown.h4": Style(color="#8aa4ff", bold=True),
-                "markdown.h5": Style(color="#8aa4ff", bold=True),
-                "markdown.h6": Style(color="#8aa4ff", bold=True),
-                "markdown.link": Style(color="#58a6ff", underline=True),
-                "markdown.code": Style(color="#e06c75", bgcolor="#1e1e1e"),
-                "markdown.block_quote": Style(color="#8b949e", italic=True),
-                "markdown.hr": Style(color="#30363d"),
-                "markdown.item.bullet": Style(color="#8aa4ff"),
-            }
-        )
-        self.console.push_theme(custom_theme)
         self.set_interval(0.1, self._tick_global_spinner)
 
         log = self.query_one("#chat-log", ChatLog)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "youngcan-wyckoff-analysis"
-version = "0.9.158"
+version = "0.9.234"
 requires-python = ">=3.11"
 description = "Wyckoff method quantitative analysis system for A-shares, Hong Kong stocks, and US stocks"
 readme = "README.md"

--- a/tests/cli/test_tui_rendering.py
+++ b/tests/cli/test_tui_rendering.py
@@ -1823,6 +1823,26 @@ def test_build_rounds_detail_records_thinking_per_round():
     assert details[0]["thinking"] == "先看持仓再判断风险"
     assert details[0]["stop_reason"] == "tool_use"
     assert "thinking" not in details[1]
+    assert "thinking_truncated" not in details[0]
+
+
+def test_build_rounds_detail_marks_truncated_thinking():
+    """超长思维链必须标注截断——残句被当成模型的完整结论会误导复盘。"""
+    from cli.tui import _PERSISTED_THINKING_MAX_CHARS, _build_rounds_detail
+
+    long_thinking = "推" * (_PERSISTED_THINKING_MAX_CHARS + 500)
+    details = _build_rounds_detail(
+        1,
+        {1: {"input_tokens": 10}},
+        {},
+        {},
+        0.0,
+        "gpt-test",
+        {1: long_thinking},
+    )
+
+    assert len(details[0]["thinking"]) == _PERSISTED_THINKING_MAX_CHARS
+    assert details[0]["thinking_truncated"] is True
 
 
 def test_display_workflow_plan_event_hides_internal_provenance_by_default():

--- a/tests/cli/test_tui_theme.py
+++ b/tests/cli/test_tui_theme.py
@@ -27,6 +27,24 @@ def test_detect_os_dark_mode_mac():
             assert detect_os_dark_mode() is False
 
 
+def test_detect_os_dark_mode_mac_bounds_the_subprocess():
+    """这是启动路径上的同步调用，必须带 timeout，否则 defaults 卡住会把 TUI 挂在黑屏上。"""
+    with patch("sys.platform", "darwin"):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "Dark"
+            detect_os_dark_mode()
+
+    assert mock_run.call_args.kwargs["timeout"] == 2
+
+
+def test_detect_os_dark_mode_mac_falls_back_on_timeout():
+    import subprocess
+
+    with patch("sys.platform", "darwin"):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("defaults", 2)):
+            assert detect_os_dark_mode() is True
+
+
 def test_detect_os_dark_mode_win():
     with patch("sys.platform", "win32"):
         mock_winreg = MagicMock()
@@ -60,6 +78,30 @@ def test_apply_theme_setting_auto():
     with patch("cli.tui.detect_os_dark_mode", return_value=False):
         res = app.apply_theme_setting("auto")
         assert res == "solarized-light"
+
+
+def test_markdown_code_style_has_no_hardcoded_background():
+    """浅色/透明主题下给代码片段硬加纯黑底色，在浅色终端上是一块突兀的黑斑。"""
+    for name in ("transparent", "solarized-light", "light", "dracula"):
+        app = WyckoffTUI()
+        with patch.object(app, "console", MagicMock()) as console:
+            app.apply_theme_setting(name)
+
+        theme = console.push_theme.call_args.args[0]
+        assert theme.styles["markdown.code"].bgcolor is None, name
+
+
+def test_markdown_theme_does_not_grow_the_console_theme_stack():
+    """push_theme 是压栈而非替换，反复切主题不能让 console 上的主题栈无限变高。"""
+    app = WyckoffTUI()
+    with patch.object(app, "console", MagicMock()) as console:
+        app.apply_theme_setting("dracula")
+        app.apply_theme_setting("light")
+        app.apply_theme_setting("transparent")
+
+    # 第一次只压不弹，之后每次都先弹掉自己上一次压入的。
+    assert console.push_theme.call_count == 3
+    assert console.pop_theme.call_count == 2
 
 
 def test_handle_theme_cmd_list():

--- a/tests/cli/test_version_check.py
+++ b/tests/cli/test_version_check.py
@@ -1,0 +1,38 @@
+"""Unit tests for the CLI update-notice version comparison."""
+
+from __future__ import annotations
+
+import pytest
+
+from cli.__main__ import _version_sort_key
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("0.9.234", (0, 9, 234)),
+        ("0.10.0", (0, 10, 0)),
+        ("1.0.0", (1, 0, 0)),
+        # 非纯数字后缀原先会让 int() 抛 ValueError，升级提示随之静默失效
+        ("1.0.0rc1", (1, 0, 0)),
+        ("0.9.235.post1", (0, 9, 235)),
+        ("  0.9.234  ", (0, 9, 234)),
+    ],
+)
+def test_version_sort_key_parses_pypi_shapes(value: str, expected: tuple[int, ...]) -> None:
+    assert _version_sort_key(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "garbage", "vNext", "."])
+def test_version_sort_key_returns_empty_for_unparseable(value: str) -> None:
+    """无法解析时返回空元组，让调用方跳过比较而不是拿残缺版本号误报。"""
+    assert _version_sort_key(value) == ()
+
+
+def test_version_sort_key_orders_prerelease_above_current_patch() -> None:
+    """1.0.0rc1 必须被认成比 0.9.234 新——大版本恰恰是最需要提示的时候。"""
+    assert _version_sort_key("1.0.0rc1") > _version_sort_key("0.9.234")
+
+
+def test_version_sort_key_does_not_flag_older_release() -> None:
+    assert not _version_sort_key("0.9.200") > _version_sort_key("0.9.234")


### PR DESCRIPTION
## 变更摘要

四个 TUI 缺陷，都是「不会报错、只会静默变坏」那一类：

1. **升级提示静默失效**（`cli/__main__.py`）
   `_check_update_async` 直接对版本号每段做 `int()`，PyPI 一旦出现 `1.0.0rc1`、
   `0.9.235.post1` 这类非纯数字版本就抛 `ValueError`，被外层 `except` 吞掉，
   升级提示从此不再出现——而且正好在最需要提示的大版本发布上失效。
   抽出 `_version_sort_key()` 做容错解析，解析不出来就跳过比较而不是崩掉。

2. **思维链无声截断**（`cli/tui.py`、`cli/dashboard_html.py`）
   `_build_rounds_detail` 把 thinking 截到 `_PERSISTED_THINKING_MAX_CHARS`
   却不留任何痕迹，而工具结果一直是有 `result_truncated` 标记的。复盘时
   读者会把一句残句当成模型的完整结论。补 `thinking_truncated`，dashboard
   渲染 `… (已截断)`。

3. **启动路径上的无界 subprocess**（`cli/tui.py`）
   `detect_os_dark_mode()` 里的 `defaults read` 没有 timeout，而它是启动时
   的同步调用。`defaults` 卡住 → 整个 TUI 挂在黑屏上，没有任何输出。
   加 `timeout=2`，超时按深色兜底。

4. **Markdown 代码片段硬编码黑底**（`cli/tui.py`）
   `markdown.code` 写死 `bgcolor="#1e1e1e"`，在浅色和透明终端上是一块突兀的
   黑斑。改成随主题切换。同时修掉 `_update_console_markdown_theme` 只压不弹：
   `push_theme` 是压栈而非替换，反复切主题会让 console 上的主题栈一直变高。

另外把 `pyproject.toml` 的版本号从 `0.9.158` 对齐到已发布的 `0.9.234`。发布
脚本用 `max(repo, pypi) + 1` 且不回写，所以仓库版本落后不影响发布，但
`--version` 和 TUI 欢迎面板会报一个落后 76 个版本的数字。

## 验证

- `pytest` — 2385 passed（新增 17 个用例）
- `ruff check .` — All checks passed
- `ruff format --check .` — 654 files already formatted
- 新增覆盖：`_version_sort_key` 的各种版本形态与不可解析输入、截断标记、
  `defaults` 的 timeout 与超时兜底、四个主题下 `markdown.code` 不带底色、
  连续切主题不涨主题栈
