### PR TITLE
chore: 移除 22 个全库零引用的死函数

### DIFF
--- a/core/backtest_execution.py
+++ b/core/backtest_execution.py
@@ -90,14 +90,6 @@ def calc_trade_excursion_pct(
     return (max_high / entry_price - 1.0) * 100.0, (min_low / entry_price - 1.0) * 100.0
 
 
-def close_on_date(df: pd.DataFrame, day: date) -> float | None:
-    row = df[df["date"] == day]
-    if row.empty:
-        return None
-    close = pd.to_numeric(row["close"], errors="coerce").dropna()
-    return None if close.empty else float(close.iloc[-1])
-
-
 def close_on_or_after(df: pd.DataFrame, day: date) -> tuple[float | None, date | None]:
     row = df[df["date"] >= day].head(1)
     if row.empty:

--- a/core/funnel_sections.py
+++ b/core/funnel_sections.py
@@ -8,25 +8,6 @@ from core.candidate_ranker import TRIGGER_GROUP_ORDER, TRIGGER_GROUP_TITLES, TRI
 from core.funnel_format import fmt_pct, fmt_ratio
 
 
-def append_leader_radar_section(
-    lines: list[str],
-    rows: list[dict],
-    name_map: dict[str, str],
-    *,
-    display_limit: int = 0,
-) -> None:
-    if not rows:
-        return
-    lines.append("")
-    lines.append(f"**【📈 趋势观察池】{len(rows)} 只**")
-    lines.append("仅用于跟踪强趋势背景，不是正式买点；进入可买区仍必须通过主线/候选车道和 confirmed 确认")
-    display = rows if display_limit <= 0 else rows[:display_limit]
-    lines.extend(_leader_row(row, name_map) for row in display)
-    omitted = len(rows) - len(display)
-    if omitted > 0:
-        lines.append(f"  ... 另 {omitted} 只略")
-
-
 def append_formal_l4_sections(
     lines: list[str],
     formal_codes: list[str],

--- a/core/hk_boards.py
+++ b/core/hk_boards.py
@@ -65,10 +65,6 @@ def is_hk_main_board(code: object) -> bool:
     return hk_board(code) == "main"
 
 
-def is_hk_gem(code: object) -> bool:
-    return hk_board(code) == "gem"
-
-
 # 2026-07 复盘 `recommendation_tracking_hk` 近 30 个交易日 312 条真实候选：整体胜率
 # 42.6%、均收 -3.45%（系统性亏损）。分信号归因：SOS 胜率 21.6%／均收 -8.96%（曹操
 # 出行 -57.8%、中国建材 -44.8%、嘀嗒出行反复 -43%+ 均由此触发）；EVR 胜率 35.8%／

--- a/core/theme_radar.py
+++ b/core/theme_radar.py
@@ -459,10 +459,6 @@ def _rotation_state(score: float) -> str:
     return "quiet"
 
 
-def _theme_members(theme: str, concept_map: dict[str, list[str]], sector_map: dict[str, str]) -> list[str]:
-    return _theme_member_index(concept_map, sector_map).get(theme, [])
-
-
 def _theme_member_index(concept_map: dict[str, list[str]], sector_map: dict[str, str]) -> dict[str, list[str]]:
     index: dict[str, set[str]] = {}
     for code, concepts in concept_map.items():

--- a/core/wbt_adapter.py
+++ b/core/wbt_adapter.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
-from importlib.util import find_spec
 from typing import Any
 
 import pandas as pd
@@ -31,12 +30,6 @@ class WbtEvaluation:
     daily_return: pd.DataFrame | None = None
     dailys: pd.DataFrame | None = None
     pairs: pd.DataFrame | None = None
-
-
-def is_wbt_installed() -> bool:
-    """Return True when the optional ``wbt`` Python package is importable."""
-
-    return find_spec("wbt") is not None
 
 
 def _record_get(record: Any, key: str, default: Any = None) -> Any:

--- a/integrations/fetch_a_share_csv.py
+++ b/integrations/fetch_a_share_csv.py
@@ -181,14 +181,6 @@ def resolve_trading_window(end_calendar_day: date, trading_days: int) -> Trading
     return TradingWindow(start_trade_date=start_trade, end_trade_date=end_trade)
 
 
-def _stock_name_from_code(symbol: str) -> str:
-    info = ak.stock_info_a_code_name()
-    row = info.loc[info["code"] == symbol, "name"]
-    if row.empty:
-        raise RuntimeError(f"symbol not found in stock list: {symbol}")
-    return str(row.iloc[0])
-
-
 def _read_stock_list_cache(cache_path: Path) -> list[dict[str, str]]:
     try:
         with open(cache_path, encoding="utf-8") as f:

--- a/integrations/local_db.py
+++ b/integrations/local_db.py
@@ -710,18 +710,6 @@ def save_market_signal(trade_date: str, data: dict) -> None:
         )
 
 
-def load_latest_market_signal() -> dict | None:
-    conn = get_db()
-    cur = conn.execute("SELECT data_json FROM market_signal_daily ORDER BY trade_date DESC LIMIT 1")
-    row = cur.fetchone()
-    if not row:
-        return None
-    try:
-        return json.loads(row["data_json"])
-    except (json.JSONDecodeError, TypeError):
-        return None
-
-
 # ---------------------------------------------------------------------------
 # Theme radar snapshot
 # ---------------------------------------------------------------------------

--- a/integrations/rag_veto.py
+++ b/integrations/rag_veto.py
@@ -107,26 +107,6 @@ def _normalize_keywords() -> list[str]:
     return parts or DEFAULT_NEGATIVE_KEYWORDS
 
 
-def _normalize_match_text(s: str) -> str:
-    return re.sub(r"\s+", "", str(s or "")).lower()
-
-
-def _extract_hits(text: str, keywords: list[str]) -> list[str]:
-    hits: list[str] = []
-    for kw in keywords:
-        k = str(kw or "").strip().lower()
-        if not k or k in {"st", "*st"}:
-            continue
-        if k in text and k not in hits:
-            hits.append(k)
-
-    if _STAR_ST_PATTERN.search(text):
-        hits.append("*st")
-    if _ST_PATTERN.search(text):
-        hits.append("st")
-    return hits
-
-
 def _is_about_this_stock(sentence: str, code: str, name: str) -> bool:
     """判断一段文本是否在讨论该股本身（而非泛泛提及其他股票）。"""
     s = sentence.lower()

--- a/integrations/recommendation_performance.py
+++ b/integrations/recommendation_performance.py
@@ -137,10 +137,6 @@ def build_market_performance_updates(
     return updates, codes_no_data, latest_td
 
 
-def empty_us_performance_summary() -> dict[str, Any]:
-    return empty_performance_summary()
-
-
 def empty_performance_summary() -> dict[str, Any]:
     return {
         "rows_total": 0,
@@ -153,17 +149,6 @@ def empty_performance_summary() -> dict[str, Any]:
         "mfe_ge_10": 0,
         "mae_le_neg5": 0,
     }
-
-
-def us_performance_summary(
-    records: list[dict[str, Any]],
-    grouped: dict[str, list[dict[str, Any]]],
-    written: int,
-    codes_no_data: int,
-    latest_trade_date: str,
-    updates: list[dict[str, Any]],
-) -> dict[str, Any]:
-    return performance_summary(records, grouped, written, codes_no_data, latest_trade_date, updates)
 
 
 def performance_summary(

--- a/integrations/supabase_market_signal.py
+++ b/integrations/supabase_market_signal.py
@@ -59,46 +59,6 @@ def market_signal_readiness(row: dict[str, Any] | None, expected_trade_date: dat
     return {"status": "ready", "reason": "当日 benchmark 与盘前风险均已就绪"}
 
 
-def _format_signed_pct(raw: Any) -> str:
-    value = _safe_float(raw)
-    if value is None:
-        return "--"
-    return f"{value:+.2f}%"
-
-
-def _format_plain(raw: Any, digits: int = 2) -> str:
-    value = _safe_float(raw)
-    if value is None:
-        return "--"
-    return f"{value:.{digits}f}"
-
-
-def _benchmark_regime_desc(regime: str) -> str:
-    mapping = {
-        "RISK_ON": "过热禁追",
-        "NEUTRAL": "中性",
-        "CAUTION": "谨慎确认",
-        "RISK_OFF": "偏弱",
-        "CRASH": "极弱",
-        "PANIC_REPAIR": "修复候选",
-        "PANIC_REPAIR_CONFIRMED": "修复成立",
-        "BLACK_SWAN": "极端恶劣",
-        "UNKNOWN": "待确认",
-    }
-    return mapping.get(str(regime or "").strip().upper(), "待确认")
-
-
-def _premarket_regime_desc(regime: str) -> str:
-    mapping = {
-        "UNKNOWN": "待确认",
-        "NORMAL": "平稳",
-        "CAUTION": "情绪冲击",
-        "RISK_OFF": "转冷",
-        "BLACK_SWAN": "急剧恶化",
-    }
-    return mapping.get(str(regime or "").strip().upper(), "待确认")
-
-
 def _normalize_benchmark_slot(regime: str) -> str:
     normalized = str(regime or "").strip().upper()
     if not normalized:

--- a/integrations/supabase_signal_feedback.py
+++ b/integrations/supabase_signal_feedback.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 from typing import Any
 
 from core.constants import (
@@ -113,10 +113,6 @@ def upsert_signal_observations(rows: list[dict[str, Any]]) -> int:
 
 def upsert_signal_outcomes(rows: list[dict[str, Any]]) -> int:
     return _execute_upsert(TABLE_SIGNAL_OUTCOMES, rows, "observation_id,horizon_days")
-
-
-def upsert_signal_health(rows: list[dict[str, Any]]) -> int:
-    return _execute_upsert(TABLE_SIGNAL_HEALTH_DAILY, rows, "market,as_of_date,signal_type,regime,horizon_days")
 
 
 def upsert_signal_registry(rows: list[dict[str, Any]]) -> int:
@@ -408,20 +404,3 @@ def load_policy_shadow_runs(days: int = 30, limit: int = 1000, market: str = "cn
     finally:
         if client is not None:
             _close(client)
-
-
-def touch_registry_defaults(market: str, signal_types: list[str]) -> int:
-    now_iso = datetime.now(UTC).isoformat()
-    rows = [
-        {
-            "market": market,
-            "signal_type": signal_type,
-            "track": "Accum" if signal_type in {"spring", "lps", "compression"} else "Trend",
-            "status": "ACTIVE",
-            "weight_multiplier": 1.0,
-            "reason": "default active",
-            "updated_at": now_iso,
-        }
-        for signal_type in signal_types
-    ]
-    return upsert_signal_registry(rows)

--- a/utils/trading_clock.py
+++ b/utils/trading_clock.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from bisect import bisect_right
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -24,23 +23,6 @@ def is_a_share_trading_day(d: date | None = None) -> bool:
         return d in set(cached_trade_dates())
     except Exception:
         return d.weekday() < 5
-
-
-def next_trading_day(after: date | None = None) -> date | None:
-    """返回 after 之后最近的交易日，找不到则返回 None。"""
-    base = after or datetime.now(CN_TZ).date()
-    try:
-        from integrations.fetch_a_share_csv import cached_trade_dates
-
-        dates = cached_trade_dates()
-        idx = bisect_right(dates, base)
-        return dates[idx] if idx < len(dates) else None
-    except Exception:
-        for i in range(1, 8):
-            d = base + timedelta(days=i)
-            if d.weekday() < 5:
-                return d
-        return None
 
 
 def resolve_end_calendar_day(

--- a/workflows/backtest_strategy_variants.py
+++ b/workflows/backtest_strategy_variants.py
@@ -92,10 +92,6 @@ def strategy_variant_overrides(raw: str) -> dict[str, object]:
     return {**_ALL_SWITCHES, **_VARIANT_SWITCHES[variant]}
 
 
-def strategy_variant_label(raw: str) -> str:
-    return VARIANT_LABELS[normalize_strategy_variant(raw)]
-
-
 def strategy_variant_entry_policy(raw: str) -> AShareEntryResearchPolicy:
     return _ENTRY_POLICIES.get(normalize_strategy_variant(raw), AShareEntryResearchPolicy())
 

--- a/workflows/recommendation_tracking_reprice.py
+++ b/workflows/recommendation_tracking_reprice.py
@@ -6,7 +6,6 @@ import logging
 import os
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
-from zoneinfo import ZoneInfo
 
 import pandas as pd
 
@@ -449,29 +448,6 @@ def _build_tushare_tracking_updates(
             if update is not None:
                 updates.append(update)
     return updates, codes_no_data, latest_trade_date
-
-
-def refresh_tracking_prices_with_tushare_unadjusted() -> dict[str, Any]:
-    from integrations.tushare_client import get_pro
-
-    if not is_admin_configured():
-        raise ValueError("SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY 未配置")
-    require_server_write_context("refresh CN tracking prices with Tushare")
-    pro = get_pro()
-    if pro is None:
-        raise ValueError("TUSHARE_TOKEN 未配置或 tushare 不可用")
-    client = create_admin_client()
-    records = fetch_recommendation_tracking_records(client, "id,code,recommend_date")
-    if not records:
-        return empty_tracking_refresh_summary()
-    grouped = _group_records_by_code6(records)
-    updates, codes_no_data, latest_trade_date = _build_tushare_tracking_updates(
-        pro,
-        grouped,
-        datetime.now(ZoneInfo("Asia/Shanghai")).date().strftime("%Y%m%d"),
-        datetime.now(UTC).isoformat(),
-    )
-    return _refresh_summary(records, grouped, updates, codes_no_data, latest_trade_date, client)
 
 
 def refresh_tracking_prices_with_tickflow_realtime() -> dict[str, Any]:

--- a/workflows/review_big_gainers.py
+++ b/workflows/review_big_gainers.py
@@ -88,15 +88,6 @@ def load_today_review_pool(
     return fetch_review_pool(all_codes, name_map_today, today_window, logger)
 
 
-def fetch_and_filter_review_codes(
-    codes: list[str],
-    name_map: dict[str, str],
-    window,
-    log: Callable[[str], None] | None = None,
-) -> list[str]:
-    return fetch_review_pool(codes, name_map, window, log).codes
-
-
 def fetch_review_pool(
     codes: list[str],
     name_map: dict[str, str],

--- a/workflows/strategy_attribution_policy.py
+++ b/workflows/strategy_attribution_policy.py
@@ -82,15 +82,6 @@ class AttributionPolicySnapshot:
         }
 
 
-def load_attribution_signal_weights(
-    *,
-    market: str = "cn",
-    log_fn: Callable[[str], None] | None = None,
-    as_of: date | None = None,
-) -> dict[str, float]:
-    return load_attribution_policy_snapshot(market=market, log_fn=log_fn, as_of=as_of).weights
-
-
 def load_attribution_policy_snapshot(
     *,
     market: str = "cn",


### PR DESCRIPTION
## 变更摘要

起因是 Actions UI 里 `Strategy ${{ matrix.period_key }} / A-M-P` 显示未插值的模板字符串，怀疑是无用代码。

**先说结论：那个不是 bug。** `run_strategy_compare` 默认 `false`，`if:` 为假使 job 在 matrix 展开前就被跳过，GitHub UI 因此只能显示原始模板字符串。上一轮 run 31233157500 同样如此。matrix 定义完整（六个周期），代码正确 —— 要启用只需触发时传 `run_strategy_compare=true`。

顺势做了全库死代码审查。

## 方法

`vulture` 扫描 + 逐个 `grep` 复核。复核范围含 `.py` / `.ts` / `.tsx` / `.yml` / `.md` / `.json`，排除 `.venv` 与 `wiki_repo`，并额外检查 `__all__` 导出与同文件字符串动态引用。

**vulture 单独用不可靠**：60% 置信度下大量误报 —— `evaluate_fundamental_overlay` 实有 7 处引用、`analyze_intraday` 有 11 处、`research_via_cdp` 有 4 处。100% 置信度只报出 6 个未使用局部变量，覆盖不足。所以必须两步走。

最终确认 22 个函数全库零引用，分布在 16 个文件。

## 特别核对的两处

看似"未启用市场的 API"，实际是死代码：

- `us_performance_summary` / `empty_us_performance_summary` 是 CN 版的薄包装（直接 `return performance_summary(...)`），而 `scripts/us_recommendation_performance_job.py` 并不调用它们，走的是通用版
- `is_hk_gem` 在 HK 链路里也无任何调用

## 连带清理

删除后 5 个 import 变为未使用，已一并移除：`find_spec`、`UTC`、`datetime`、`bisect_right`、`ZoneInfo`。

## 验证

- 16 个受影响模块**逐个 import 成功**（不只依赖测试覆盖）
- `pytest tests/` — **2529 passed**
- `tsc --noEmit` — 通过
- `ruff check` / `ruff format` — 通过
- `quality_gate.py --check-functions` — 0 违规
- `check_workflow_hygiene.py` — PASS
- diff 复核：恰好 22 个 `-def`，与验证清单一致，无误删

净删除 223 行。

## 未发现的问题

- 无完全未被引用的 Python 模块（全部 `core/` `workflows/` `tools/` `integrations/` `utils/` 逐个检查）
- TS 侧 `tsc` 干净；未启用 `noUnusedLocals`，如需更严可另行开启

🤖 Generated with [Claude Code](https://claude.com/claude-code)