### PR TITLE
fix: 跨日确认信号补跑损失护栏（回测与实盘口径不一致）

### DIFF
--- a/core/backtest_replay.py
+++ b/core/backtest_replay.py
@@ -32,7 +32,7 @@ from core.backtest_execution import (
     market_of_board,
     resolve_trade_exit,
 )
-from core.backtest_selection import combine_trigger_scores, select_ai_input_codes
+from core.backtest_selection import candidate_entry_loss_guard, combine_trigger_scores, select_ai_input_codes
 from core.candidate_policy import CandidatePolicyConfig, candidate_score_value
 from core.candidate_ranker import rank_l3_candidates
 from core.candidate_tracks import candidate_entry_track
@@ -92,6 +92,9 @@ class BacktestReplayConfig:
     mainline_config: MainlineEngineConfig | None = None
     signal_weight_map: dict[str, float] = field(default_factory=dict)
     signal_weight_meta: dict[str, object] = field(default_factory=dict)
+    # 对跨日确认信号补跑损失护栏，与实盘 apply_loss_guard 对齐。
+    # 默认开启；设 False 可复现历史上"confirmed 绕过护栏"的旧口径做对照。
+    enforce_confirmed_loss_guard: bool = True
     market_breadth_calculator: MarketBreadthCalculator | None = None
     market_regime_analyzer: MarketRegimeAnalyzer | None = None
     a_share_entry_research: AShareEntryResearchPolicy = field(default_factory=AShareEntryResearchPolicy)
@@ -507,6 +510,11 @@ def _select_ranked_codes(
     config: BacktestReplayConfig,
 ) -> tuple[_RankedSelection | None, int]:
     confirmed = _confirmed_signals(ctx, pending_pool, sector_map, config.a_share_entry_research)
