### PR TITLE
fix(ranking): spring 确认先验 0.65 → 0.15

### DIFF
--- a/core/a_share_entry_research.py
+++ b/core/a_share_entry_research.py
@@ -24,6 +24,25 @@ class AShareEntryResearchPolicy:
 
 # Research priors only. Production promotion still requires cross-period and
 # walk-forward evidence; a Wyckoff label alone never grants execution priority.
+# 确认信号的类型先验。数值越高表示该形态确认后越值得给分。
+#
+# 2026-08-09 用 run 31293167694（五个市场环境、3594 笔成交）校准了一次：
+#   trend_pullback  prior 1.00   实测 +0.86%  n=171
+#   lps             prior 0.90   实测 -2.95%  n=11   （样本不足，不动）
+#   compression     prior 0.75   实测 +1.44%  n=30   （样本不足，不动）
+#   spring          prior 0.65   实测 -3.15%  n=1285 ← 唯一明确错配
+#   sos             prior 0.35   实测 -0.99%  n=876
+#   evr             prior 0.10   实测 -2.66%  n=1221
+# prior 与实测收益的 Spearman = +0.257，方向大致正确，只有 spring 定得过高。
+#
+# spring 0.65 → 0.15：它是唯一"样本充足且五个周期方向全部为负"的类型
+# （-4.66 / -4.45 / -4.68 / -1.62 / -2.68，周期均值标准差仅 1.39），
+# 对照其余类型 Welch t=-4.26。0.15 使其落到 evr(0.10) 与 sos(0.35) 之间，
+# 与实测末位相称，且与实盘 _trigger_score 的 spring 降权（45→12）方向一致。
+#
+# 未调 trend_pullback / compression / lps：trend_pullback 虽实测最好但逐周期
+# 方向不稳（+3.12 / +0.98 / -9.25 / -5.93 / +12.26，标准差 8.39），
+# compression(30 笔) 与 lps(11 笔) 样本不足，按它们调整等于拟合噪声。
 CONFIRMED_SIGNAL_PRIOR = {
     "trend_pullback": 1.00,
     "trend_lane_pullback": 1.00,
@@ -32,8 +51,8 @@ CONFIRMED_SIGNAL_PRIOR = {
     "mainline": 0.95,
     "lps": 0.90,
     "compression": 0.75,
-    "spring": 0.65,
     "sos": 0.35,
+    "spring": 0.15,
     "evr": 0.10,
 }
 

--- a/tests/core/test_a_share_entry_research.py
+++ b/tests/core/test_a_share_entry_research.py
@@ -59,7 +59,33 @@ def test_empirical_score_caps_raw_strength_and_prioritizes_better_signal_familie
 
     evr = calibrated_confirmation_score(policy, "evr", 100)
     spring = calibrated_confirmation_score(policy, "spring", 5)
+    compression = calibrated_confirmation_score(policy, "compression", 5)
     trend_pullback = calibrated_confirmation_score(policy, "trend_pullback", 5)
 
-    assert trend_pullback > spring > evr
+    # 强原始分的差信号不得超过弱原始分的好信号：evr 即使满强度也压不过
+    # compression / trend_pullback 的低强度确认。
+    assert trend_pullback > compression > evr
+    # spring prior 已按实测下调到 0.15（低于 evr 的 0.10 + 满强度），故不再
+    # 参与"prior 高者胜"的比较；它只需低于 compression / trend_pullback。
+    assert compression > spring
     assert calibrated_confirmation_score(AShareEntryResearchPolicy(), "evr", 100) == 100
+
+
+def test_spring_prior_reflects_measured_underperformance() -> None:
+    """spring prior 0.65 → 0.15：它是唯一样本充足且五周期方向全负的类型。
+
+    run 31293167694（3594 笔、五个市场环境）：spring -3.15%/n=1285，逐周期
+    -4.66 / -4.45 / -4.68 / -1.62 / -2.68（均值标准差仅 1.39），对照其余类型
+    Welch t=-4.26。原 prior 0.65 让它排第四高，与实测末位不符。
+
+    未调 trend_pullback / compression / lps：前者逐周期方向不稳（标准差 8.39），
+    后两者样本仅 30 / 11 笔。
+    """
+    from core.a_share_entry_research import CONFIRMED_SIGNAL_PRIOR
+
+    assert CONFIRMED_SIGNAL_PRIOR["spring"] == 0.15
+    # spring 应低于所有 prior 未变的形态，仅高于 evr
+    assert CONFIRMED_SIGNAL_PRIOR["spring"] < CONFIRMED_SIGNAL_PRIOR["sos"]
+    assert CONFIRMED_SIGNAL_PRIOR["spring"] < CONFIRMED_SIGNAL_PRIOR["compression"]
+    assert CONFIRMED_SIGNAL_PRIOR["spring"] < CONFIRMED_SIGNAL_PRIOR["trend_pullback"]
+    assert CONFIRMED_SIGNAL_PRIOR["spring"] > CONFIRMED_SIGNAL_PRIOR["evr"]


### PR DESCRIPTION
## 变更摘要

用 `run 31293167694`（五个市场环境、**3594 笔**成交，样本量比上轮翻倍）校准 `CONFIRMED_SIGNAL_PRIOR`：

| 类型 | prior | 实测均收 | n |
| --- | --- | --- | --- |
| `trend_pullback` | 1.00 | +0.86% | 171 |
| `lps` | 0.90 | -2.95% | 11 |
| `compression` | 0.75 | +1.44% | 30 |
| **`spring`** | **0.65** | **-3.15%** | **1285** ← 唯一明确错配 |
| `sos` | 0.35 | -0.99% | 876 |
| `evr` | 0.10 | -2.66% | 1221 |

prior 与实测收益的 Spearman = **+0.257** —— 方向大致正确，只有 spring 定得过高。

spring 是唯一「样本充足且五周期方向全部为负」的类型（-4.66 / -4.45 / -4.68 / -1.62 / -2.68，周期均值标准差仅 **1.39**），对照其余类型 Welch t = **-4.26**。`0.15` 使其落到 `evr`(0.10) 与 `sos`(0.35) 之间，与实盘 `_trigger_score` 的 spring 降权（45→12）方向一致。

**未调其他三项**：`trend_pullback` 虽实测最好但逐周期方向不稳（+3.12 / +0.98 / -9.25 / -5.93 / +12.26，标准差 **8.39**）；`compression`(30 笔) 与 `lps`(11 笔) 样本不足，按它们调整等于拟合噪声。

## 效果（离线推演）

开启 `calibrate_confirmed_score` 后，分位检验方向翻正：

| 口径 | Q5 均收 | Q1 均收 | Welch t |
| --- | --- | --- | --- |
| 原始分（现状） | -3.32% | -1.89% | **-2.58**（高分更差） |
| 校准分 + 旧 prior | — | — | +1.40 |
| 校准分 + 新 prior | -1.55% | -3.17% | **+2.63** |

逐周期 Spearman 四升一降（`bull_2020` +0.139、`volatile_2024` +0.185、`bear_2022` +0.029、`recent_6m` +0.025、`sideways_2023` -0.043）。

## 三个必须说明的局限

**一、`calibrate_confirmed_score` 默认为 `False`**，只有策略变体 "I" 启用。所以本次 prior 调整**当前不影响任何生产路径**，包括 CI 回测。它是为后续启用校准做准备 —— 我没有顺手打开开关，因为那会同时改变分数刻度与排序，出问题无法归因。

**二、整体 Spearman 并未改善**（+0.052 → +0.000）。Q5-Q1 显著改善但秩相关走平，两个指标测的不是同一件事：spring 占样本 36%，被压到 Q1/Q2 后拉开了两端差距，但其内部收益方差大，单调秩相关被摊平。

**三、分位收益不单调**（Q1 -3.17 / Q2 -1.72 / Q3 -2.80 / Q4 -1.88 / Q5 -1.55）。说明校准分只做到「两端可分」，尚未做到「逐级递增」。要单调需要重新设计分数构成，不是调 prior 能解决的。

## 验证

- `ruff check` / `ruff format` — 通过
- `pytest tests/` — **2584 passed**（新增 1 个测试）

配套修正 `test_empirical_score_caps_raw_strength_and_prioritizes_better_signal_families`：它原以 `spring > evr` 表达「强原始分的差信号不得超过弱原始分的好信号」，而新 prior 下 spring 已低于 evr 满强度值。改用 `compression` 承载该意图，并保留 spring 需低于 `compression` / `trend_pullback` 的断言。

🤖 Generated with [Claude Code](https://claude.com/claude-code)