### PR TITLE
fix(backtest): 触发分按类型内分位归一化到 0~100

### DIFF
--- a/core/backtest_selection.py
+++ b/core/backtest_selection.py
@@ -47,16 +47,49 @@ SIGNAL_WEIGHT_ALIASES = {
 }
 
 
+#: 触发分归一化后的刻度上限。与 candidate_entries 的 _lane_score / _candidate_entry
+#: 同为 0~100，两条路径的分数才能在 _expand_tradeable_quality_pool 里安全 max()，
+#: pure_*_min_score 这组阈值也才对所有触发类型一视同仁。
+TRIGGER_SCORE_SCALE = 100.0
+
+
 def combine_trigger_scores(
     triggers: dict[str, list[tuple[str, float]]],
     signal_weight_map: dict[str, float] | None = None,
     *,
     regime: str = "",
 ) -> dict[str, tuple[float, str]]:
+    """合并同一标的的多触发器分数，归一化到 0~100 后取最大值。
+
+    各 detector 返回的是**不同物理量**，直接比较是错的（实测 1983 笔）：
+
+        _detect_spring → 收回幅度%   1.00 ~ 100.00（中位 8.05）
+        _detect_sos    → 量比        3.05 ~  20.49（中位 4.69）
+        _detect_evr    → 量比        1.86 ~   8.93（中位 2.79）
+        _detect_lps    → 缩量比      0.58
+        _detect_compression → 缩量比 0.61 ~ 0.72
+        trend_pullback → 缩量比      0.25 ~ 0.60
+
+    后果有两层：
+
+    1. **排序错**：spring 天然高一到两个量级，但它 10 日均收 -3.93% 是六类最差，
+       分数几乎最低的 compression 是 +1.44%（类型级 score-ret Spearman = -0.257）。
+    2. **阈值错**：`pure_*_min_score` 默认 6.0 这一刀，只有 spring 的中位分(8.05)
+       能过，trend_pullback(0.43) / compression(0.67) / lps(0.58) 被整类砍掉——
+       而后两者恰是收益最好的。此前观察到"低分拦截拦掉的标的反而更好"
+       （Welch t=-4.51）根因就在这里：阈值不是方向反了，是刻度不对。
+
+    改为先在各触发类型内部做分位归一化，再乘 TRIGGER_SCORE_SCALE 对齐
+    candidate_entries 的 0~100 刻度，最后乘治理权重取 max。分位是无量纲量，
+    消除单位差异；类型内部的相对排序完全保留。
+
+    详见 docs/SCORING_SYSTEM_AUDIT_2026_08.md。
+    """
     reason_map: dict[str, list[str]] = {}
     score_map: dict[str, float] = {}
     for key, pairs in triggers.items():
-        for code, score in pairs:
+        normalized = normalized_trigger_scores(pairs)
+        for code, _score in pairs:
             code_s = str(code).strip()
             if not code_s:
                 continue
@@ -65,9 +98,43 @@ def combine_trigger_scores(
             reason_map[code_s].append(key)
             score_map[code_s] = max(
                 candidate_score_value(score_map.get(code_s)),
-                candidate_score_value(score) * signal_weight_multiplier(key, signal_weight_map, regime=regime),
+                normalized.get(code_s, 0.0) * signal_weight_multiplier(key, signal_weight_map, regime=regime),
             )
     return {code: (score_map.get(code, 0.0), "、".join(reasons)) for code, reasons in reason_map.items()}
+
+
+def normalized_trigger_scores(pairs: list[tuple[str, float]]) -> dict[str, float]:
+    """把同一触发类型内的原始分数转成 0~TRIGGER_SCORE_SCALE，使其跨类型可比。
+
+    两个必须保留的行为（均为实测踩到的回归）：
+
+    1. **非法或非正分数仍归 0**，不参与分位计算。否则 rank(pct) 会让它拿到中位
+       分位（实测 0.5 → 50 分），等于给"算不出分数"的候选一个中等评价。
+    2. **只有一个有效候选时给满分**——该类型内它就是最高分，不该因样本少被压低。
+       实测单候选情形仅占 2%，不影响整体分布。
+
+    同分并列取平均分位，避免顺序抖动。
+    """
+    valid: dict[str, float] = {}
+    zeros: list[str] = []
+    for code, score in pairs or []:
+        code_s = str(code).strip()
+        if not code_s:
+            continue
+        value = candidate_score_value(score)
+        if value > 0:
+            valid[code_s] = value
+        else:
+            zeros.append(code_s)
+    out: dict[str, float] = dict.fromkeys(zeros, 0.0)
+    if not valid:
+        return out
+    if len(valid) == 1:
+        out[next(iter(valid))] = TRIGGER_SCORE_SCALE
+        return out
+    ranks = pd.Series(valid).rank(pct=True, method="average")
+    out.update({str(code): float(pct) * TRIGGER_SCORE_SCALE for code, pct in ranks.items()})
+    return out
 
 
 def dedup_order(codes: list[str]) -> list[str]:

--- a/tests/core/test_backtest_replay.py
+++ b/tests/core/test_backtest_replay.py
@@ -573,14 +573,16 @@ def test_name_score_map_prefers_higher_confirmed_source_name() -> None:
     )
     confirmed = replay_mod._ConfirmedSignals(
         codes=["000001"],
-        score_map={"000001": 90.0},
+        # 触发分已归一化到 0~100（该类型内唯一候选得满分 100），故 confirmed 分数
+        # 需高于 100 才能体现"分数更高时优先 confirmed 名称"这一意图。
+        score_map={"000001": 110.0},
         track_map={"000001": "Accum"},
         trigger_map={"000001": "spring"},
     )
 
     got = replay_mod._name_score_map(result, confirmed)
 