+    if config.enforce_confirmed_loss_guard:
+        guarded_codes, guard_dropped = _guarded_confirmed_codes(confirmed, ctx, config)
+        if guard_dropped:
+            logger.debug("confirmed 护栏拦截 %d 只: %s", len(guard_dropped), guard_dropped)
+        confirmed = replace(confirmed, codes=guarded_codes)
     selected_codes, score_map, track_map = select_ai_input_codes(
         result=ctx.result,
         day_df_map=ctx.day_df_map,
@@ -607,6 +615,43 @@ def _merge_confirmed_metadata(
         if code not in score_map or score > candidate_score_value(score_map.get(code)):
             score_map[code] = score
             track_map[code] = confirmed.track_map.get(code, track_map.get(code, ""))
+
+
+def _guarded_confirmed_codes(
+    confirmed: _ConfirmedSignals,
+    ctx: _DayContext,
+    config: BacktestReplayConfig,
+) -> tuple[list[str], dict[str, str]]:
+    """对跨日确认信号补跑损失护栏。
+
+    实盘 (workflows/wyckoff_funnel.py) 对漏斗输出统一调用 apply_loss_guard，
+    但回测的 confirmed 路径此前直接绕过 candidate_policy：pending_mode="only"
+    时 _merge_codes 返回未经护栏的 confirmed，导致「单 SOS/单 Spring 仅观察」
+    「结构止损距离上限」等护栏在回测中全部失效——护栏类改动因此无法被验证，
+    且回测会系统性高估这些标的的入选量。
+
+    确认状态由信号状态机提供，不代表通过护栏：两者约束的是不同维度
+    （前者是"结构是否跨日存活"，后者是"该结构值不值得买"）。
+    """
+    if not confirmed.codes:
+        return [], {}
+    kept: list[str] = []
+    dropped: dict[str, str] = {}
+    for code in confirmed.codes:
+        item = {"code": code, "entry_type": confirmed.trigger_map.get(code, ""), "score": confirmed.score_map.get(code)}
+        reason = candidate_entry_loss_guard(
+            item,
+            result=ctx.result,
+            day_df_map=ctx.day_df_map,
+            regime=ctx.regime,
+            candidate_policy=config.candidate_policy,
+            signal_weight_map=config.signal_weight_map,
+        )
+        if reason:
+            dropped[code] = reason
+        else:
+            kept.append(code)
+    return kept, dropped
 
 
 def _merge_codes(selected: list[str], confirmed: list[str], pending_mode: str, merge_order: str) -> list[str]:

--- a/tests/core/test_backtest_replay.py
+++ b/tests/core/test_backtest_replay.py
@@ -659,7 +659,10 @@ def test_low_score_confirmed_signal_does_not_downgrade_funnel_candidate(monkeypa
             self.written = True
 
         def tick(self, *_args, **_kwargs):
-            return [{"code": "000001", "score": 20.0, "track": "Trend", "signal_type": "evr"}]
+            # 单 EVR 会被 pure_evr_observe_only 正确拦掉；本用例要测的是
+            # "低分 confirmed 不得覆盖漏斗候选元数据"，故改用能通过护栏的
+            # compression，以隔离该行为。
+            return [{"code": "000001", "score": 20.0, "track": "Trend", "signal_type": "compression"}]
 
     monkeypatch.setattr("core.backtest_replay.calc_market_breadth", lambda _df_map: {})
     monkeypatch.setattr(
@@ -747,3 +750,49 @@ def test_watch_score_map_degrades_to_empty_on_failure(monkeypatch):
     )
 
     assert replay_mod._watch_score_map(ctx, {}) == {}
+
+
+def test_confirmed_codes_pass_through_loss_guard(monkeypatch) -> None:
+    """跨日确认信号必须补跑损失护栏，与实盘 apply_loss_guard 对齐。
+
+    pending_mode="only" 时 _merge_codes 原本直接返回未经护栏的 confirmed，
+    导致「单 EVR/单 SOS/单 Spring 仅观察」「结构止损上限」等护栏在回测中全部
+    失效——护栏类改动因此无法被验证，且回测系统性高估这些标的的入选量。
+    """
+
+    class Pending:
+        def write(self, *_args, **_kwargs):
+            return None
+
+        def tick(self, *_args, **_kwargs):
+            # 单 EVR：pure_evr_observe_only 默认 True，应被护栏拦掉
+            return [{"code": "000001", "score": 20.0, "track": "Trend", "signal_type": "evr"}]
+
+    monkeypatch.setattr("core.backtest_replay.calc_market_breadth", lambda _df_map: {})
+    monkeypatch.setattr(
+        "core.backtest_replay.analyze_benchmark_and_tune_cfg", lambda *_args, **_kwargs: {"regime": "NEUTRAL"}
+    )
+    monkeypatch.setattr(
+        "core.backtest_replay.run_funnel", lambda **_kwargs: _result()._replace(triggers={}, candidate_entries=[])
+    )
+    monkeypatch.setattr("core.backtest_replay.PendingPool", Pending)
+
+    cfg = FunnelConfig(trading_days=3)
+    cfg.ma_long = 2
+    kwargs = dict(
+        all_df_map={"000001": _hist()},
+        bench_df=_hist(),
+        trade_dates=[date(2026, 1, day) for day in range(1, 6)],
+        name_map={"000001": "平安银行"},
+        market_cap_map={},
+        sector_map={},
+        base_cfg=cfg,
+    )
+
+    guarded = replay_backtest(config=replace(_config(), pending_mode="only"), **kwargs)
+    assert guarded.records == [], "单 EVR 应被护栏拦掉，不得成交"
+
+    legacy = replay_backtest(
+        config=replace(_config(), pending_mode="only", enforce_confirmed_loss_guard=False), **kwargs
+    )
+    assert legacy.records, "关闭开关应能复现旧口径（confirmed 绕过护栏）"


### PR DESCRIPTION
## 问题

`core/backtest_replay.py:612` 的 `_merge_codes` 在 `pending_mode="only"` 时**直接返回 `confirmed` 并丢弃 `selected`**：

```python
if pending_mode == "only":
    return confirmed          # selected 被丢弃
```

而 `_confirmed_signals()` 完全不调用 `candidate_policy`。CI 用的正是 `BT_PENDING_MODE=only`。

**后果：回测里所有损失护栏失效** —— 单 SOS / 单 Spring / 单 EVR / 单 LPS 仅观察、结构止损距离上限、高位追涨、短期过热，全部不生效。

这不只是少一层过滤，而是**护栏类改动完全无法被回测验证**。今天合并的「单 Spring 仅观察」在验证轮 (run 31248741109) 里逐位复现了上一轮结果：

| | 上轮 31237549718 | 验证轮 31248741109 |
|---|---|---|
| 成交 | 1983 笔 | 1983 笔 |
| spring 占比 | 696 (35%) | 696 (35%) |
| 均收 | -1.635% | -1.636% |
| 夏普 | -0.545 | -0.564 |

改动被这条路径整个吞掉了。

## 实盘不存在该问题

`workflows/wyckoff_funnel.py:317` 对漏斗输出统一调用 `apply_loss_guard`。所以：

- **spring 降级在实盘是生效的**
- 但回测无法验证它 —— 这是回测与主链路的一处实质性不一致

## 修复

确认状态与护栏约束的是**不同维度**：前者是"结构是否跨日存活"（信号状态机），后者是"该结构值不值得买"（candidate_policy）。通过前者不代表通过后者。

现对 confirmed 复用 `candidate_entry_loss_guard`，与实盘口径对齐。新增 `enforce_confirmed_loss_guard`（默认 `True`），设 `False` 可复现旧口径做对照。

## 验证

- `ruff check` / `ruff format` — 通过
- `pytest tests/` — **2566 passed**
- `quality_gate.py --check-functions` — 0 违规

新增 `test_confirmed_codes_pass_through_loss_guard`：单 EVR 的 confirmed 信号必须被拦掉（`guarded.records == []`），且关闭开关后能复现旧口径（`legacy.records` 非空）—— 同时锁住修复与逃生开关。

**顺带修正一个测试的口径问题**：`test_low_score_confirmed_signal_does_not_downgrade_funnel_candidate` 用单 EVR 作 confirmed 载体，**原本只因绕过护栏才通过**。该用例真实意图是"低分 confirmed 不得覆盖漏斗候选元数据"，改用 `compression` 隔离该行为。

期间还发现 `candidate_entry_key` 对 `"sos+evr"` 这类组合值会原样返回（不在 `LOSS_GUARD_ENTRY_KEYS` 中），导致护栏被静默跳过 —— 所以测试 fixture 必须用合法单类型，不能用组合串绕过。

## 后续

合并后需重跑 `all_defined` 验证轮，才能拿到护栏真实生效下的数据。在此之前：

- spring 降级的真实效果未知（事后剔除估算是均收 -1.53% → -0.24%）
- `parameter_stability` / `walk_forward` 的 `fail` 结论、以及 `alloc_score` / `watch_score` 的相关性，都是护栏未生效状态下的产物，不宜据此重写 `candidate_ranker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)