### PR TITLE
fix(ops): 市场信号就绪判据排除 UNKNOWN，固化只读体检入口

### DIFF
--- a/docs/ITERATION_STRATEGY.md
+++ b/docs/ITERATION_STRATEGY.md
@@ -452,6 +452,46 @@ fail-closed 本身要保留，缺的是可见性：缺失与「行情确实不�
 方法论上这两条同源：**不要用「工作流成功」当验收标准**，要盯产出分布。零产出、恒定产出、
 产出与输入无交集，都是要当故障排查的信号。
 
+## 两条运维验收项的判据修正（2026-08-09）
+
+第一次直接读库体检上面两条 P0，结论是**两条都比记录的更健康，但我原先写下的判据本身有缺陷**。
+体检入口固化为只读脚本 `scripts/check_execution_loop.py`（不写库、不发通知）。
+
+**盘前风控：`schedule` 兜底确实生效。** `premarket_regime` 按周几的非空率为周一 9/11、周二 8/11、
+周三 11/11、周四 11/11、周五 10/10；07-29 兜底上线之前周一周二有 5 天空，上线之后 2/2 均已填上。
+`benchmark_regime` 全窗口（05-25 ~ 08-07，54 行）只缺 5 天，其中 4 天正是本文档上一节记录的
+`PANIC_REPAIR` 撞 CHECK 约束那次，之后未复发。
+
+**但「两字段均非空」这个判据放得过松。** `premarket_regime = UNKNOWN` 是非空的，能通过该检查，
+而 `UNKNOWN` 本身就是禁买状态——`normalize_premarket_regime` 会把缺失值和真实判定压成同一个值。
+生产 2026-08-07 即此形态：A50 数据缺失，盘前写入 `UNKNOWN`、`premarket_reasons` 为
+「A50 数据缺失，盘前风险无法完整确认」。判据已改为「`benchmark_regime` 非空，且 `premarket_regime`
+非空且不为 `UNKNOWN`」，与 `market_signal_readiness` 的 `ready` 条件对齐，并由测试锁定两者同口径。
+生产代码本身没有这个问题：`market_signal_readiness` 早已把 `UNKNOWN` 判为 `partial`。
+
+**周五的 `trade_date` 结构性拿不到当日 `benchmark_regime`。** `wyckoff_funnel.yml` 的 cron 是
+`17 9 * * 0-4`（周日至周四），各次运行写自己那天的行。窗口内 10 个周五行只有 1 个的
+`daily_job.updated_at` 落在当日，其余都来自 08-05 01:03 的一次批量补写。这不是故障，但意味着
+「连续 10 个交易日就绪」的门槛在只靠排期的情况下无法达成——每周五都会断一次。要么接受按
+「周一至周四」计数，要么给周五补一次盘后运行。这一条尚未决定，先记录。
+
+**执行环当前无告警，且告警逻辑没有盲区。** 11 个运行日（07-23 ~ 08-06）内 `find_unexecuted_exits`
+返回空。体检中一度怀疑存在盲区：603661 恒林股份连续 11 个运行日全是 EXIT、工单写
+`source=holding shares=600`，但它不在 `portfolio_positions` 里，而 `find_unexecuted_exits` 的第一步
+`if code in held` 会把它整个跳过。核查后否决了这个怀疑——600378、600611 呈同样形态且离场单都停在
+07-31，最合理的解释是这些仓位已在 07-31 至 08-03 之间卖出，「不在持仓即视为已执行」正是
+`test_exit_for_a_code_no_longer_held_means_it_was_executed` 明确的设计契约。
+
+**该怀疑源自一处口径错误，值得单独记下来：用 `daily_nav.positions_value` 反推持仓。** 当时的推理是
+08-06 的 `positions_value` 68,439 减去 6 只现存 A 股市值 49,864，缺口 18,575 接近 603661 的
+600 股 × 31.55 = 18,930，故判断它仍在持仓。但 `total_equity 93,866.47 − free_cash 25,427.47`
+恰好等于 68,439.00——**`positions_value` 是残差，不是市值合计**，本文档「实盘反馈验收」一节记的
+`daily_nav` 口径问题就是这件事。拿一个已知为残差的字段去反推持仓，等于用结论证明结论。
+
+三处一并固化进脚本，避免重踩：`trade_orders`/`portfolio_positions` 的主键是 `USER_LIVE:<uuid>`
+而非裸 `USER_LIVE`（后者是另一条早期遗留记录）；`market_signal_daily` 没有 `market` 列；
+`positions_value` 不可当账本。
+
 ## 产业基本面召回通道：立论前提未成立（2026-08-08）
 
 [`FUNDAMENTAL_THEME_LANE_TECHNICAL_DESIGN.md`](FUNDAMENTAL_THEME_LANE_TECHNICAL_DESIGN.md) 提出新建一条
