### PR TITLE
chore: 自托管 Star History 图

### DIFF
--- a/.github/workflows/star_history.yml
+++ b/.github/workflows/star_history.yml
@@ -1,0 +1,57 @@
+name: Star History
+
+# GitHub 自 2026-06-30 起收紧 stargazers API：第三方服务无法再公开拉 star 时间线，
+# README 里 api.star-history.com 的实时图会显示 "restricted access"。
+# 本 workflow 用仓库自己的 GITHUB_TOKEN 读本仓 stargazers，生成 SVG 并写回 README。
+
+on:
+  schedule:
+    - cron: "0 12 * * 0" # 每周日 UTC 12:00 ≈ 北京时间 20:00
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: false
+
+jobs:
+  star-history:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Render chart into README.md
+        uses: narayann7/star-history-action@v1
+        with:
+          repos: ${{ github.repository }}
+          output-dir: assets/star-history
+          type: Date
+          themes: light,dark
+          update-readme: true
+          readme: README.md
+          commit: false
+
+      - name: Render chart into docs/README_EN.md
+        uses: narayann7/star-history-action@v1
+        with:
+          repos: ${{ github.repository }}
+          output-dir: assets/star-history
+          type: Date
+          themes: light,dark
+          update-readme: true
+          readme: docs/README_EN.md
+          commit: false
+
+      - name: Commit and push chart
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/star-history README.md docs/README_EN.md
+          if git diff --staged --quiet; then
+            echo "No star history changes"
+            exit 0
+          fi
+          git commit -m "chore: update star history [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -266,4 +266,5 @@ wyckoff dashboard
 
 ---
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YoungCan-Wang/WyckoffTradingAgent&type=Date)](https://star-history.com/#YoungCan-Wang/WyckoffTradingAgent&Date)
+<!-- star-history:start -->
+<!-- star-history:end -->

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -330,4 +330,5 @@ If this project helps, a GitHub Star is appreciated. If it helps you make money,
 
 ---
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YoungCan-Wang/WyckoffTradingAgent&type=Date)](https://star-history.com/#YoungCan-Wang/WyckoffTradingAgent&Date)
+<!-- star-history:start -->
+<!-- star-history:end -->


### PR DESCRIPTION
## Summary
- GitHub 收紧 stargazers API 后，README 里 `api.star-history.com` 实时图失效
- 改为 CI 用本仓 token 生成 SVG，写回 `README.md` / `docs/README_EN.md`

## Test plan
- [ ] Merge 后手动跑一次 `Star History` workflow
- [ ] 确认 README 出现 star 曲线图，不再显示 restricted access


Made with [Cursor](https://cursor.com)