-    assert got["000001"] == (90.0, "spring(确认)")
+    assert got["000001"] == (110.0, "spring(确认)")
     assert got["000002"] == (70.0, "tight_base")
 
 
@@ -610,7 +612,9 @@ def test_name_score_map_treats_invalid_candidate_scores_as_zero() -> None:
 
     got = replay_mod._name_score_map(result, confirmed)
 
-    assert got["000001"] == (2.0, "sos")
+    # 触发分已归一化：sos 在该类型内是唯一有效候选，得满分 100。
+    # 非法的 candidate_entries 分数（inf/nan）仍归 0，不会顶掉触发名。
+    assert got["000001"] == (100.0, "sos")
     assert got["000002"] == (0.0, "tight_base")
 
 

--- a/tests/core/test_backtest_selection.py
+++ b/tests/core/test_backtest_selection.py
@@ -73,7 +73,8 @@ def test_all_formal_l4_selection_treats_invalid_trigger_scores_as_zero() -> None
     )
 
     assert codes == ["GOOD", "BAD", "INF", "NAN"]
-    assert score_map == {"GOOD": 2.0, "BAD": 0.0, "INF": 0.0, "NAN": 0.0}
+    # 触发分在类型内归一化到 0~100（跨类型可比）；非法分数仍归 0。
+    assert score_map == {"GOOD": 100.0, "BAD": 0.0, "INF": 0.0, "NAN": 0.0}
     assert track_map == {"GOOD": "Trend", "BAD": "Trend", "INF": "Trend", "NAN": "Trend"}
 
 
@@ -101,7 +102,7 @@ def test_all_formal_l4_selection_excludes_stage_only_candidates() -> None:
     )
 
     assert codes == ["000001"]
-    assert score_map == {"000001": 2.0}
+    assert score_map == {"000001": 100.0}
     assert track_map == {"000001": "Trend"}
 
 
@@ -130,7 +131,8 @@ def test_all_formal_l4_selection_respects_hard_cap() -> None:
     )
 
     assert codes == ["000001", "000002"]
-    assert score_map == {"000001": 3.0, "000002": 2.0}
+    # 三个候选的类内分位为 3/3、2/3、1/3 → 100 / 66.67 / 33.33，硬上限截到前两个。
+    assert score_map == {"000001": 100.0, "000002": pytest.approx(66.667, abs=0.01)}
     assert track_map == {"000001": "Trend", "000002": "Trend"}
 
 
@@ -159,8 +161,9 @@ def test_all_formal_l4_selection_applies_signal_weight_map() -> None:
     )
 
     assert codes == ["000001", "000002"]
-    assert score_map["000001"] == 8.0
-    assert score_map["000002"] == pytest.approx(4.8)
+    # 各类型最高分归一化为 100；权重乘数仍生效（lps ×0.4 → 40）。
+    assert score_map["000001"] == 100.0
+    assert score_map["000002"] == pytest.approx(40.0)
     assert track_map == {"000001": "Trend", "000002": "Accum"}
 
 
@@ -189,8 +192,9 @@ def test_all_formal_l4_selection_applies_scoped_regime_signal_weight() -> None:
     )
 
     assert codes == ["000001", "000002"]
-    assert score_map["000001"] == 8.0
-    assert score_map["000002"] == pytest.approx(4.8)
+    # 各类型最高分归一化为 100；权重乘数仍生效（lps ×0.4 → 40）。
+    assert score_map["000001"] == 100.0
+    assert score_map["000002"] == pytest.approx(40.0)
     assert track_map == {"000001": "Trend", "000002": "Accum"}
 
 
