### PR TITLE
fix(workflow): 超时不再冒充用户决定，planner 补上对话历史，写入请求不再误入 workflow

### DIFF
--- a/cli/tools.py
+++ b/cli/tools.py
@@ -614,6 +614,9 @@ def is_concurrency_safe(name: str) -> bool:
     return bool(spec and spec.concurrency_safe)
 
 
+ASK_USER_TIMEOUT_SENTINEL = "__ask_user_question_timeout__"
+
+
 def ask_user_question(
     question: str,
     options: list[str] | None = None,
@@ -627,6 +630,17 @@ def ask_user_question(
     if registry and getattr(registry, "_ask_user_question_callback", None):
         try:
             answer = registry._ask_user_question_callback(question, options, allow_free_text, default_answer)
+            if answer == ASK_USER_TIMEOUT_SENTINEL:
+                # 超时不是答复：原先它会以 status="answered" 返回「已超时未作答」这句话本身，
+                # 模型只能把这句话当成用户的回答内容继续往下推理。
+                return {
+                    "status": "timeout",
+                    "error": (
+                        "提问等待超时，用户没有作答——这既不是答复也不是拒绝。"
+                        "不要把超时当成用户的回答内容，也不要重复追问同一个问题；"
+                        "请直接说明未收到答复以及需要用户补充什么。"
+                    ),
+                }
             return {"status": "answered", "answer": answer, "result": f"用户已答复: {answer}"}
         except Exception as e:
             logger.error("ask_user_question_callback failed", exc_info=True)
@@ -917,6 +931,16 @@ class ToolRegistry:
             }
         confirm = self._confirm_callback(name, args)
         action = confirm.get("action", "deny")
+        if action == "timeout":
+            # 超时和明确拒绝必须分开：说成「用户拒绝」等于伪造一件没发生的事，模型只能照着
+            # 这个措辞往下写，用户会在回复里读到自己从没做过的决定。
+            return args, {
+                "error": (
+                    f"操作 [{name}] 的确认弹窗等待超时，用户没有做出选择——这不是拒绝。"
+                    "不要声称用户拒绝或取消了操作。请说明确认超时、该操作尚未执行，"
+                    "并让用户确认后重试。"
+                )
+            }
         if action == "deny":
             return args, {"error": "用户拒绝执行此操作"}
         if action == "always":

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -4327,6 +4327,10 @@ class WyckoffTUI(App):
     ) -> None:
         if not notify_followup:
             return