@@ -577,8 +617,8 @@ Newey-West `|t| >= 2`、五分位单调 `rho >= 0.7`、Top-Bottom spread 跨窗�
 |--------|------|----------|
 | P0 | 修复数据泄漏、标签污染、候选与回测口径不一致 | 同一输入在实盘与回放得到同一候选语义 |
 | P0 | **停止**在 OHLCV 形态阈值 / 排序 / 退出参数上迭代 | 见「L4 形态信号四层归因结论」；再开此类实验须先说明为何结论不适用 |
-| P0 | 闭合执行环 | 见「实盘反馈验收」；成交回填与拖延告警已上线，需连续两周无「未执行离场工单」告警才算闭合 |
-| P0 | 恢复盘前风控的按时产出 | 见「漏斗体检」；`schedule` 兜底已上线，需连续两周 `market_signal_daily` 当日行的 `premarket_regime` 与 `benchmark_regime` 均非空 |
+| P0 | 闭合执行环 | 见「实盘反馈验收」；成交回填与拖延告警已上线，需连续两周无「未执行离场工单」告警才算闭合。用 `scripts/check_execution_loop.py` 体检 |
+| P0 | 恢复盘前风控的按时产出 | 见「漏斗体检」与「两条运维验收项的判据修正」；需连续两周 `market_signal_daily` 当日行 `benchmark_regime` 非空、且 `premarket_regime` 非空**且不为 `UNKNOWN`**。仅「非空」会假通过 |
 | P0 | **停止**在合成价值分及其变体上迭代 | 见「连续历史证伪」；全周期八格全负、加宽度 t 值衰减到负，再开须先给出与 beta 分离的新证据 |
 | P0 | 任何新因子结论先过连续历史 | 挑窗一律不作数；须同时给出 beta 调整后 alpha 的 t 值与宽度扫描 |
 | P0 | 「某只票没进漏斗」先做逐层归因，再谈新建通道 | 用 `scripts/diagnose_funnel_recall.py` 给出 L1/L2/L3/买点/离场的真实拒绝层；见「产业基本面召回通道」 |

--- a/docs/OPERATOR_PLAYBOOK.md
+++ b/docs/OPERATOR_PLAYBOOK.md
@@ -83,6 +83,16 @@ wyckoff portfolio fill 600519 --side buy  --shares 100 --price 1680 --date 20260
 工单顶部若出现「未执行的离场工单」，说明某只票的 EXIT 已连发多日仍未落地——
 要么去券商补掉这一笔，要么回填你实际已经成交的记录。
 
+想主动体检而不是等工单提醒，用只读脚本（不写库、不发通知）：
+
+```bash
+.venv/bin/python scripts/check_execution_loop.py
+```
+
+它同时给出执行环状态与 `market_signal_daily` 的连续就绪天数。两点容易误读：工单里出现但已不在
+持仓表的代码属于**已执行**，不是漏报；`daily_nav.positions_value` 是 `total_equity − free_cash`
+的残差，不能用它反推持仓。
+
 工单底部的现金是“若全部工单成交后的预计可用现金”，不是券商实时余额。未成交 `EXIT`
 不会再把模型给出的历史破位价写回持仓；若新仓工单出现同时高于成本和现价的止损，OMS 会将
 该离场动作降级为 `HOLD`。此时应先核对买入日期和原始入场失效位，不要把倒挂价当保护止损。