@@ -229,7 +233,7 @@ def test_tradeable_l4_selection_uses_formal_l4_without_l3_fallback() -> None:
     )
 
     assert codes == ["000005", "000006"]
-    assert score_map == {"000005": 1.5, "000006": 1.0}
+    assert score_map == {"000005": 100.0, "000006": 100.0}
 
 
 def test_tradeable_l4_selection_unions_candidate_board_with_formal_quality_pool() -> None:
@@ -264,7 +268,8 @@ def test_tradeable_l4_selection_unions_candidate_board_with_formal_quality_pool(
     )
 
     assert codes == ["000001", "000002"]
-    assert score_map == {"000001": 85.0, "000002": 78.0}
+    # 两条路径现在同为 0~100 刻度：triggers 归一化后 100，candidate_entries 原样 78。
+    assert score_map == {"000001": 100.0, "000002": 78.0}
     assert track_map == {"000001": "Trend", "000002": "Trend"}
 
 


### PR DESCRIPTION
## 变更摘要

各 detector 返回的是**不同物理量**，却被 `combine_trigger_scores` 当同一 score 直接 `max()` 比较（实测 1983 笔）：

| detector | 物理量 | 实测范围 |
| --- | --- | --- |
| `_detect_spring` | **收回幅度%** | 1.00 ~ **100.00**（中位 8.05） |
| `_detect_sos` | 量比 | 3.05 ~ 20.49（中位 4.69） |
| `_detect_evr` | 量比 | 1.86 ~ 8.93（中位 2.79） |
| `_detect_lps` / `compression` / `trend_pullback` | 缩量比 | 0.25 ~ 0.72 |

后果有两层，**此前被我当成两个独立问题**：

1. **排序错**：spring 天然高一到两个量级，但它 10 日均收 -3.93% 是六类最差，分数几乎最低的 compression 是 +1.44%（类型级 score-ret Spearman = -0.257）。
2. **阈值错**：`pure_*_min_score` 默认 6.0 这一刀，**只有 spring 的中位分(8.05)能过**，`trend_pullback`(0.43) / `compression`(0.67) / `lps`(0.58) 被整类砍掉 —— 而后两者恰是收益最好的。此前观察到「低分拦截拦掉的标的反而更好」（Welch t=-4.51）根因就在这里：**阈值不是方向反了，是刻度不对**。

## 改动

类内分位归一化后乘 `TRIGGER_SCORE_SCALE`(100)，与 `candidate_entries` 的 `_lane_score` 同刻度，两条路径才能在 `_expand_tradeable_quality_pool` 里安全 `max()`。

实测归一化后六个类型的中位分**全部对齐到 55**，阈值不再按类型一刀切：

```
compression 55.0  evr 55.0  lps 55.0  sos 55.0  spring 55.0  trend_pullback 55.0
```

**上一次尝试只归一化了 `triggers` 一条路径**，与 `candidate_entries` 的 0~100 刻度冲突（78.0 > 1.0 使排序变乱）而回退。本次两条路径刻度已统一 —— 原先失败的那个排序测试现在通过。

保留两个必要行为（均为实测踩到的回归）：

- 非法/非正分数仍归 0，不参与分位计算 —— 否则 `rank(pct)` 会给"算不出分数"的候选中位分位（0.5 → 50 分）
- 单一有效候选给满分，不因样本少被压低（实测单候选情形占 2%）

## 两个必须说明的局限

**一、`pure_*_min_score`=6.0 在新刻度下几乎不再拦任何标的**（实测拦截率 66.0% → 0.0%）。这是刻度对齐的必然结果：归一化后最低分位也远高于 6。**这组阈值需要按新刻度重新标定**，否则等于事实上关闭了"低分拦截"。本 PR 不动阈值 —— 先让刻度正确，再谈阈值取值，否则又是在错误刻度上调参。

**二、归一化本身不改善分数与收益的相关性**（Spearman -0.063 → -0.058）。这符合预期：归一化只消除量纲差异，不改变类型**内部**排序，而类内相关性本就接近零（`evr` +0.016、`sos` -0.013、`spring` -0.102）。它解决的是"类型间不可比"，不是"分数无预测力"。后者需要重新设计分数构成，属另一件事。

## 验证

- `ruff check` / `ruff format` — 通过
- `pytest tests/` — **2583 passed**
- `quality_gate.py --check-functions` — 0 违规

9 个测试的断言从原始分数改为归一化值。逐个核对了意图未变：权重乘数仍生效（`lps` ×0.4 → 40）、排序关系保持、非法分数仍归 0。其中 `test_name_score_map_prefers_higher_confirmed_source_name` 的 fixture 需把 confirmed 分数从 90 提到 110 —— 归一化后单候选触发分是 100，原值无法再体现"分数更高时优先 confirmed 名称"这一意图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)