+        if status == "completed":
+            # 成功时不再追加一轮：final_text 已经显示、已经落库、也已经进了 _messages，
+            # 模型下一轮本来就看得到。再叫它就同一份结果说一次，只会得到一段和上一条重复的话。
+            return
         summary = _background_task_summary("dynamic_workflow", task_id, result)
         self._queue.append(
             _system_notification_queue_item(_workflow_background_notification(task_id, result, status, summary))

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -2187,7 +2187,10 @@ class WyckoffTUI(App):
             self.push_screen(ToolConfirmScreen(name, args, display), _on_dismiss)
 
         self.call_from_thread(_show)
-        event.wait(timeout=120)
+        if not event.wait(timeout=120):
+            # 沉默不是否决：超时必须和 deny 区分开，否则模型会告诉用户「你拒绝了」，
+            # 而用户只是没看见弹窗。
+            return {"action": "timeout"}
         return result[0] or {"action": "deny"}
 
     def _request_user_question(
@@ -2212,9 +2215,14 @@ class WyckoffTUI(App):
                 self.query_one("#chat-input", ChatInput).focus()
 
         self.call_from_thread(_show)
-        event.wait(timeout=300)  # 等待最长 5 分钟
+        answered = event.wait(timeout=300)  # 等待最长 5 分钟
         self.call_from_thread(self._clear_pending_user_question, pending)
-        return result[0] or default_answer or "已超时未作答"
+        if not answered and not default_answer:
+            from cli.tools import ASK_USER_TIMEOUT_SENTINEL
+
+            # 用哨兵而不是「已超时未作答」这类自然语言：后者会被当成用户真的这么回答了。
+            return ASK_USER_TIMEOUT_SENTINEL
+        return result[0] or default_answer
 
     def _clear_pending_user_question(self, pending: _PendingUserQuestion) -> None:
         if self._pending_user_question is pending:

--- a/cli/workflows/_shared.py
+++ b/cli/workflows/_shared.py
@@ -64,6 +64,48 @@ def compact_text(value: Any) -> str:
     return re.sub(r"[\s。！!,.，、？?]+", "", str(value or "").lower())
 
 
+def recent_dialogue_context(
+    messages: list[dict[str, Any]] | None,
+    current_user_text: str,
+    *,
+    max_messages: int,
+    max_chars: int,
+) -> str:
+    """Render the tail of the dialogue for routing / planning prompts.
+
+    Router 和 planner 必须看同一份历史。两边各写一份实现，就会出现路由知道「继续录入」是
+    承接上一轮、而 planner 完全不知道上一轮说了什么的信息量断层。
+    """
+    if not messages:
+        return ""
+    lines: list[str] = []
+    skipped_current = False
+    for message in reversed(messages):
+        role = str(message.get("role") or "").strip()
+        if role not in {"user", "assistant"}:
+            continue
+        text = dialogue_message_text(message)
+        if not text:
+            continue
+        if not skipped_current and role == "user" and text == current_user_text:
+            skipped_current = True
+            continue
+        label = "用户" if role == "user" else "助手"
+        clipped = text[:max_chars] + ("..." if len(text) > max_chars else "")
+        lines.append(f"{label}: {clipped}")
+        if len(lines) >= max_messages:
+            break
+    return "\n".join(reversed(lines))
+
+
+def dialogue_message_text(message: dict[str, Any]) -> str:
+    """Flatten one message to a single whitespace-normalised line."""
+    raw = message.get("_raw_content") or message.get("content") or ""
+    if isinstance(raw, list):
+        raw = " ".join(str(item) for item in raw)
+    return " ".join(str(raw).split())
+
+
 def collect_stream_text(chunks: Any) -> str:
     """Concatenate text_delta chunks from a streaming provider response."""
     parts: list[str] = []

--- a/cli/workflows/dispatch.py
+++ b/cli/workflows/dispatch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 from cli.runtime import AgentRuntime
@@ -10,6 +11,7 @@ from cli.scratchpad import AgentScratchpad
 from cli.workflows.executor import WorkflowExecutor
 from cli.workflows.model_router import route_workflow_with_model
 from cli.workflows.models import WorkflowContext
+from cli.workflows.router import WORKFLOWS
 
 _DIRECT_TOOL_ORDER = (
     "search_stock_by_name",
@@ -58,32 +60,75 @@ def build_turn_runtime(
 
     workflow = workflow_context or route_workflow_with_model(user_text, provider, routing_messages)
     if workflow.is_general and not workflow_script:
-        kwargs: dict[str, Any] = {
-            "scratchpad": scratchpad,
-            "cancel_check": cancel_check,
-            "allowed_tools": infer_direct_allowed_tools(user_text),
-            "enforce_turn_expectations": _direct_turn_expectations_default(enforce_turn_expectations),
-        }
-        if stream_chunk_timeout is not None:
-            kwargs["stream_chunk_timeout"] = stream_chunk_timeout
-        return AgentRuntime(provider, tools, **kwargs), workflow
-    return (
-        WorkflowExecutor(
+        return _direct_runtime(
             provider,
             tools,
-            session_id=session_id,
             user_text=user_text,
             scratchpad=scratchpad,
             cancel_check=cancel_check,
             stream_chunk_timeout=stream_chunk_timeout,
-            workflow_context=workflow,
-            workflow_script=workflow_script,
-            source_run_id=workflow_source_run_id,
-            workflow_args=workflow_args,
-            only_step_id=workflow_only_step_id,
-            planning_messages=routing_messages,
-        ),
-        workflow,
+            enforce_turn_expectations=enforce_turn_expectations,
+        ), workflow
+    executor = WorkflowExecutor(
+        provider,
+        tools,
+        session_id=session_id,
+        user_text=user_text,
+        scratchpad=scratchpad,
+        cancel_check=cancel_check,
+        stream_chunk_timeout=stream_chunk_timeout,
+        workflow_context=workflow,
+        workflow_script=workflow_script,
+        source_run_id=workflow_source_run_id,
+        workflow_args=workflow_args,
+        only_step_id=workflow_only_step_id,
+        planning_messages=routing_messages,
+    )
+    if workflow_script or workflow_only_step_id:
+        # 用户显式重放/续跑某个 script 时不做交还：他要的就是这份计划。
+        return executor, workflow
+    if handoff := executor.plan_handoff_reason():
+        # planner 看过工具摘要后说这轮它办不成。这里落回 direct 只花一次规划调用，
+        # 继续跑要几分钟并交付用户没要的东西。
+        return _direct_runtime(
+            provider,
+            tools,
+            user_text=user_text,
+            scratchpad=scratchpad,
+            cancel_check=cancel_check,
+            stream_chunk_timeout=stream_chunk_timeout,
+            enforce_turn_expectations=enforce_turn_expectations,
+        ), _handoff_workflow_context(workflow, handoff)
+    return executor, workflow
+
+
+def _direct_runtime(
+    provider: Any,
+    tools: Any,
+    *,
+    user_text: str,
+    scratchpad: AgentScratchpad | None,
+    cancel_check: Callable[[], bool] | None,
+    stream_chunk_timeout: float | None,
+    enforce_turn_expectations: bool | None,
+) -> AgentRuntime:
+    kwargs: dict[str, Any] = {
+        "scratchpad": scratchpad,
+        "cancel_check": cancel_check,
+        "allowed_tools": infer_direct_allowed_tools(user_text),
+        "enforce_turn_expectations": _direct_turn_expectations_default(enforce_turn_expectations),
+    }
+    if stream_chunk_timeout is not None:
+        kwargs["stream_chunk_timeout"] = stream_chunk_timeout
+    return AgentRuntime(provider, tools, **kwargs)
+
+
+def _handoff_workflow_context(workflow: WorkflowContext, reason: str) -> WorkflowContext:
+    return replace(
+        WORKFLOWS["general_chat"],
+        route_reason=f"planner 交还直接对话：{reason}（原路由：{workflow.route_reason}）",
+        route_confidence=workflow.route_confidence,
+        route_matches=(*workflow.route_matches, "planner_handoff"),
     )
 
 

--- a/cli/workflows/dispatch.py
+++ b/cli/workflows/dispatch.py
@@ -81,6 +81,7 @@ def build_turn_runtime(
             source_run_id=workflow_source_run_id,
             workflow_args=workflow_args,
             only_step_id=workflow_only_step_id,
+            planning_messages=routing_messages,
         ),
         workflow,
     )

--- a/cli/workflows/executor.py
+++ b/cli/workflows/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import time
@@ -40,6 +41,7 @@ from cli.workflows.planner import (
     adapt_workflow_script,
     plan_workflow,
     revise_workflow_script,
+    script_handoff_reason,
     workflow_steps_from_script,
 )
 from cli.workflows.store import append_workflow_event, persist_workflow_script, save_workflow_run
@@ -49,6 +51,8 @@ from core.candidate_ranker import TRIGGER_SHORT_LABELS
 from core.strategy_policy_display import policy_execution_mode_label, policy_next_action_label
 from utils.safe import drop_empty as _drop_empty
 from utils.tool_result_preview import tool_result_brief_lines
+
+logger = logging.getLogger(__name__)
 
 _AGENTS: dict[str, SubAgent] = {
     "task": WORKFLOW_TASK_AGENT,
@@ -235,9 +239,41 @@ class WorkflowExecutor:
         self.only_step_id = only_step_id
         self._stopped = False
         self.run: WorkflowRun | None = None
+        # plan_handoff_reason() 会先把 run 规划出来但不落库，所以「已规划」和「已落库」得分开记。
+        self._persisted_run = False
 
     def set_control(self, control: WorkflowControl | None) -> None:
         self.workflow_control = control
+
+    def plan_handoff_reason(self) -> str:
+        """Plan this turn and report why the planner declined to orchestrate it, if it did.
+
+        规划结果会缓存到 self.run，交还与继续执行都不会多花一次规划调用。交还时不落库：
+        一次没跑过任何 step 的 run 写进 workflow_run 只会让历史里多一条噪音。
+        """
+
+        try:
+            run = self._planned_run()
+        except Exception:
+            logger.debug("workflow handoff planning failed", exc_info=True)
+            return ""
+        return script_handoff_reason(run.script)
+
+    def _planned_run(self) -> WorkflowRun:
+        if self.run is None:
+            self.run = plan_workflow(
+                self.user_text,
+                session_id=self.session_id,
+                context=self.workflow_context,
+                provider=self.provider,
+                tools=self.tools,
+                workflow_script=self.workflow_script,
+                source_run_id=self.source_run_id,
+                workflow_args=self.workflow_args,
+                only_step_id=self.only_step_id,
+                messages=self.planning_messages,
+            )
+        return self.run
 
     def prepare_run(self) -> RuntimeEvent:
         self._plan_run(PENDING)
@@ -275,6 +311,7 @@ class WorkflowExecutor:
         )
         self.run.run_id = old_run_id
         self.run.status = PENDING
+        self._persisted_run = True
         persist_workflow_script(self.run)
         save_workflow_run(self.run)
         payload = self._plan_event()
@@ -283,7 +320,9 @@ class WorkflowExecutor:
 
     def run_stream(self, messages: list[dict[str, Any]], system_prompt: str = "") -> Iterator[RuntimeEvent]:
         started_at = time.monotonic()
-        if self.run is None:
+        if not self._persisted_run:
+            # 判据是「计划公布过没有」而不是「规划过没有」：plan_handoff_reason() 会先规划但不落库，
+            # 按 self.run is None 判会把这一轮的 workflow_plan 事件整个跳掉。
             self._plan_run(RUNNING)
             yield self._plan_event()
         else:
@@ -340,25 +379,16 @@ class WorkflowExecutor:
         }
 
     def _plan_run(self, status: str) -> None:
-        if self.run is not None:
-            self.run.status = status
-            save_workflow_run(self.run)
+        if self._persisted_run:
+            run = self._require_run()
+            run.status = status
+            save_workflow_run(run)
             return
-        self.run = plan_workflow(
-            self.user_text,
-            session_id=self.session_id,
-            context=self.workflow_context,
-            provider=self.provider,
-            tools=self.tools,
-            workflow_script=self.workflow_script,
-            source_run_id=self.source_run_id,
-            workflow_args=self.workflow_args,
-            only_step_id=self.only_step_id,
-            messages=self.planning_messages,
-        )
-        self.run.status = status
-        persist_workflow_script(self.run)
-        save_workflow_run(self.run)
+        run = self._planned_run()
+        run.status = status
+        self._persisted_run = True
+        persist_workflow_script(run)
+        save_workflow_run(run)
 
     def _plan_event(self) -> RuntimeEvent:
         run = self._require_run()
@@ -646,13 +676,14 @@ class WorkflowExecutor:
         return self._require_run().step_payload(step)
 
     def _synthesize_results(self, results: list[dict[str, Any]], system_prompt: str) -> tuple[str, dict[str, int]]:
-        prompt = _synthesis_prompt(self._require_run(), results)
+        run = self._require_run()
+        prompt = _synthesis_prompt(run, results)
         fallback_text = _fallback_summary(results)
         try:
             text, usage = _collect_synthesis(self.provider, prompt, system_prompt, fallback_text=fallback_text)
         except Exception:
             text, usage = fallback_text, {"input_tokens": 0, "output_tokens": 0}
-        return _ensure_candidate_delivery(text, results), usage
+        return _with_failure_lead(_ensure_candidate_delivery(text, results), run), usage
 
     def _mark_run_done(self, final_text: str) -> RuntimeEvent:
         run = self._require_run()
@@ -747,6 +778,22 @@ def _workflow_adaptation_count(run: WorkflowRun) -> int:
 
 def _workflow_runtime(run: WorkflowRun) -> dict[str, Any]:
     return run.script.get("runtime") if isinstance(run.script.get("runtime"), dict) else {}
+
+
+def _with_failure_lead(text: str, run: WorkflowRun) -> str:
+    """Put failed steps at the top when the run did not fully succeed.
+
+    昊华科技那次 run 是 failed，用户读到的开头却是三条候选结论——候选前插逻辑不看运行状态，
+    真正重要的事实（那一步超时了、清仓没被记录）被埋在后面。失败必须先说。
+    """
+
+    failed = [step for step in run.steps if step.status == FAILED]
+    if not failed:
+        return text
+    titles = ", ".join(_clip(step.title or step.step_id, 40) for step in failed[:4])
+    more = f" 等 {len(failed)} 步" if len(failed) > 4 else ""
+    lead = f"⚠️ 本次 workflow 未完全成功：{len(failed)} 个步骤失败（{titles}{more}）。以下结论缺少这些步骤的事实支撑。"
+    return f"{lead}\n\n{text}" if text.strip() else lead
 
 
 def _empty_workflow_text(run: WorkflowRun) -> str:

--- a/cli/workflows/executor.py
+++ b/cli/workflows/executor.py
@@ -217,11 +217,13 @@ class WorkflowExecutor:
         workflow_args: Any = None,
         workflow_control: WorkflowControl | None = None,
         only_step_id: str = "",
+        planning_messages: list[dict[str, Any]] | None = None,
     ) -> None:
         self.provider = provider
         self.tools = tools
         self.session_id = session_id
         self.user_text = user_text
+        self.planning_messages = planning_messages
         self.scratchpad = scratchpad
         self.cancel_check = cancel_check
         self.stream_chunk_timeout = stream_chunk_timeout
@@ -269,6 +271,7 @@ class WorkflowExecutor:
             source_run_id=self.source_run_id,
             workflow_args=self.workflow_args,
             only_step_id=self.only_step_id,
+            messages=self.planning_messages,
         )
         self.run.run_id = old_run_id
         self.run.status = PENDING
@@ -351,6 +354,7 @@ class WorkflowExecutor:
             source_run_id=self.source_run_id,
             workflow_args=self.workflow_args,
             only_step_id=self.only_step_id,
+            messages=self.planning_messages,
         )
         self.run.status = status
         persist_workflow_script(self.run)

--- a/cli/workflows/model_router.py
+++ b/cli/workflows/model_router.py
@@ -23,6 +23,7 @@ from cli.workflows._shared import (
     dialogue_message_text,
     has_stock_style_target,
     loads_json,
+    parse_confidence,
     provider_chat_response,
     recent_dialogue_context,
 )
