### PR TITLE
fix: 回测 trades 分列记录排序分与 L3 质量分

### DIFF
--- a/core/backtest_execution.py
+++ b/core/backtest_execution.py
@@ -35,6 +35,12 @@ class TradeRecord:
     ret_pct: float
     track: str = ""
     regime: str = ""
+    # 排序诊断用：score 是候选排序分（allocate_ai_candidates 输出，含阶段分/主升
+    # +100/触发分等），alloc_score 与之相同、显式命名以免误读；watch_score 是
+    # candidate_ranker 的 L3 质量分，在最终排序里只贡献 watch_score*8（上限 9.6）。
+    # 两者必须分列记录，否则无法区分"排序主体无效"与"质量分无效"。
+    alloc_score: float | None = None
+    watch_score: float | None = None
     entry_price_source: str = "daily_open"
     entry_target_time: str = ""
     exit_reason: str = "unknown"

--- a/core/backtest_replay.py
+++ b/core/backtest_replay.py
@@ -34,6 +34,7 @@ from core.backtest_execution import (
 )
 from core.backtest_selection import combine_trigger_scores, select_ai_input_codes
 from core.candidate_policy import CandidatePolicyConfig, candidate_score_value
+from core.candidate_ranker import rank_l3_candidates
 from core.candidate_tracks import candidate_entry_track
 from core.mainline_engine import MainlineEngineConfig
 from core.market_breadth import calc_market_breadth
@@ -160,6 +161,7 @@ class _RankedSelection:
     trigger_name_map: dict[str, tuple[float, str]]
     confirmed_codes: frozenset[str] = field(default_factory=frozenset)
     signal_type_map: dict[str, str] = field(default_factory=dict)
+    watch_score_map: dict[str, float] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -377,6 +379,7 @@ def _limit_probe_only_selection(
             {code: selected.trigger_name_map[code] for code in kept if code in selected.trigger_name_map},
             frozenset(code for code in kept if code in selected.confirmed_codes),
             {code: selected.signal_type_map[code] for code in kept if code in selected.signal_type_map},
+            {code: selected.watch_score_map[code] for code in kept if code in selected.watch_score_map},
         ),
         len(selected.codes) - 1,
     )