--- a/scripts/check_execution_loop.py
+++ b/scripts/check_execution_loop.py
@@ -1,0 +1,195 @@
+"""只读体检两条运维验收项：执行环闭合与市场信号就绪。
+
+不写库、不发通知、不改配置。用于回答「这两条 P0 现在到底达标了没有」，
+避免每次都手写临时脚本重踩同样的坑。
+
+用法：
+    python scripts/check_execution_loop.py
+    python scripts/check_execution_loop.py --days 30 --portfolio-id USER_LIVE:<uuid>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date, datetime, timedelta
+
+import _bootstrap  # noqa: F401
+
+from core.execution_audit import find_unexecuted_exits
+from integrations.supabase_base import create_admin_client
+
+# premarket_regime 非空并不等于就绪：缺失值与真实判定都会被压成 UNKNOWN，
+# 而 UNKNOWN 本身是禁买状态。判定必须排除它，否则「两字段非空」会给出假通过。
+INVALID_PREMARKET = frozenset({"", "UNKNOWN"})
+REQUIRED_STREAK = 10
+
+
+def market_signal_row_ready(row: dict) -> bool:
+    """当日行是否真的可用于 Step4 放行判定。
+
+    与 `integrations.supabase_market_signal.market_signal_readiness` 的 ready 条件对齐，
+    但只看本地已取到的两个字段，不做 trade_date 新鲜度校验（调用方已按日期取行）。
+    """
+    benchmark = str(row.get("benchmark_regime") or "").strip().upper()
+    premarket = str(row.get("premarket_regime") or "").strip().upper()
+    return bool(benchmark) and premarket not in INVALID_PREMARKET
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="只读体检执行环与市场信号就绪度")
+    parser.add_argument("--days", type=int, default=30, help="market_signal_daily 回看天数")
+    parser.add_argument("--portfolio-id", default="", help="留空则自动选用工单最多的组合")
+    return parser.parse_args()
+
+
+def _resolve_portfolio_id(client, explicit: str) -> str:
+    if explicit:
+        return explicit
+    rows = client.table("trade_orders").select("portfolio_id").order("trade_date", desc=True).limit(200).execute()
+    counts: dict[str, int] = {}
+    for row in rows.data or []:
+        pid = str(row.get("portfolio_id") or "").strip()
+        if pid:
+            counts[pid] = counts.get(pid, 0) + 1
+    if not counts:
+        return ""
+    # 组合主键形如 USER_LIVE:<uuid>，裸 USER_LIVE 是另一条早期遗留记录，不能混用
+    return max(counts.items(), key=lambda kv: kv[1])[0]
+
+
+def check_market_signal(client, days: int) -> bool:
+    print("=" * 78)
+    print(f"[1/2] market_signal_daily 就绪度（近 {days} 天）")
+    print("=" * 78)
+    cutoff = (date.today() - timedelta(days=days)).isoformat()
+    rows = (
+        client.table("market_signal_daily")
+        .select("trade_date,premarket_regime,benchmark_regime,source_jobs")
+        .gte("trade_date", cutoff)
+        .order("trade_date")
+        .execute()
+    )
+    data = list(rows.data or [])
+    if not data:
+        print("无记录，无法判定")
+        return False
+
+    weekdays = "一二三四五六日"
+    print(f"{'trade_date':12s}{'周':>4s}{'premarket':>12s}{'benchmark':>14s}{'daily_job写入日':>18s}{'判定':>8s}")
+    streak = 0
+    for row in data:
+        day = date.fromisoformat(str(row.get("trade_date"))[:10])
+        pre = str(row.get("premarket_regime") or "").strip().upper()
+        bench = str(row.get("benchmark_regime") or "").strip().upper()
+        ready = market_signal_row_ready(row)
+        streak = streak + 1 if ready else 0
+        print(
+            f"{day.isoformat():12s}{weekdays[day.weekday()]:>4s}{pre or '-':>12s}{bench or '-':>14s}"
+            f"{_daily_job_day(row) or '-':>18s}{'OK' if ready else '未就绪':>8s}"
+        )
+
+    print(f"\n当前连续就绪 = {streak} 个交易日（门槛 {REQUIRED_STREAK}）")
+    print("判定口径：benchmark_regime 非空，且 premarket_regime 非空且不为 UNKNOWN")
+    _report_friday_gap(data)
+    return streak >= REQUIRED_STREAK
+
+
+def _daily_job_day(row: dict) -> str:
+    payload = row.get("source_jobs")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            return ""
+    updated = ((payload or {}).get("daily_job") or {}).get("updated_at")
+    return str(updated)[:10] if updated else ""
+
+
+def _report_friday_gap(data: list[dict]) -> None:
+    """周五的 trade_date 没有对应排期：漏斗 cron 是周日到周四，各自写当天的行。"""
+    fridays = [r for r in data if date.fromisoformat(str(r.get("trade_date"))[:10]).weekday() == 4]
+    if not fridays:
+        return
+    same_day = sum(1 for r in fridays if _daily_job_day(r) == str(r.get("trade_date"))[:10])
+    print(f"周五行 {len(fridays)} 个，其中 daily_job 当日写入 {same_day} 个")
+    if same_day < len(fridays):
+        print("  提示：wyckoff_funnel.yml 的 cron 为 '17 9 * * 0-4'（周日至周四），")
+        print("  周五 trade_date 只能靠事后补写获得 benchmark_regime。")
+
+
+def check_execution_loop(client, portfolio_id: str) -> bool:
+    print("\n" + "=" * 78)
+    print(f"[2/2] 执行环闭合（portfolio_id={portfolio_id or '未找到'}）")
+    print("=" * 78)
+    if not portfolio_id:
+        print("无工单记录，无法判定")
+        return False
+    orders = list(
+        client.table("trade_orders")
+        .select("code,name,action,status,trade_date")
+        .eq("portfolio_id", portfolio_id)
+        .order("trade_date", desc=True)
+        .limit(400)
+        .execute()
+        .data
+        or []
+    )
+    positions = list(
+        client.table("portfolio_positions")
+        .select("code,name,shares")
+        .eq("portfolio_id", portfolio_id)
+        .limit(200)
+        .execute()
+        .data
+        or []
+    )
+    held = [str(p.get("code") or "").strip() for p in positions if str(p.get("code") or "").strip()]
+    run_dates = sorted({str(o.get("trade_date"))[:10] for o in orders if o.get("trade_date")})
+    print(f"持仓 {len(held)} 只: {', '.join(sorted(held)) or '-'}")
+    print(
+        f"工单 {len(orders)} 条，覆盖运行日 {len(run_dates)} 个"
+        + (f": {run_dates[0]} .. {run_dates[-1]}" if run_dates else "")
+    )
+
+    stale = find_unexecuted_exits(orders, held)
+    if stale:
+        print(f"\n发现 {len(stale)} 只连续被建议离场但仍在持仓:")
+        for item in stale:
+            severe = " 【严重 ≥3日】" if item.is_severe else ""
+            print(f"  {item.code} {item.name}: {item.action} 连续 {item.days} 运行日，自 {item.since}{severe}")
+        return False
+    print("\n无连续未执行的离场工单 → 当前无告警")
+    _report_closed_orders(orders, set(held))
+    return True
+
+
+def _report_closed_orders(orders: list[dict], held: set[str]) -> None:
+    """已离场代码仅供人工核对，不是告警：不在持仓即视为工单已执行。"""
+    closed: dict[str, list[str]] = {}
+    for row in orders:
+        code = str(row.get("code") or "").strip()
+        if code in held or str(row.get("action") or "").strip().upper() not in {"EXIT", "TRIM"}:
+            continue
+        closed.setdefault(code, []).append(str(row.get("trade_date"))[:10])
+    if not closed:
+        return
+    print("\n历史离场单已不在持仓（视为已执行，仅供核对）:")
+    for code, days in sorted(closed.items()):
+        print(f"  {code}: {len(days)} 条，{min(days)} .. {max(days)}")
+
+
+def main() -> int:
+    args = _parse_args()
+    client = create_admin_client()
+    print(f"体检时间 {datetime.now().strftime('%Y-%m-%d %H:%M')}\n")
+    signal_ok = check_market_signal(client, args.days)
+    loop_ok = check_execution_loop(client, _resolve_portfolio_id(client, args.portfolio_id))
+    print("\n" + "=" * 78)
+    print(f"市场信号就绪: {'达标' if signal_ok else '未达标'}    执行环闭合: {'无告警' if loop_ok else '有告警'}")
+    print("=" * 78)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_execution_loop.py
+++ b/tests/scripts/test_check_execution_loop.py
@@ -1,0 +1,41 @@
+"""市场信号就绪判据：非空不等于就绪。"""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations.supabase_market_signal import market_signal_readiness
+from scripts.check_execution_loop import market_signal_row_ready
+
+
+def _row(premarket: str, benchmark: str, trade_date: str = "2026-08-07") -> dict:
+    return {"trade_date": trade_date, "premarket_regime": premarket, "benchmark_regime": benchmark}
+
+
+def test_both_fields_present_and_valid_is_ready() -> None:
+    assert market_signal_row_ready(_row("NORMAL", "BEAR_REBOUND")) is True
+
+
+@pytest.mark.parametrize("premarket", ["UNKNOWN", "unknown", "", "   "])
+def test_unknown_or_blank_premarket_is_not_ready(premarket: str) -> None:
+    """回归：UNKNOWN 非空但本身就是禁买状态，「两字段非空」会给出假通过。
+
+    生产 2026-08-07 即此形态：A50 缺失导致盘前写入 UNKNOWN。
+    """
+    assert market_signal_row_ready(_row(premarket, "BEAR_REBOUND")) is False
+
+
+def test_missing_benchmark_is_not_ready() -> None:
+    assert market_signal_row_ready(_row("NORMAL", "")) is False
+
+
+@pytest.mark.parametrize(
+    ("premarket", "benchmark"),
+    [("NORMAL", "BEAR_REBOUND"), ("UNKNOWN", "BEAR_REBOUND"), ("NORMAL", ""), ("", "NEUTRAL")],
+)
+def test_matches_production_readiness_verdict(premarket: str, benchmark: str) -> None:
+    """判据必须与 Step4 实际使用的 readiness 同口径，否则体检结论与生产放行不一致。"""
+    row = _row(premarket, benchmark)
+    expected = market_signal_readiness(row, "2026-08-07")["status"] == "ready"
+
+    assert market_signal_row_ready(row) is expected


### PR DESCRIPTION
## Summary

第一次直接读生产库体检 #224 / #225 里登记的两条 P0 观察项。结论:**两条都比记录的更健康,但我先前写下的判据本身有缺陷。**

### 1. 「两字段均非空」会假通过

原判据是「连续两周 `market_signal_daily` 当日行的 `premarket_regime` 与 `benchmark_regime` 均非空」。问题在于 `premarket_regime = UNKNOWN` **是非空的**,能通过检查,而 `UNKNOWN` 本身就是禁买状态——`normalize_premarket_regime` 会把缺失值和真实判定压成同一个值。

生产 2026-08-07 正是此形态:A50 数据缺失,盘前写入 `UNKNOWN`,`premarket_reasons` 为「A50 数据缺失,盘前风险无法完整确认」。

判据改为「`benchmark_regime` 非空,且 `premarket_regime` 非空**且不为 `UNKNOWN`**」,并由测试锁定与 `market_signal_readiness` 的 `ready` 条件同口径。**生产代码本身没有这个问题**——它早已把 `UNKNOWN` 判为 `partial`,只有我写进文档的验收条件写松了。

### 2. 盘前风控兜底确实生效

`premarket_regime` 按周几非空率:周一 9/11、周二 8/11、周三 11/11、周四 11/11、周五 10/10。07-29 `schedule` 兜底上线前周一周二有 5 天空,上线后 2/2 均填上。`benchmark_regime` 全窗口(05-25~08-07,54 行)只缺 5 天,其中 4 天正是文档记录的 `PANIC_REPAIR` 撞 CHECK 约束那次,之后未复发。

### 3. 新发现:周五结构性拿不到当日 benchmark

`wyckoff_funnel.yml` 的 cron 是 `17 9 * * 0-4`(周日至周四),各次运行写自己那天的行。窗口内 10 个周五行只有 1 个的 `daily_job.updated_at` 落在当日,其余都来自 08-05 01:03 的一次批量补写。

这不是故障,但意味着**「连续 10 个交易日就绪」在只靠排期时每周五必断一次**。要么按「周一至周四」计数,要么给周五补一次盘后运行。已记录,未决定处理方式 —— 这属于排期语义变更,想先听你的意见。

### 4. 执行环无告警,且告警逻辑没有盲区

11 个运行日(07-23~08-06)内 `find_unexecuted_exits` 返回空。

体检中我一度怀疑存在盲区:603661 恒林股份连续 11 个运行日全是 EXIT、工单写 `source=holding shares=600`,但它不在 `portfolio_positions` 里,而 `find_unexecuted_exits` 第一步 `if code in held` 会把它整个跳过。**核查后否决了这个怀疑**:600378、600611 呈同样形态且离场单都停在 07-31,最合理解释是这些仓位已在 07-31 至 08-03 之间卖出;「不在持仓即视为已执行」正是 `test_exit_for_a_code_no_longer_held_means_it_was_executed` 明确的设计契约。

该怀疑源自一处口径错误,值得单独记下来:**我用 `daily_nav.positions_value` 反推了持仓。** 但 `total_equity 93,866.47 − free_cash 25,427.47` 恰好等于 `positions_value 68,439.00` —— 它是残差,不是市值合计,正是文档「实盘反馈验收」记过的 `daily_nav` 口径问题。拿已知为残差的字段反推持仓,等于用结论证明结论。

### 5. 固化只读体检入口

新增 `scripts/check_execution_loop.py`(不写库、不发通知),一次给出执行环状态与连续就绪天数,并固化本轮踩到的三个坑:主键是 `USER_LIVE:<uuid>` 而非裸 `USER_LIVE`(后者是早期遗留记录);`market_signal_daily` 没有 `market` 列;`positions_value` 不可当账本。

## Validation

- 新增 `tests/scripts/test_check_execution_loop.py`(10 项),含与生产 `market_signal_readiness` 的同口径参数化校验
- `pytest tests/ -x -q` → **2575 passed**
- `tests/scripts/test_script_help_smoke.py` → 24 passed(自动覆盖新脚本)
- `ruff check .` / `ruff format --check .` → 通过
- `quality_gate.py --ci` → 无新增违规
- `check_workflow_hygiene.py` / `check_dependency_hygiene.py` → 通过
- 脚本已对生产库实跑,输出与逐条手工核对一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)