@@ -127,6 +128,26 @@ _ACCOUNT_WRITE_MARKERS = (
     "移除持仓",
 )
 _ACCOUNT_WRITE_METHOD_MARKERS = ("怎么", "如何", "方法", "是什么", "什么是", "啥意思", "概念", "解释", "能不能")
+# 进 workflow 的置信度门槛。低于它就落 direct：错判成 direct 只多花几秒，错判成 workflow 要几分钟。
+_WORKFLOW_CONFIDENCE_FLOOR = 0.7
+_LOCAL_WRITE_TOOLS = ("write_file", "exec_command")
+_LOCAL_WRITE_MARKERS = (
+    "写个文件",
+    "写入文件",
+    "改一下文件",
+    "保存到文件",
+    "存成文件",
+    "跑一下命令",
+    "执行命令",
+    "跑个脚本",
+    "执行脚本",
+)
+# 「这一轮需要什么能力」→「哪些工具提供它」。判据是能力集合的差，关键词只用来推断需要哪种能力；
+# 缺哪个工具由目标车道的实时白名单算出来，不写死。
+_CAPABILITY_GROUPS: tuple[tuple[str, tuple[str, ...], tuple[str, ...], tuple[str, ...]], ...] = (
+    ("账户写入", _ACCOUNT_WRITE_TOOLS, _ACCOUNT_WRITE_MARKERS, _ACCOUNT_WRITE_METHOD_MARKERS),
+    ("本地写入/执行", _LOCAL_WRITE_TOOLS, _LOCAL_WRITE_MARKERS, _ACCOUNT_WRITE_METHOD_MARKERS),
+)
 _MODE_ALIASES = {
     "direct": {
         "answer",
@@ -219,7 +240,9 @@ def _context_from_model_decision(decision: dict[str, Any]) -> WorkflowContext:
 
 def _guarded_context_for_model_decision(user_text: str, decision: dict[str, Any]) -> WorkflowContext | None:
     if _should_use_workflow(decision):
-        return _account_write_downgrade_context(user_text, decision)
+        if downgrade := _account_write_downgrade_context(user_text, decision):
+            return downgrade
+        return _low_confidence_downgrade_context(decision)
     if _needs_stock_selection_workflow_fallback(user_text):
         return replace(
             WORKFLOWS["dynamic_task"],
@@ -231,6 +254,30 @@ def _guarded_context_for_model_decision(user_text: str, decision: dict[str, Any]
     return None
 
 
+def _low_confidence_downgrade_context(decision: dict[str, Any]) -> WorkflowContext | None:
+    """Require real confidence to enter workflow, because the two misroutes cost very differently.
+
+    判错成 direct：模型多调一个工具，几秒。判错成 workflow：几分钟、后台执行、计划落库、
+    往对话里插好几个轮次、还可能零产出。confidence 以前算完就落库，dispatch 和 executor
+    一次都没读过——0.2 和 0.9 一样照跑。不确定的时候按便宜的那种错法走。
+    """
+
+    if not decision.get("confidence_reported"):
+        return None
+    confidence = float(decision.get("confidence") or 0.0)
+    if confidence >= _WORKFLOW_CONFIDENCE_FLOOR:
+        return None
+    return replace(
+        WORKFLOWS["general_chat"],
+        route_reason=(
+            f"模型 workflow 判断置信度 {confidence:.2f} 低于门槛 {_WORKFLOW_CONFIDENCE_FLOOR:.2f}，"
+            f"按直接对话处理：{decision['reason']}"
+        ),
+        route_confidence=confidence,
+        route_matches=("model_router_guard", "workflow_confidence_floor"),
+    )
+
+
 def _account_write_downgrade_context(user_text: str, decision: dict[str, Any]) -> WorkflowContext | None:
     """Downgrade to direct chat when the request needs a tool the workflow does not have.
 
@@ -238,40 +285,56 @@ def _account_write_downgrade_context(user_text: str, decision: dict[str, Any]) -
     挡在编排之外。所以「把这两只录进持仓」被判成 workflow 时，它不是跑得慢，是根本干不成：
     最好的结果也只是核对完代码再让用户自己去录。这类请求必须留在 direct agent。
     """
-    missing = _account_write_tools_missing_from_workflow(user_text)
+    capability, missing = missing_workflow_capability(user_text)
     if not missing:
         return None
     return replace(
         WORKFLOWS["general_chat"],
-        route_reason=(f"账户写入请求需要 {', '.join(missing)}，动态 workflow 无此工具；覆盖模型 workflow 判断"),
+        route_reason=(f"{capability}请求需要 {', '.join(missing)}，动态 workflow 无此工具；覆盖模型 workflow 判断"),
         route_confidence=0.7,
         route_matches=("model_router_guard", "account_write_guard"),
     )
 
 
 def _account_write_fallback_context(user_text: str, fallback_reason: str) -> WorkflowContext:
-    missing = ", ".join(_account_write_tools_missing_from_workflow(user_text))
+    capability, missing_tools = missing_workflow_capability(user_text)
+    missing = ", ".join(missing_tools)
     label = _fallback_reason_label(fallback_reason) if fallback_reason else "模型判断"
     return replace(
         WORKFLOWS["general_chat"],
-        route_reason=f"账户写入请求需要 {missing}，动态 workflow 无此工具（{label}），直接 agent 处理",
+        route_reason=f"{capability}请求需要 {missing}，动态 workflow 无此工具（{label}），直接 agent 处理",
         route_confidence=0.7,
         route_matches=("model_router_fallback", "account_write_guard"),
     )
 
 
-def _account_write_tools_missing_from_workflow(user_text: str) -> tuple[str, ...]:
-    if not _looks_like_account_write_request(user_text):
-        return ()
+def missing_workflow_capability(user_text: str) -> tuple[str, tuple[str, ...]]:
+    """Return the capability this turn needs and the tools dynamic_task lacks for it.
+
+    模式决策必须发生在能力校验之后。路由只看语义、不看工具，就会把「录入持仓」这类请求分进一条
+    结构上就干不成的车道——白名单里没有写入工具，最好的结果也只是核对完让用户自己再来一遍。
+    """
+
+    text = _compact_user_text(user_text)
+    if not text:
+        return "", ()
     allowed = set(WORKFLOWS["dynamic_task"].allowed_tools)
-    return tuple(name for name in _ACCOUNT_WRITE_TOOLS if name not in allowed)
+    for label, tool_names, markers, method_markers in _CAPABILITY_GROUPS:
+        if any(marker in text for marker in method_markers):
+            continue
+        if not any(marker in text for marker in markers):
+            continue
+        if missing := tuple(name for name in tool_names if name not in allowed):
+            return label, missing
+    return "", ()
+
+
+def _account_write_tools_missing_from_workflow(user_text: str) -> tuple[str, ...]:
+    return missing_workflow_capability(user_text)[1]
 
 
 def _looks_like_account_write_request(user_text: str) -> bool:
-    text = _compact_user_text(user_text)
-    if not text or any(marker in text for marker in _ACCOUNT_WRITE_METHOD_MARKERS):
-        return False
-    return any(marker in text for marker in _ACCOUNT_WRITE_MARKERS)
+    return bool(_account_write_tools_missing_from_workflow(user_text))
 
 
 def _model_route_reason(decision: dict[str, Any]) -> str:
@@ -420,8 +483,15 @@ def _parse_decision(response: Any) -> dict[str, Any] | None:
     return {
         "mode": mode,
         "confidence": confidence,
+        # 缺字段时 decision_confidence 也返回 0.0，和模型明确报 0.0 分不开。
+        # 置信度门槛只对「真的报了一个低值」生效，不能因为 provider 不输出这个字段就关掉 workflow。
+        "confidence_reported": _decision_reports_confidence(payload),
         "reason": _clean_reason(payload.get("reason")),
     }
+
+
+def _decision_reports_confidence(payload: dict[str, Any]) -> bool:
+    return any(parse_confidence(payload.get(key)) is not None for key in ("confidence", "score", "probability", "prob"))
 
 
 def _router_decision_payload(payload: dict[str, Any]) -> dict[str, Any]:

--- a/cli/workflows/model_router.py
+++ b/cli/workflows/model_router.py
@@ -20,9 +20,11 @@ from cli.workflows._shared import (
     STOCK_STYLE_TARGETS,
     compact_text,
     decision_confidence,
+    dialogue_message_text,
     has_stock_style_target,
     loads_json,
     provider_chat_response,
+    recent_dialogue_context,
 )
 from cli.workflows.models import WorkflowContext
 from cli.workflows.router import WORKFLOWS, route_resume_workflow, route_workflow
@@ -95,6 +97,36 @@ _SHORT_STOCK_SELECTION_RE = re.compile(
     r"(?:选出|挑出|筛出|找(?:几只|几个)?|给我找|帮我找).{0,10}(?:好股票|好票|好标的|值得复核的票|值得跟踪的票)"
 )
 _STOCK_SELECTION_METHOD_MARKERS = ("怎么", "如何", "方法", "是什么", "什么是", "是什么意思", "啥意思", "概念", "解释")
+# 写入账户事实的工具；dynamic_task 白名单里刻意没有它们。
+_ACCOUNT_WRITE_TOOLS = ("update_portfolio", "record_trade_fill")
+_ACCOUNT_WRITE_MARKERS = (
+    "录入",
+    "登记",
+    "记一下",
+    "记下",
+    "加进持仓",
+    "加入持仓",
+    "计入持仓",
+    "写入持仓",
+    "更新持仓",
+    "改持仓",
+    "改一下持仓",
+    "建仓",
+    "补仓",
+    "加仓",
+    "减仓",
+    "清仓",
+    "调仓",
+    "买入了",
+    "卖出了",
+    "已买入",
+    "已卖出",
+    "成交回填",
+    "回填成交",
+    "删掉持仓",
+    "移除持仓",
+)
+_ACCOUNT_WRITE_METHOD_MARKERS = ("怎么", "如何", "方法", "是什么", "什么是", "啥意思", "概念", "解释", "能不能")
 _MODE_ALIASES = {
     "direct": {
         "answer",
@@ -164,6 +196,9 @@ def route_workflow_with_model(
         if guarded := _guarded_context_for_model_decision(user_text, decision):
             return guarded
         return _context_from_model_decision(decision)
+    if _account_write_tools_missing_from_workflow(user_text):
+        # 兜底路径也要挡：显式 workflow 标记和选股兜底都可能把写入请求送进没有写入工具的通道。
+        return _account_write_fallback_context(user_text, fallback_reason)
     if not fallback_context.is_general:
         return _context_with_router_fallback(fallback_context, fallback_reason)
     if guarded := _stock_selection_fallback_context(user_text, fallback_reason):
@@ -184,7 +219,7 @@ def _context_from_model_decision(decision: dict[str, Any]) -> WorkflowContext:
 
 def _guarded_context_for_model_decision(user_text: str, decision: dict[str, Any]) -> WorkflowContext | None:
     if _should_use_workflow(decision):
-        return None
+        return _account_write_downgrade_context(user_text, decision)
     if _needs_stock_selection_workflow_fallback(user_text):
         return replace(
             WORKFLOWS["dynamic_task"],
@@ -194,6 +229,49 @@ def _guarded_context_for_model_decision(user_text: str, decision: dict[str, Any]
         )
     # 组合复盘不再覆盖模型的 direct 判断：模型看得到上下文，比关键词更清楚该不该编排。
     return None
+
+
+def _account_write_downgrade_context(user_text: str, decision: dict[str, Any]) -> WorkflowContext | None:
+    """Downgrade to direct chat when the request needs a tool the workflow does not have.
+
+    workflow 的工具白名单里没有 update_portfolio / record_trade_fill——写入类动作被刻意
+    挡在编排之外。所以「把这两只录进持仓」被判成 workflow 时，它不是跑得慢，是根本干不成：
+    最好的结果也只是核对完代码再让用户自己去录。这类请求必须留在 direct agent。
+    """
+    missing = _account_write_tools_missing_from_workflow(user_text)
+    if not missing:
+        return None
+    return replace(
+        WORKFLOWS["general_chat"],
+        route_reason=(f"账户写入请求需要 {', '.join(missing)}，动态 workflow 无此工具；覆盖模型 workflow 判断"),
+        route_confidence=0.7,
+        route_matches=("model_router_guard", "account_write_guard"),
+    )
+
+
+def _account_write_fallback_context(user_text: str, fallback_reason: str) -> WorkflowContext:
+    missing = ", ".join(_account_write_tools_missing_from_workflow(user_text))
+    label = _fallback_reason_label(fallback_reason) if fallback_reason else "模型判断"
+    return replace(
+        WORKFLOWS["general_chat"],
+        route_reason=f"账户写入请求需要 {missing}，动态 workflow 无此工具（{label}），直接 agent 处理",
+        route_confidence=0.7,
+        route_matches=("model_router_fallback", "account_write_guard"),
+    )
+
+
+def _account_write_tools_missing_from_workflow(user_text: str) -> tuple[str, ...]:
+    if not _looks_like_account_write_request(user_text):
+        return ()
+    allowed = set(WORKFLOWS["dynamic_task"].allowed_tools)
+    return tuple(name for name in _ACCOUNT_WRITE_TOOLS if name not in allowed)
+
+
+def _looks_like_account_write_request(user_text: str) -> bool:
+    text = _compact_user_text(user_text)
+    if not text or any(marker in text for marker in _ACCOUNT_WRITE_METHOD_MARKERS):
+        return False
+    return any(marker in text for marker in _ACCOUNT_WRITE_MARKERS)
 
 
 def _model_route_reason(decision: dict[str, Any]) -> str:
@@ -232,36 +310,16 @@ def _router_user_prompt(user_text: str, messages: list[dict[str, Any]] | None = 
 
 
 def _recent_dialogue_context(messages: list[dict[str, Any]] | None, current_user_text: str) -> str:
-    if not messages:
-        return ""
-    lines: list[str] = []
-    skipped_current = False
-    for message in reversed(messages):
-        role = str(message.get("role") or "").strip()
-        if role not in {"user", "assistant"}:
-            continue
-        text = _routing_message_text(message)
-        if not text:
-            continue
-        if not skipped_current and role == "user" and text == current_user_text:
-            skipped_current = True
-            continue
-        label = "用户" if role == "user" else "助手"
-        lines.append(f"{label}: {_clip_routing_context(text)}")
-        if len(lines) >= _MAX_ROUTING_CONTEXT_MESSAGES:
-            break
-    return "\n".join(reversed(lines))
+    return recent_dialogue_context(
+        messages,
+        current_user_text,
+        max_messages=_MAX_ROUTING_CONTEXT_MESSAGES,
+        max_chars=_MAX_ROUTING_CONTEXT_CHARS,
+    )
 
 
 def _routing_message_text(message: dict[str, Any]) -> str:
-    raw = message.get("_raw_content") or message.get("content") or ""
-    if isinstance(raw, list):
-        raw = " ".join(str(item) for item in raw)
-    return " ".join(str(raw).split())
-
-
-def _clip_routing_context(text: str) -> str:
-    return text[:_MAX_ROUTING_CONTEXT_CHARS] + ("..." if len(text) > _MAX_ROUTING_CONTEXT_CHARS else "")
+    return dialogue_message_text(message)
 
 
 def _context_with_router_fallback(context: WorkflowContext, fallback_reason: str) -> WorkflowContext:

--- a/cli/workflows/planner.py
+++ b/cli/workflows/planner.py
@@ -22,12 +22,17 @@ from cli.workflows._shared import (
     compact_text,
     has_stock_style_target,
     looks_like_portfolio_review,
+    recent_dialogue_context,
 )
 from cli.workflows.models import WorkflowContext, WorkflowRun, WorkflowStep
 from cli.workflows.router import route_workflow
 
 MAX_WORKFLOW_STEPS = 24
 ASK_USER_TOOL = "ask_user_question"
+# 比 router 给得多：planner 要沿用上文里的代码、股数、成本价这类具体事实，
+# 而 router 只需要判断本轮是不是承接。
+_MAX_PLANNER_CONTEXT_MESSAGES = 8
+_MAX_PLANNER_CONTEXT_CHARS = 600
 TASK_LIST_FIELDS = ("tasks", "steps", "items", "subtasks", "jobs", "actions", "plan")
 PHASE_LIST_FIELDS = ("phases", "stages", "stage_groups", "sections", "groups", "milestones")
 SCRIPT_CONTAINER_FIELDS = ("workflow", "workflow_script", "script", "plan")
@@ -287,6 +292,7 @@ def plan_workflow(
     source_run_id: str = "",
     workflow_args: Any = None,
     only_step_id: str = "",
+    messages: list[dict[str, Any]] | None = None,
 ) -> WorkflowRun:
     """Create a model-authored workflow run for one user turn."""
 
@@ -294,7 +300,7 @@ def plan_workflow(
     raw_script = (
         _normalize_supplied_script(workflow_script, source_run_id, workflow_args, only_step_id)
         if workflow_script
-        else _generate_script(user_text, context, provider, tools)
+        else _generate_script(user_text, context, provider, tools, messages)
     )
     steps = _script_steps(raw_script, user_text, context)
     script = _script_with_step_tool_scopes(raw_script, steps)
@@ -730,10 +736,11 @@ def _generate_script(
     context: WorkflowContext,
     provider: Any | None,
     tools: Any | None,
+    messages: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if provider is None:
         return _fallback_script(user_text, context, reason="provider unavailable")
-    prompt = _planner_user_prompt(user_text, context, tools)
+    prompt = _planner_user_prompt(user_text, context, tools, messages)
     try:
         text = _collect_planner_text(provider, prompt)
         script = _normalize_generated_script(_loads_script(text))
@@ -811,15 +818,38 @@ def _tool_contract_repair_prompt(
     )
 
 
-def _planner_user_prompt(user_text: str, context: WorkflowContext, tools: Any | None) -> str:
+def _planner_user_prompt(
+    user_text: str,
+    context: WorkflowContext,
+    tools: Any | None,
+    messages: list[dict[str, Any]] | None = None,
+) -> str:
     catalog = _tool_catalog(tools, context)
     return (
         f"用户请求:\n{user_text}\n\n"
+        f"{_planner_dialogue_block(messages, user_text)}"
         f"运行上下文: {context.label} ({context.name})\n"
         f"路由原因: {context.route_reason or '-'}\n\n"
         f"当前可用工具摘要（供你决定任务边界，不要直接调用）:\n{catalog}\n\n"
         "请生成 workflow JSON。"
     )
+
+
+def _planner_dialogue_block(messages: list[dict[str, Any]] | None, user_text: str) -> str:
+    """Give the planner the same dialogue tail the router already sees.
+
+    没有这段历史，「继续录入」这类承接性请求只能被规划成「先问用户要录入什么」——上一轮
+    刚说过的代码、股数、成本价对 planner 完全不可见，于是它去问用户已经给过的信息。
+    """
+    context = recent_dialogue_context(
+        messages,
+        user_text,
+        max_messages=_MAX_PLANNER_CONTEXT_MESSAGES,
+        max_chars=_MAX_PLANNER_CONTEXT_CHARS,
+    )
+    if not context:
+        return ""
+    return f"最近对话（本轮可能承接上文；上文已给出的事实要直接沿用，不要再问用户一遍）:\n{context}\n\n"
 
 
 def _tool_catalog(tools: Any | None, context: WorkflowContext) -> str:

--- a/cli/workflows/planner.py
+++ b/cli/workflows/planner.py
@@ -29,6 +29,10 @@ from cli.workflows.router import route_workflow
 
 MAX_WORKFLOW_STEPS = 24
 ASK_USER_TOOL = "ask_user_question"
+# planner 唯一的退出通道。没有它，planner 只能在「编不出计划」和「编一个替代任务」之间选后者：
+# 昊华科技那次它自己写明了「当前工具集中没有可写入或更新持仓的工具」，然后照样拆成只读复核跑了 324 秒。
+HANDOFF_FIELD = "handoff"
+HANDOFF_DIRECT = "direct"
 # 比 router 给得多：planner 要沿用上文里的代码、股数、成本价这类具体事实，
 # 而 router 只需要判断本轮是不是承接。
 _MAX_PLANNER_CONTEXT_MESSAGES = 8
@@ -194,6 +198,16 @@ _PLAN_SYSTEM_PROMPT = """\
   "synthesis_prompt": "最终汇总时应该如何整合结果"
 }
 
+如果这一轮根本不该由 workflow 承接，输出交还 JSON，不要硬编一份计划:
+{"handoff":"direct","reason":"简短中文原因，说明为什么 workflow 办不成这件事"}
+
+什么时候交还:
+- 用户要的动作需要写入持仓、回填成交、改文件这类工具，而工具摘要里没有它们——编排拿不到这些工具，
+  拆成「只读复核」并不是用户要的事。
+- 单轮直接对话就能完成，不需要多阶段、并发或持久化计划。
+- 请求指向的对象/动作还不明确，需要先问用户一句，而不是先跑一串任务。
+交还比编一个替代任务好：交还只花几秒就回到直接对话，替代任务要跑几分钟、还交付了用户没要的东西。
+
 运行边界:
 - 只输出 JSON，不要 Markdown，不要代码块。
 - phases 总任务数 1-24 个；如果要处理很多股票或对象，用工具批量处理，不要为每个对象单独生成 task。
@@ -302,6 +316,17 @@ def plan_workflow(
         if workflow_script
         else _generate_script(user_text, context, provider, tools, messages)
     )
+    if script_handoff_reason(raw_script):
+        # 交还必须绕开 _script_steps：那里对空 phases 的处理是兜底生成一个 task，
+        # 正好会把交还重新变成一份要跑的计划。
+        return WorkflowRun(
+            run_id=f"wf_{uuid.uuid4().hex[:12]}",
+            session_id=session_id,
+            user_text=user_text,
+            context=context,
+            steps=[],
+            script=raw_script,
+        )
     steps = _script_steps(raw_script, user_text, context)
     script = _script_with_step_tool_scopes(raw_script, steps)
     return WorkflowRun(
@@ -748,6 +773,9 @@ def _generate_script(
         return _fallback_script(user_text, context, reason=f"planner failed: {exc}")
     if not isinstance(script, dict):
         return _fallback_script(user_text, context, reason="planner returned non-object JSON")
+    if reason := script_handoff_reason(script):
+        # 交还不走 repair/limit：那两步是给「有任务的计划」补工具契约的，会把交还改回一份计划。
+        return _handoff_script(reason)
     script = _mark_model_script(_limit_generated_script(script))
     return _repair_model_tool_contract(user_text, context, provider, tools, script)
 
@@ -934,6 +962,27 @@ def _loads_repair_script(text: str) -> Any:
         if not match:
             raise
         return json.loads(match.group(0))
+
+
+def script_handoff_reason(script: Any) -> str:
+    """Return the planner's handoff reason when it declined to orchestrate this turn."""
+
+    if not isinstance(script, dict):
+        return ""
+    if str(script.get(HANDOFF_FIELD) or "").strip().lower() != HANDOFF_DIRECT:
+        return ""
+    reason = " ".join(str(script.get("reason") or script.get("rationale") or "").split())
+    return reason or "planner 判断本轮不适合 workflow"
+
+
+def _handoff_script(reason: str) -> dict[str, Any]:
+    return {
+        HANDOFF_FIELD: HANDOFF_DIRECT,
+        "reason": reason,
+        "title": "交还直接对话",
+        "phases": [],
+        "runtime": {"planner": "model_handoff"},
+    }
 
 
 def _normalize_generated_script(script: Any) -> Any:

--- a/tests/cli/test_tool_specs.py
+++ b/tests/cli/test_tool_specs.py
@@ -5,6 +5,7 @@ import time
 from cli.background import BackgroundTask, BackgroundTaskManager
 from cli.sub_agent_prompts import RESEARCH_AGENT_PROMPT, WORKFLOW_TASK_AGENT_PROMPT
 from cli.tools import (
+    ASK_USER_TIMEOUT_SENTINEL,
     BACKGROUND_TOOLS,
     CONCURRENCY_SAFE_TOOLS,
     CONFIRM_TOOLS,
@@ -12,6 +13,7 @@ from cli.tools import (
     TOOL_SCHEMAS,
     TOOL_SPECS,
     ToolRegistry,
+    ask_user_question,
 )
 
 
@@ -38,6 +40,52 @@ def test_tool_registry_reads_runtime_behavior_from_specs():
     assert registry.is_background("run_backtest")
     assert registry.is_background("evaluate_recommendation_events")
     assert registry.display_name("unknown_tool") == "unknown_tool"
+
+
+def test_confirm_timeout_is_not_reported_as_user_denial():
+    """超时说成「用户拒绝」等于伪造一件没发生的事，用户会读到自己从没做过的决定。"""
+    registry = ToolRegistry()
+    registry.set_confirm_callback(lambda _name, _args: {"action": "timeout"})
+
+    _args, error = registry._confirm_high_risk_call("update_portfolio", {"code": "002648"}, None)
+
+    assert error is not None
+    assert error["error"] != "用户拒绝执行此操作"
+    assert "超时" in error["error"]
+    assert "这不是拒绝" in error["error"]
+    assert "重试" in error["error"]
+
+
+def test_confirm_deny_still_reports_denial():
+    registry = ToolRegistry()
+    registry.set_confirm_callback(lambda _name, _args: {"action": "deny"})
+
+    _args, error = registry._confirm_high_risk_call("update_portfolio", {"code": "002648"}, None)
+
+    assert error == {"error": "用户拒绝执行此操作"}
+
+
+def test_ask_user_question_timeout_is_not_reported_as_an_answer():
+    """原先它以 status=answered 返回「已超时未作答」，模型只能把这句话当成用户的回答。"""
+    registry = ToolRegistry()
+    registry.set_ask_user_question_callback(lambda *_a, **_k: ASK_USER_TIMEOUT_SENTINEL)
+
+    result = ask_user_question("要录入哪一条？", tool_context=registry._tool_context)
+
+    assert result["status"] == "timeout"
+    assert "answer" not in result
+    assert ASK_USER_TIMEOUT_SENTINEL not in result["error"]
+    assert "不要把超时当成用户的回答" in result["error"]
+
+
+def test_ask_user_question_still_returns_real_answers():
+    registry = ToolRegistry()
+    registry.set_ask_user_question_callback(lambda *_a, **_k: "卫星化学 200股")
+
+    result = ask_user_question("要录入哪一条？", tool_context=registry._tool_context)
+
+    assert result["status"] == "answered"
+    assert result["answer"] == "卫星化学 200股"
 
 
 def test_tool_registry_filters_schemas_by_workflow_scope():

--- a/tests/cli/test_tui_rendering.py
+++ b/tests/cli/test_tui_rendering.py
@@ -1315,7 +1315,7 @@ def test_complete_workflow_background_does_not_wake_idle_agent():
     assert "workflow 后台完成" in str(log.lines[-2])
 
 
-def test_complete_workflow_background_queues_system_notification_when_busy():
+def _busy_tui_for_workflow_completion() -> WyckoffTUI:
     app = object.__new__(WyckoffTUI)
     log = _FakeLog()
     app.query_one = lambda *_args, **_kwargs: log
@@ -1325,6 +1325,13 @@ def test_complete_workflow_background_queues_system_notification_when_busy():
     app._session_tokens = {"input": 0, "output": 0, "rounds": 0}
     app._update_status = lambda: None
     app._chatlog_save = lambda *_args, **_kwargs: None
+    return app
+
+
+def test_complete_workflow_background_does_not_queue_notification_on_success():
+    """成功结果已经显示、落库并进了 _messages，再叫模型说一遍只会得到重复的一轮。"""
+
+    app = _busy_tui_for_workflow_completion()
 
     WyckoffTUI._complete_workflow_background(
         app,
@@ -1337,13 +1344,33 @@ def test_complete_workflow_background_queues_system_notification_when_busy():
         },
     )
 
+    assert not app._queue
+    assert app._messages[-1]["role"] == "assistant"
+    assert "候选结论: 首选 300750 宁德时代" in app._messages[-1]["content"]
+
+
+def test_complete_workflow_background_queues_system_notification_on_failure():
+    """失败结果不会进 _messages，所以必须靠通知让模型知道这轮没跑成。"""
+
+    app = _busy_tui_for_workflow_completion()
+
+    WyckoffTUI._complete_workflow_background(
+        app,
+        "wfbg_busy",
+        {
+            "workflow_run_id": "wf_busy",
+            "workflow": "dynamic_task",
+            "error": "step 超时",
+            "events": [{"type": "workflow_step_done", "step": {"title": "扫描候选", "status": "failed"}}],
+        },
+    )
+
     assert len(app._queue) == 1
     item = app._queue[0]
     assert item["type"] == "system_notification"
     assert "<run-id>wf_busy</run-id>" in item["content"]
+    assert "<status>failed</status>" in item["content"]
     assert "dynamic-workflow event" in item["content"]
-    assert "候选结论: 首选 300750 宁德时代" in item["content"]
-    assert app._messages[-1]["role"] == "assistant"
 
 
 def test_display_retry_event_surfaces_required_tool_and_reason():

--- a/tests/cli/test_tui_rendering.py
+++ b/tests/cli/test_tui_rendering.py
@@ -5,6 +5,7 @@ import threading
 from collections import deque
 from datetime import datetime
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -2206,3 +2207,57 @@ def test_wyckoff_tui_spinner_start_stop_clears_label():
     WyckoffTUI._stop_spinner(app)
     assert app._spinner_label == ""
     assert updated == [True]
+
+
+def test_request_tool_confirm_reports_timeout_not_deny():
+    """弹窗等了两分钟没人理，不等于用户点了拒绝——把沉默当否决会伪造用户的决定。"""
+    app = object.__new__(WyckoffTUI)
+    app._tools = None
+    app.call_from_thread = lambda fn, *a: None
+
+    with patch("threading.Event.wait", return_value=False):
+        choice = WyckoffTUI._request_tool_confirm(app, "update_portfolio", {"code": "002648"})
+
+    assert choice == {"action": "timeout"}
+
+
+def test_request_tool_confirm_still_denies_on_explicit_choice():
+    app = object.__new__(WyckoffTUI)
+    app._tools = None
+
+    def _fake_call_from_thread(fn, *args):
+        return None
+
+    app.call_from_thread = _fake_call_from_thread
+
+    with patch("threading.Event.wait", return_value=True):
+        choice = WyckoffTUI._request_tool_confirm(app, "update_portfolio", {"code": "002648"})
+
+    # result[0] 仍是 None（没人真的 dismiss），保持原有的保守 deny 兜底。
+    assert choice == {"action": "deny"}
+
+
+def test_request_user_question_returns_timeout_sentinel():
+    """返回「已超时未作答」这句自然语言，会被模型当成用户真的这么回答了。"""
+    from cli.tools import ASK_USER_TIMEOUT_SENTINEL
+
+    app = object.__new__(WyckoffTUI)
+    app.call_from_thread = lambda fn, *a: None
+
+    with patch("threading.Event.wait", return_value=False):
+        answer = WyckoffTUI._request_user_question(app, "要录入哪一条？")
+
+    assert answer == ASK_USER_TIMEOUT_SENTINEL
+
+
+def test_request_user_question_prefers_default_answer_over_timeout_sentinel():
+    from cli.tools import ASK_USER_TIMEOUT_SENTINEL
+
+    app = object.__new__(WyckoffTUI)
+    app.call_from_thread = lambda fn, *a: None
+
+    with patch("threading.Event.wait", return_value=False):
+        answer = WyckoffTUI._request_user_question(app, "继续吗？", default_answer="继续")
+
+    assert answer == "继续"
+    assert answer != ASK_USER_TIMEOUT_SENTINEL

--- a/tests/cli/test_workflow_executor.py
+++ b/tests/cli/test_workflow_executor.py
@@ -20,6 +20,7 @@ from cli.workflows.executor import (
     _step_context,
     _synthesis_handoff_summary,
     _synthesis_prompt,
+    _with_failure_lead,
     _workflow_handoff_state,
 )
 from cli.workflows.models import WorkflowContext, WorkflowRun, WorkflowStep
@@ -5691,3 +5692,45 @@ def test_build_recent_workflow_context_is_bounded_reference():
     assert "证据: 候选结论: 首选 A 高质量候选" in context
     assert "证据: 候选护栏: 禁止直接买入" in context
     assert context.endswith("</recent-workflow-context>")
+
+
+def _run_with_step_statuses(*statuses: str) -> WorkflowRun:
+    return WorkflowRun(
+        run_id="wf_lead",
+        session_id="s_lead",
+        user_text="昊华科技清仓了",
+        context=WORKFLOWS["dynamic_task"],
+        steps=[
+            WorkflowStep(step_id=f"s{index}", title=f"步骤{index}", status=status)
+            for index, status in enumerate(statuses)
+        ],
+    )
+
+
+def test_failure_lead_puts_failed_steps_above_the_candidate_block():
+    """failed run 的开头曾经是候选结论，真正重要的事实被埋在后面。"""
+
+    run = _run_with_step_statuses("failed", "completed")
+    text = "候选结论: 重点观察 300628 亿联网络"
+
+    final_text = _with_failure_lead(text, run)
+
+    assert final_text.startswith("⚠️ 本次 workflow 未完全成功")
+    assert "1 个步骤失败" in final_text
+    assert "步骤0" in final_text
+    assert final_text.index("未完全成功") < final_text.index("候选结论")
+
+
+def test_failure_lead_is_absent_when_every_step_succeeded():
+    run = _run_with_step_statuses("completed", "completed")
+
+    assert _with_failure_lead("候选结论: 观察 002648", run) == "候选结论: 观察 002648"
+
+
+def test_failure_lead_collapses_a_long_failure_list():
+    run = _run_with_step_statuses(*(["failed"] * 6))
+
+    final_text = _with_failure_lead("结论", run)
+
+    assert "6 个步骤失败" in final_text
+    assert "等 6 步" in final_text

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -856,6 +856,123 @@ def test_dispatch_falls_back_to_workflow_for_short_stock_selection_when_model_ro
     assert workflow.route_matches == ("model_router_fallback", "stock_selection_guard")
 
 
+def _planner_prompt_for(user_text: str, messages: list[dict] | None = None) -> str:
+    provider = ScriptedProvider([[{"type": "text_delta", "text": '{"title":"t","phases":[]}'}]])
+    plan_workflow(
+        user_text,
+        context=WORKFLOWS["dynamic_task"],
+        provider=provider,
+        tools=StubToolRegistry(),
+        messages=messages,
+    )
+    return provider.calls[0]["messages"][0]["content"]
+
+
+def test_plan_workflow_passes_recent_dialogue_to_the_planner():
+    """router 看得到历史、planner 看不到，承接性请求就会去问用户已经给过的信息。"""
+    prompt = _planner_prompt_for(
+        "继续录入",
+        [
+            {"role": "user", "content": "卫星化学 25.395 200股 2026-7-30买的"},
+            {"role": "assistant", "content": "002648 卫星化学 未写入：确认超时。"},
+            {"role": "user", "content": "继续录入"},
+        ],
+    )
+
+    assert "最近对话" in prompt
+    assert "卫星化学 25.395 200股" in prompt
+    assert "不要再问用户一遍" in prompt
+
+
+def test_plan_workflow_prompt_omits_dialogue_block_without_history():
+    assert "最近对话" not in _planner_prompt_for("帮我选出好股票")
+
+
+def test_dispatch_threads_planning_messages_into_the_executor():
+    provider = RouterDecisionProvider('{"mode":"dynamic_workflow","confidence":0.9,"reason":"需要多阶段复核"}')
+    messages = [{"role": "user", "content": "帮我找几只值得复核的票"}]
+
+    runtime, _workflow = build_turn_runtime(
+        provider,
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="再带上风险边界和买卖计划",
+        routing_messages=messages,
+    )
+
+    assert isinstance(runtime, WorkflowExecutor)
+    assert runtime.planning_messages == messages
+
+
+def test_dynamic_task_scope_excludes_account_write_tools():
+    """写入类工具刻意不在 workflow 白名单里；下面的降级 guard 全靠这个前提成立。"""
+    allowed = WORKFLOWS["dynamic_task"].allowed_tools
+
+    assert "update_portfolio" not in allowed
+    assert "record_trade_fill" not in allowed
+    assert "update_portfolio" in infer_direct_allowed_tools("继续录入")
+
+
+def test_dispatch_keeps_account_write_request_direct_against_model_workflow_decision():
+    """录入持仓需要 update_portfolio，而 workflow 没有这个工具——送进去必然干不成。"""
+    provider = RouterDecisionProvider(
+        '{"mode":"dynamic_workflow","confidence":0.85,"reason":"承接上一轮继续录入持仓，需调用工具执行账户事实更新"}'
+    )
+
+    runtime, workflow = build_turn_runtime(
+        provider,
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="继续录入",
+    )
+
+    assert workflow.name == "general_chat"
+    assert isinstance(runtime, AgentRuntime)
+    assert "update_portfolio" in workflow.route_reason
+    assert workflow.route_matches == ("model_router_guard", "account_write_guard")
+
+
+def test_dispatch_keeps_account_write_request_direct_when_router_unavailable():
+    runtime, workflow = build_turn_runtime(
+        ScriptedProvider([]),
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="把这两只加进持仓",
+    )
+
+    assert workflow.name == "general_chat"
+    assert isinstance(runtime, AgentRuntime)
+    assert workflow.route_matches == ("model_router_fallback", "account_write_guard")
+
+
+def test_dispatch_keeps_account_write_direct_even_with_explicit_workflow_opt_in():
+    """显式 `用 workflow` 也要挡：照办等于保证失败，原因写进 route_reason 供用户看见。"""
+    runtime, workflow = build_turn_runtime(
+        ScriptedProvider([]),
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="用 workflow 把茅台录入持仓",
+    )
+
+    assert workflow.name == "general_chat"
+    assert isinstance(runtime, AgentRuntime)
+    assert workflow.route_matches == ("model_router_fallback", "account_write_guard")
+
+
+def test_account_write_guard_ignores_how_to_and_review_questions():
+    """「持仓怎么录入」是问方法，「复盘持仓」是只读，都不该被 guard 拽走。"""
+    for text in ("持仓怎么录入", "能不能录入持仓", "复盘一下我的持仓"):
+        provider = RouterDecisionProvider('{"mode":"dynamic_workflow","confidence":0.8,"reason":"需要多阶段复核"}')
+        _runtime, workflow = build_turn_runtime(
+            provider,
+            StubToolRegistry(),
+            session_id="s1",
+            user_text=text,
+        )
+
+        assert workflow.route_matches == ("model_router",), text
+
+
 def test_stock_selection_fallback_script_always_forms_action_boundaries():
     _runtime, workflow = build_turn_runtime(
         ScriptedProvider([]),

--- a/tests/cli/test_workflows.py
+++ b/tests/cli/test_workflows.py
@@ -7,7 +7,7 @@ from cli.runtime import AgentRuntime
 from cli.tools import TOOL_SCHEMAS
 from cli.workflows.dispatch import build_turn_runtime, infer_direct_allowed_tools
 from cli.workflows.executor import WorkflowExecutor
-from cli.workflows.model_router import _ROUTER_SYSTEM_PROMPT
+from cli.workflows.model_router import _ROUTER_SYSTEM_PROMPT, missing_workflow_capability
 from cli.workflows.pending_reply import _PENDING_REPLY_SYSTEM_PROMPT, route_pending_workflow_reply
 from cli.workflows.planner import (
     _PLAN_SYSTEM_PROMPT,
@@ -16,6 +16,7 @@ from cli.workflows.planner import (
     _tool_catalog,
     adapt_workflow_script,
     plan_workflow,
+    script_handoff_reason,
 )
 from cli.workflows.router import WORKFLOWS, build_workflow_system_prompt, route_workflow
 from tests.helpers.agent_loop_harness import ScriptedProvider, StubToolRegistry
@@ -763,7 +764,9 @@ def test_dispatch_model_can_override_explicit_workflow_marker_to_direct():
     assert isinstance(runtime, AgentRuntime)
 
 
-def test_dispatch_respects_low_confidence_dynamic_decision():
+def test_dispatch_downgrades_low_confidence_dynamic_decision():
+    """两种错判代价不对称：错判 direct 多花几秒，错判 workflow 要几分钟且可能零产出。"""
+
     provider = RouterDecisionProvider('{"mode":"dynamic_workflow","confidence":0.51,"reason":"可能需要多阶段"}')
 
     runtime, workflow = build_turn_runtime(
@@ -773,9 +776,25 @@ def test_dispatch_respects_low_confidence_dynamic_decision():
         user_text="分阶段看看这个概念怎么理解",
     )
 
-    assert workflow.name == "dynamic_task"
-    assert workflow.route_reason == "模型判断需要动态 workflow：可能需要多阶段"
+    assert workflow.name == "general_chat"
     assert workflow.route_confidence == 0.51
+    assert "0.51" in workflow.route_reason
+    assert "workflow_confidence_floor" in workflow.route_matches
+    assert not isinstance(runtime, WorkflowExecutor)
+
+
+def test_dispatch_keeps_high_confidence_dynamic_decision():
+    provider = RouterDecisionProvider('{"mode":"dynamic_workflow","confidence":0.88,"reason":"需要多阶段交付"}')
+
+    runtime, workflow = build_turn_runtime(
+        provider,
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="帮我完整选股，给候选、理由和攻防计划",
+    )
+
+    assert workflow.name == "dynamic_task"
+    assert workflow.route_confidence == 0.88
     assert isinstance(runtime, WorkflowExecutor)
 
 
@@ -3104,3 +3123,138 @@ def test_route_workflow_resume_without_label_stays_dynamic():
 
     assert workflow.name == "dynamic_task"
     assert workflow.route_reason == "用户明确要求继续已有 workflow"
+
+
+class HandoffRoutingProvider(RouterDecisionProvider):
+    """Route to workflow, then have the planner hand the turn back."""
+
+    def __init__(self, decision: str, planner_text: str):
+        super().__init__(decision)
+        self.planner_text = planner_text
+        self.stream_calls = 0
+
+    def chat_stream(self, messages, tools=None, system_prompt=""):
+        self.stream_calls += 1
+        yield {"type": "text_delta", "text": self.planner_text}
+
+
+def test_planner_prompt_offers_a_handoff_instead_of_a_substitute_plan():
+    assert '{"handoff":"direct"' in _PLAN_SYSTEM_PROMPT
+    assert "交还比编一个替代任务好" in _PLAN_SYSTEM_PROMPT
+
+
+def test_plan_workflow_returns_no_steps_for_a_handoff_script():
+    provider = ScriptedProvider(
+        [[{"type": "text_delta", "text": '{"handoff":"direct","reason":"缺少写入持仓的工具"}'}]]
+    )
+
+    run = plan_workflow(
+        "昊华科技清仓了",
+        context=WORKFLOWS["dynamic_task"],
+        provider=provider,
+        tools=StubToolRegistry(),
+    )
+
+    assert run.steps == []
+    assert script_handoff_reason(run.script) == "缺少写入持仓的工具"
+
+
+def test_dispatch_falls_back_to_direct_when_planner_hands_the_turn_back():
+    """planner 说它办不成时交还，而不是拆成一份用户没要的只读复核。"""
+
+    provider = HandoffRoutingProvider(
+        '{"mode":"dynamic_workflow","confidence":0.86,"reason":"承接持仓管理"}',
+        '{"handoff":"direct","reason":"当前工具集中没有可写入持仓的工具"}',
+    )
+
+    runtime, workflow = build_turn_runtime(
+        provider,
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="帮我把这轮的结论整理成一句话",
+    )
+
+    assert not isinstance(runtime, WorkflowExecutor)
+    assert workflow.name == "general_chat"
+    assert "planner_handoff" in workflow.route_matches
+    assert "当前工具集中没有可写入持仓的工具" in workflow.route_reason
+    assert "update_portfolio" in runtime.allowed_tools
+
+
+def test_dispatch_ignores_handoff_when_user_replays_an_explicit_script():
+    provider = HandoffRoutingProvider(
+        '{"mode":"dynamic_workflow","confidence":0.9,"reason":"显式脚本"}',
+        '{"handoff":"direct","reason":"不该编排"}',
+    )
+    script = {
+        "title": "用户指定脚本",
+        "phases": [{"id": "p1", "title": "p1", "tasks": [{"id": "t1", "title": "看持仓", "tools": ["portfolio"]}]}],
+    }
+
+    runtime, workflow = build_turn_runtime(
+        provider,
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="重跑这个脚本",
+        workflow_script=script,
+    )
+
+    assert isinstance(runtime, WorkflowExecutor)
+    assert workflow.name == "dynamic_task"
+
+
+def test_handoff_planning_is_reused_instead_of_planned_twice():
+    provider = HandoffRoutingProvider(
+        '{"mode":"dynamic_workflow","confidence":0.9,"reason":"需要多阶段"}',
+        json.dumps(
+            {
+                "title": "看持仓",
+                "phases": [
+                    {"id": "p1", "title": "p1", "tasks": [{"id": "t1", "title": "看持仓", "tools": ["portfolio"]}]}
+                ],
+            },
+            ensure_ascii=False,
+        ),
+    )
+
+    runtime, workflow = build_turn_runtime(
+        provider,
+        StubToolRegistry(),
+        session_id="s1",
+        user_text="完整复盘持仓，给候选、理由和攻防计划",
+    )
+
+    assert isinstance(runtime, WorkflowExecutor)
+    assert workflow.name == "dynamic_task"
+    planning_calls = provider.stream_calls
+    assert runtime.plan_handoff_reason() == ""
+    assert provider.stream_calls == planning_calls
+
+
+def test_missing_workflow_capability_reports_the_capability_and_tools():
+    capability, missing = missing_workflow_capability("昊华科技清仓了")
+
+    assert capability == "账户写入"
+    assert "update_portfolio" in missing
+
+
+def test_missing_workflow_capability_covers_local_write_requests():
+    capability, missing = missing_workflow_capability("把这份结论保存到文件")
+
+    assert capability == "本地写入/执行"
+    assert "write_file" in missing
+
+
+def test_missing_workflow_capability_is_derived_from_the_live_allowlist():
+    """判据是能力集合的差，不是硬编码的工具名。"""
+
+    allowed = set(WORKFLOWS["dynamic_task"].allowed_tools)
+    _, missing = missing_workflow_capability("帮我录入持仓")
+
+    assert missing
+    assert not set(missing) & allowed
+
+
+def test_missing_workflow_capability_ignores_how_to_questions():
+    assert missing_workflow_capability("清仓是什么意思")[1] == ()
+    assert missing_workflow_capability("怎么录入持仓")[1] == ()


### PR DESCRIPTION
## 变更摘要

三个缺陷都来自同一次真实会话（session `a0ae8be01c22`）：用户给了两条持仓，卫星化学
「录入失败」，用户说「继续录入」，结果下一轮完全不记得上文，又起了个四分钟零产出的
workflow。

### 1. 超时被当成用户拒绝（`cli/tui.py`、`cli/tools.py`）

`_request_tool_confirm` 的 `event.wait(timeout=120)` 超时后返回 `{"action": "deny"}`，
模型于是收到 `用户拒绝执行此操作` 并照此措辞回复用户。会话日志里那次 `update_portfolio`
的 `elapsed_ms` 正好是 **120013** —— 用户根本没点拒绝，只是没看见弹窗。

把沉默当否决等于伪造一件没发生的事：明确拒绝意味着「别再问了」，超时意味着「没看见，
再问一次」，两者合流之后用户会在回复里读到自己从没做过的决定。

现在超时返回 `action="timeout"`，错误文案明确「这不是拒绝」并要求确认后重试。

`ask_user_question` 是同一个毛病的另一处：超时返回 `status="answered"` 加上
`已超时未作答` 这句自然语言，模型只能把这句话本身当成用户的回答内容继续推理。改为
返回哨兵值 + `status="timeout"`。

### 2. planner 拿不到对话历史（`cli/workflows/planner.py`、`_shared.py`、`executor.py`、`dispatch.py`）

`plan_workflow()` 只收 `user_text`，`_planner_user_prompt()` 拼出的 prompt 里没有任何
上文。而 `model_router` 是拿了历史的 —— 它准确判断出「继续录入」是承接上一轮（落库的
路由原因就是「承接上一轮继续录入持仓」），然后把活交给一个啥都不知道的 planner。

于是生成的脚本第一步必然是问用户「请提供持仓信息」，问的正是上一轮刚给过的东西。
持久化的 rationale 写得很直白：「用户要求"继续录入"，但当前消息未提供要录入的股票、
数量、成本等持仓字段」。两次问询各自超时，四分钟零产出。

把 router 的历史提取逻辑提到 `_shared.recent_dialogue_context()` 给两边共用，planner
给更长的窗口（8 条 / 600 字），因为它要沿用代码、股数、成本价这类具体事实，而 router
只需要判断本轮是不是承接。

### 3. 写入请求被路由进没有写入工具的 workflow（`cli/workflows/model_router.py`）

`dynamic_task` 的白名单里刻意没有 `update_portfolio` / `record_trade_fill`（planner
prompt 里也明确「不要新增写入、交易或文件修改类任务」）。所以「继续录入持仓」被判成
workflow 时，它不是跑得慢，是**结构上干不成** —— 最好的结果也只是核对完代码再让用户
自己去录。planner 自己都发现了这点，rationale 里写着「可用工具中没有写入或修改持仓的
工具」。

原先的两处 guard 都是单向的（`_needs_stock_selection_workflow_fallback` 只把 direct
**升级**成 workflow），没有任何逻辑能把不合适的 workflow 判断**降级**回 direct。

新增 `account_write_guard`：识别到账户写入意图后，若目标 workflow 缺少所需工具就降级
到 direct agent。模型判断和显式 `用 workflow` 标记都挡 —— 照办等于保证失败，降级原因
写进 `route_reason` 供用户看见。缺失工具名从实际白名单推导而非硬编码，所以白名单一旦
补上写入工具，guard 会自动让路。问方法（「持仓怎么录入」）和只读复盘不受影响。

## 验证

- `pytest` — 2384 passed（新增 16 个用例）
- `ruff check .` — All checks passed
- `ruff format --check .` — 653 files already formatted
- `quality_gate.py --ci` — No new violations（TS-LOC WARNING 是既有的，本 PR 未动 TS）
- 按原会话回放确认：`继续录入` + 同样的模型 workflow 判断 + 同样的上文，现在得到
  `AgentRuntime` / `general_chat`，且 `update_portfolio` 在可用工具里
- 新增覆盖：超时不报成拒绝、明确拒绝仍报拒绝、`ask_user_question` 超时不冒充答复、
  真实答复不受影响、planner 收到历史且无历史时不加空段、`planning_messages` 一路
  透传到 executor、写入请求在三条路由路径上都降级、问方法/只读复盘不被 guard 拽走


---

## 追加：整体机制的四处修复

上面三条修的是那次会话里的具体缺陷。回头看整条链路加上库里的实际运行记录，问题在机制
本身：会话 `a0ae8be01c22` 的 4 个用户轮次有 3 个进了 workflow，而**唯一走 direct 的那轮
是唯一办成事的**（63 秒，`search_stock_by_name` + `update_portfolio`）。同一件事交给
workflow 花了 281 秒，产出是用户没要的诊断报告；`昊华科技清仓了` 跑了 324 秒后 failed，
而 `600378` 至今仍是 200 股。

### 4. planner 只能输出计划，不能交还（`planner.py`、`dispatch.py`、`executor.py`）

`wf_8bbdef879fc1` 的 rationale 是 planner 自己写的：「用户表达的是持仓变动事实：昊华
科技已清仓。**当前工具集中没有可写入或更新持仓的工具**，且运行边界禁止生成写入持仓
任务，**因此拆分为只读复核**」。

它完全清楚自己办不成这件事，但唯一合法的输出格式就是一份 phases 计划，所以把「清仓」
改写成了「复核清仓」—— 一个用户没提的任务 —— 然后跑了 324 秒、失败、汇报。这是整套设计
里最贵的一处缺口：planner 没有「这个请求不属于这里」这个动词，只能在「编不出来」和
「编一个替代任务」之间选后者。

现在它可以输出 `{"handoff":"direct","reason":...}`，dispatch 收到就落回 direct agent。
交还路径不落库，不留空 run；显式重放某个 script 时不做交还（用户要的就是那份计划）。
规划结果缓存复用，交还与继续执行都只花一次规划调用。

### 5. 模式决策发生在能力校验之前（`model_router.py`）

路由定通道时压根不看这一轮需要什么工具，所以写入请求会被分进一条结构上就干不成的车道。
第 3 条的 guard 治的是症状 —— 26 个硬编码关键词。换成能力表：「这一轮需要什么能力」→
「哪些工具提供它」→ 缺哪个由目标车道的实时白名单算出来。目前覆盖账户写入和本地写入/执行
两类，加一类只需往表里加一行。

### 6. confidence 算了不用（`model_router.py`）

两种错判的代价差了两个数量级：错判成 direct 是模型多调一个工具、几秒；错判成 workflow
是几分钟、后台执行、计划落库、往对话里插好几个轮次、还可能零产出。`_ROUTER_SYSTEM_PROMPT`
里写了「默认用 direct」，但那只是一句提示。

`route_confidence` 每次都算出来、落进库里，然后 `dispatch.py` 和 `executor.py` 里一次
都没被读过 —— `昊华科技清仓了` 那次是 0.86，即便 0.2 也照样会跑。现在低于 0.7 落 direct。
模型没报这个字段时不触发（`decision_confidence` 缺字段也返回 0.0，和明确报 0.0 分不开），
避免因 provider 不输出就把 workflow 整个关掉。

### 7. 抢戏是字面意义上的（`cli/tui.py`、`executor.py`）

用户轮次 6 说了一句话，`chat_log` 里长出 5 行：ack → 结果 → 通知 → 助手 → 通知 → 助手。
轮次 10 和 12 内容重叠，12 自己都承认「和刚才一致」。成功时 `final_text` 已经显示、落库、
进了 `_messages`，再发一条通知叫模型就同一份结果说一遍，只会得到重复的一轮。现在成功
不再追加轮次，失败仍然通知（失败文本不进 `_messages`，模型得靠通知才知道这轮没跑成）。

另一处：轮次 18 问的是昊华科技，轮次 20 的汇总开头两段在讲亿联网络和卫星化学，而 run
状态是 `failed`。`_ensure_candidate_delivery` 把候选行插在最前面且不看运行状态，于是
用户先读到一大片看起来很像成果的候选结论，真正重要的事实（那一步超时了、清仓没被记录）
被埋在后面。现在 failed run 先说哪几步失败、结论缺什么支撑。

## 追加验证

- `pytest` — 2398 passed（本次再加 14 个用例）
- `ruff check` / `ruff format --check` — 干净，653 files already formatted
- `quality_gate.py --ci` — No new violations
- 原场景回放：`继续录入`、`昊华科技清仓了` 都留在 direct；`做一下持仓诊断`（0.55）按
  置信度门槛落 direct；`帮我完整做一遍今天的A股选股`、`复盘一下持仓`、`找几只值得跟踪的票`
  等正常编排请求不受能力校验影响
- 交还路径实测不写 `workflow_run`、不留 run 文件；`prepare_run()` 在预规划之后仍然只
  规划一次、只落一行、照常发 `workflow_plan` 事件