@@ -520,6 +523,7 @@ def _select_ranked_codes(
     ranked_codes = _apply_selection_guards(ranked_codes, ctx, config)
     if not ranked_codes:
         return None, len(confirmed.codes)
+    watch_score_map = _watch_score_map(ctx, sector_map)
     return (
         _RankedSelection(
             ranked_codes,
@@ -528,9 +532,31 @@ def _select_ranked_codes(
             _name_score_map(ctx.result, confirmed, prefer_confirmed=config.pending_mode == "only"),
             frozenset(confirmed.codes),
             confirmed.trigger_map,
+            watch_score_map,
         ),
         len(confirmed.codes),
     )
+
+
+def _watch_score_map(ctx: _DayContext, sector_map: dict[str, str]) -> dict[str, float]:
+    """L3 质量分（candidate_ranker.watch_score），仅用于排序有效性诊断。
+
+    它不参与回测决策：最终排序由 allocate_ai_candidates 决定，watch_score 在那里
+    只贡献 watch_score*8（上限 9.6），相对主升 +100 与触发分是小量。分列记录才能
+    区分"排序主体无效"与"质量分无效"。
+    """
+    try:
+        _, score_map = rank_l3_candidates(
+            l3_symbols=ctx.result.layer3_symbols,
+            df_map=ctx.day_df_map,
+            sector_map=sector_map,
+            triggers=ctx.result.triggers,
+            top_sectors=ctx.result.top_sectors,
+            l2_channel_map=ctx.result.channel_map,
+        )
+    except Exception:
+        return {}
+    return {str(k): float(v) for k, v in (score_map or {}).items()}
 
 
 def _confirmed_signals(
@@ -787,6 +813,8 @@ def _make_trade_record(
         name=name_map.get(code, code),
         trigger=trigger_name,
         score=candidate_score_value(selected.score_map.get(code)),
+        alloc_score=candidate_score_value(selected.score_map.get(code)),
+        watch_score=selected.watch_score_map.get(code),
         entry_close=plan.entry_close,
         exit_close=exit_close,
         ret_pct=(exit_exec - entry_exec) / entry_exec * 100.0 if entry_exec > 0 else 0.0,

--- a/tests/core/test_backtest_replay.py
+++ b/tests/core/test_backtest_replay.py
@@ -694,3 +694,56 @@ def test_low_score_confirmed_signal_does_not_downgrade_funnel_candidate(monkeypa
     assert replay.records[0].track == "Accum"
     assert replay.records[0].trigger == "spring"
     assert replay.records[0].signal_confirmed is True
+
+
+def test_trade_record_carries_alloc_and_watch_scores_separately():
+    """排序诊断需要分列记录两种分数。
+
+    score/alloc_score 是 allocate_ai_candidates 的排序分（含主升 +100、触发分等）；
+    watch_score 是 candidate_ranker 的 L3 质量分，在最终排序里只贡献 *8（上限 9.6）。
+    合成一列会让"排序主体无效"与"质量分无效"无法区分——此前 trades.csv 只有 score
+    一列且实为触发分，导致相关性分析口径错误。
+    """
+    import dataclasses
+
+    from core.backtest_execution import TradeRecord
+
+    fields = {f.name for f in dataclasses.fields(TradeRecord)}
+    assert {"alloc_score", "watch_score"} <= fields
+
+    record = TradeRecord(
+        signal_date=date(2026, 1, 2),
+        entry_date=date(2026, 1, 3),
+        exit_date=date(2026, 1, 5),
+        code="000001",
+        name="平安银行",
+        trigger="sos",
+        score=42.0,
+        entry_close=10.0,
+        exit_close=11.0,
+        ret_pct=10.0,
+        alloc_score=42.0,
+        watch_score=0.87,
+    )
+    row = dataclasses.asdict(record)
+    assert row["alloc_score"] == 42.0
+    assert row["watch_score"] == 0.87
+    assert row["watch_score"] != row["alloc_score"]
+
+
+def test_watch_score_map_degrades_to_empty_on_failure(monkeypatch):
+    """诊断字段不得影响回测主流程：排名失败时返回空表而非抛出。"""
+    monkeypatch.setattr(replay_mod, "rank_l3_candidates", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+    ctx = replay_mod._DayContext(
+        0,
+        date(2026, 1, 2),
+        date(2026, 1, 3),
+        {},
+        {},
+        FunnelConfig(),
+        _result(),
+        "NEUTRAL",
+        {},
+    )
+
+    assert replay_mod._watch_score_map(ctx, {}) == {}


### PR DESCRIPTION
## 变更摘要

修正一个我自己造成的评估口径错误，并让排序有效性变得可评估。

### 问题

`trades.csv` 原本只有一列 `score`。我此前据此得出"`watch_score` 相关系数 +0.0025 = 评分排名无效"，**这个口径是错的**：

追到 `core/backtest_selection.py:152`，那列 `score` 实际是 `hit_score_map`（`combine_trigger_scores` 的输出，即触发分），不是 `candidate_ranker` 的 `watch_score`。两者量级也不同 —— 实测 `score` 分布 0.45~94，而 `watch_score` 是分位加权和、理论范围约 0~1.1。混在一起做 pooled 相关性必然被稀释。

### 查清的真实权重

`allocate_ai_candidates` 的排序分构成（`core/ai_candidate_allocation.py:504`）：

| 分项 | 量级 |
|---|---|
| `_stage_score` | ~10-100 |
| 主升段 `markup_set` | **+100** |
| `_trigger_score` | ~10-60 |
| `_track_alignment_bonus` | 赛道对齐 |
| **`_layer3_rank_bonus`** | **`watch_score*8`，上限 9.6** |
| `_exit_penalty` | 负向 |

**`watch_score` 在最终排序里权重不到 10%。** 即使它有效也救不了排序 —— 真正决定排序的是阶段分与触发分。

这意味着"评分排名失效"这个结论需要拆成两个独立问题：排序主体（阶段分/触发分）是否有效，与质量分（watch_score）是否有效。原来的单列结构无法区分。

### 改动

- `TradeRecord` 新增 `alloc_score`（排序分，与 `score` 同值、显式命名避免误读）与 `watch_score`（L3 质量分）
- 在 `_watch_score_map()` 里调 `rank_l3_candidates` 取质量分，**纯诊断用途，不参与回测决策**
- 失败时返回空表，不影响主流程

## 验证

- `ruff check` / `ruff format` — 通过
- `pytest tests/` — **2529 passed**（新增 2 个测试）
- `quality_gate.py --check-functions` — 0 违规
- 实测两列进入 trades DataFrame 且取值独立

新增测试锁定两点：两列必须分列存在且取值可不同；`rank_l3_candidates` 抛异常时 `_watch_score_map` 返回空表而非中断回测。

## 关联

配套触发了 `period=all_defined` 的跨周期回测（run 31237549718），用于判断动量因子在 bull_2020 / bear_2022 / sideways_2023 / volatile_2024 四种环境下符号是否一致 —— 这决定评分逻辑该"重做公式"还是"加 regime 自适应权重"。该 run 使用旧的单列结构，本 PR 合并后的下一次 run 才会带上分列诊断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)