### PR TITLE
feat: 批量调仓 items，压多轮 LLM

### DIFF
--- a/agents/portfolio_tools.py
+++ b/agents/portfolio_tools.py
@@ -51,6 +51,7 @@ def update_portfolio(
     free_cash: float = 0,
     table: str = "",
     codes: list[str] | None = None,
+    items: list[dict[str, Any]] | None = None,
     tool_context: ToolContext | None = None,
 ) -> dict:
     try:
@@ -59,6 +60,8 @@ def update_portfolio(
             return _delete_tracking_records(table, codes)
         portfolio_id = _portfolio_id(tool_context)
         cloud = has_cloud(tool_context)
+        if items is not None:
+            return _update_portfolio_batch(normalized_action, portfolio_id, items, free_cash, cloud, tool_context)
         msg = _apply_portfolio_action(
             normalized_action, portfolio_id, code, name, shares, cost_price, buy_dt, free_cash, cloud, tool_context
         )
@@ -70,6 +73,84 @@ def update_portfolio(
     except Exception as e:
         logger.exception("update_portfolio error")
         return {"error": str(e)}
+
+
+_BATCH_ACTIONS = frozenset({"add", "update", "remove"})
+_BATCH_MAX_ITEMS = 30
+
+
+def _update_portfolio_batch(
+    action: str,
+    portfolio_id: str,
+    items: list[dict[str, Any]],
+    free_cash: float,
+    cloud: bool,
+    tool_context: ToolContext | None,
+) -> dict:
+    """一次工具调用改多只：减少 Agent 多轮 LLM，利于 prompt cache。"""
+    if action == "set_cash":
+        return {"error": "批量 items 不支持 set_cash，请单独调用"}
+    if action not in _BATCH_ACTIONS:
+        return {"error": f"批量 items 仅支持 add/update/remove，收到: {action}"}
+    if not isinstance(items, list) or not items:
+        return {"error": "items 必须是非空数组"}
+    if len(items) > _BATCH_MAX_ITEMS:
+        return {"error": f"单次最多 {_BATCH_MAX_ITEMS} 条，请拆分后重试"}
+
+    ok_messages: list[str] = []
+    failures: list[dict[str, Any]] = []
+    for index, raw in enumerate(items):
+        row = _batch_item_row(index, raw, failures)
+        if row is None:
+            continue
+        msg = _apply_portfolio_action(
+            action,
+            portfolio_id,
+            row["code"],
+            row["name"],
+            row["shares"],
+            row["cost_price"],
+            row["buy_dt"],
+            free_cash,
+            cloud,
+            tool_context,
+        )
+        if isinstance(msg, dict) and msg.get("error"):
+            failures.append({"index": index, "code": row["code"], "error": msg["error"]})
+        else:
+            ok_messages.append(str(msg))
+
+    if not ok_messages:
+        first = failures[0]["error"] if failures else "批量操作失败"
+        return {"error": first, "failures": failures, "updated_count": 0, "failed_count": len(failures)}
+    if cloud:
+        _sync_remote_portfolio_to_local(portfolio_id, tool_context)
+    summary = _local_update_summary(portfolio_id, f"批量{action}成功 {len(ok_messages)} 只", cloud)
+    summary["updated_count"] = len(ok_messages)
+    summary["failed_count"] = len(failures)
+    summary["item_messages"] = ok_messages
+    if failures:
+        summary["failures"] = failures
+    return summary
+
+
+def _batch_item_row(index: int, raw: Any, failures: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        failures.append({"index": index, "error": "item 必须是对象"})
+        return None
+    try:
+        shares = int(raw.get("shares") or 0)
+        cost_price = float(raw.get("cost_price") or 0)
+    except (TypeError, ValueError):
+        failures.append({"index": index, "code": raw.get("code"), "error": "shares/cost_price 无效"})
+        return None
+    return {
+        "code": str(raw.get("code") or "").strip(),
+        "name": str(raw.get("name") or "").strip(),
+        "shares": shares,
+        "cost_price": cost_price,
+        "buy_dt": str(raw.get("buy_dt") or "").strip(),
+    }
 
 
 def record_trade_fill(

--- a/cli/tools.py
+++ b/cli/tools.py
@@ -258,7 +258,10 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
     },
     {
         "name": "update_portfolio",
-        "description": "管理用户持仓或删除追踪记录。操作后返回最新状态。",
+        "description": (
+            "管理用户持仓或删除追踪记录。操作后返回最新状态。"
+            "用户一次给出多只加/改/删时，必须用 items 一次提交，禁止拆成多次调用。"
+        ),
         "parameters": {
             "type": "object",
             "properties": {
@@ -269,7 +272,7 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                 },
                 "code": {
                     "type": "string",
-                    "description": "股票代码（add/update/remove 必填）：A股6位如601881，港股06881.HK，美股AAPL.US",
+                    "description": "单只股票代码（无 items 时 add/update/remove 必填）：A股6位如601881，港股06881.HK，美股AAPL.US",
                 },
                 "name": {"type": "string", "description": "股票名称（可选）"},
                 "shares": {"type": "integer", "description": "持仓股数"},
@@ -281,6 +284,24 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "仅 delete_records：股票代码列表",
+                },
+                "items": {
+                    "type": "array",
+                    "description": (
+                        "批量 add/update/remove：一次传入多只。"
+                        "每项含 code；add/update 另需 shares、cost_price；name/buy_dt 可选。"
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "code": {"type": "string"},
+                            "name": {"type": "string"},
+                            "shares": {"type": "integer"},
+                            "cost_price": {"type": "number"},
+                            "buy_dt": {"type": "string"},
+                        },
+                        "required": ["code"],
+                    },
                 },
             },
             "required": ["action"],

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -1860,22 +1860,48 @@ class ToolConfirmScreen(ModalScreen[dict]):
             size = len(self.tool_args.get("content", ""))
             return f"  路径: {path}\n  内容: {size} 字符"
         if self.tool_name == "update_portfolio":
-            action = self.tool_args.get("action", "")
-            code = self.tool_args.get("code", "")
-            parts = [f"操作: {action}"]
-            if code:
-                parts.append(f"代码: {code}")
-            shares = self.tool_args.get("shares")
-            if shares:
-                parts.append(f"股数: {shares}")
-            cost = self.tool_args.get("cost_price")
-            if cost:
-                parts.append(f"成本: {cost}")
-            cash = self.tool_args.get("free_cash")
-            if cash is not None:
-                parts.append(f"现金: {cash}")
-            return "  " + "  ".join(parts)
+            return self._format_portfolio_confirm_summary()
         return f"  {json.dumps(self.tool_args, ensure_ascii=False)}"
+
+    def _format_portfolio_confirm_summary(self) -> str:
+        action = str(self.tool_args.get("action", "") or "")
+        items = self.tool_args.get("items")
+        if isinstance(items, list) and items:
+            lines = [f"  操作: {action} × {len(items)} 只"]
+            for row in items[:8]:
+                if not isinstance(row, dict):
+                    continue
+                code = str(row.get("code") or "").strip()
+                name = str(row.get("name") or "").strip()
+                shares = row.get("shares")
+                cost = row.get("cost_price")
+                detail = " ".join(
+                    part
+                    for part in (
+                        name,
+                        f"{shares}股" if shares not in (None, "", 0) else "",
+                        f"成本{cost}" if cost not in (None, "") else "",
+                    )
+                    if part
+                )
+                lines.append(f"  · {code} {detail}".rstrip())
+            if len(items) > 8:
+                lines.append(f"  · …另有 {len(items) - 8} 只")
+            return "\n".join(lines)
+        code = self.tool_args.get("code", "")
+        parts = [f"操作: {action}"]
+        if code:
+            parts.append(f"代码: {code}")
+        shares = self.tool_args.get("shares")
+        if shares:
+            parts.append(f"股数: {shares}")
+        cost = self.tool_args.get("cost_price")
+        if cost:
+            parts.append(f"成本: {cost}")
+        cash = self.tool_args.get("free_cash")
+        if cash is not None and action == "set_cash":
+            parts.append(f"现金: {cash}")
+        return "  " + "  ".join(parts)
 
     def _editable_value(self) -> str:
         if self.tool_name == "exec_command":

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -487,6 +487,7 @@ CHAT_AGENT_SYSTEM_PROMPT = """\
 - "我有什么持仓""持仓列表""我买了啥""我的持仓有什么""持仓情况" → **查看持仓**（portfolio mode="view"），返回数据即可，不要诊断
 - "我持仓怎么样""帮我看看持仓""持仓健康吗" → **持仓审判**（portfolio mode="diagnose"）
 - "帮我加/删/改持仓""改成本价""改股数" → **调仓操作**（update_portfolio），操作完确认结果即可，**绝不自动追加诊断**
+- **批量铁律：** 用户一次给出多只加/改/删（含「这些成本一起改」）时，必须单次 `update_portfolio`，用 `items` 打包；**禁止一只一轮、禁止连发多次单票调用**
 - **最高优先级：** "帮我看看/看下/分析一下/诊断一下/能不能买/值不值得买 + 股票代码或股票名" 一律是读盘诊断 → analyze_stock mode="diagnose"
 - "帮我看看 000001"、"看下平安银行"、"000001 能不能买" 都必须调 analyze_stock mode="diagnose"，这些不是闲聊，也不是查价
 - 只有用户明确说"最近走势/行情/价格/K线/日线数据/OHLCV/收盘价/涨跌幅"这类查价意图时，才用 analyze_stock mode="price"
@@ -517,6 +518,8 @@ CHAT_AGENT_SYSTEM_PROMPT = """\
 - 用户只给了名字没给代码 → 先调 **搜索** 查出代码，再调 update_portfolio
 - 搜索到多个匹配时，让用户确认是哪一只
 - 绝不允许插入只有代码没有名字、或只有名字没有代码的持仓记录
+- 多只时用 `items: [{code, name, shares, cost_price, buy_dt?}, ...]`，`action` 取 add/update/remove；现金仍单独 `set_cash`
+- 批量场景下不要先查再逐只改：能从用户话里凑齐字段就一次 `items` 提交，最多再 `portfolio(mode="view")` 核对结果
 
 # 分析框架
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -253,7 +253,7 @@ System Prompt 内建路由规则，LLM 自主判断调哪个工具：
 
 - "我有什么持仓" → `portfolio(mode="view")`（纯数据，秒回）
 - "持仓健康吗" → `portfolio(mode="diagnose")`（逐只诊断，较慢）
-- "帮我加/删持仓" → Web 使用 `plan_portfolio_update` → 用户确认 → `execute_portfolio_update`；CLI 使用 `update_portfolio` 并由 TUI 弹窗确认
+- "帮我加/删持仓" → Web 使用 `plan_portfolio_update` → 用户确认 → `execute_portfolio_update`；CLI 使用 `update_portfolio` 并由 TUI 弹窗确认；多只变更时 CLI/MCP 用 `items` 一次提交，避免多轮 LLM
 - "有什么机会" → `screen_stocks`（后台执行）
 
 **铁律：一个工具能回答的问题，绝不调两个。用户没要求分析，就不要分析。**

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -201,7 +201,7 @@ The agent's arsenal — 10 quant tools + 5 general capabilities:
 | `search_stock_by_name` | Fuzzy search by name, ticker, or pinyin |
 | `analyze_stock` | Wyckoff diagnosis / recent OHLCV quotes / fundamental quality overlay (mode switch) |
 | `portfolio` | View holdings / batch portfolio health scan (mode switch) |
-| `update_portfolio` | Add / modify / delete holdings, set available cash, delete tracking records |
+| `update_portfolio` | Add / modify / delete holdings (use `items` for multi-symbol batches), set available cash, delete tracking records |
 | `record_trade_fill` | Back-fill an executed trade: averages cost basis, deducts fees, reports realised P&L |
 | `get_market_overview` | Broad market temperature overview |
 | `screen_stocks` | Mainline funnel full-market screening (⚡background) |

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -481,10 +481,12 @@ def update_portfolio(
     free_cash: float = 0,
     table: str = "",
     codes: list[str] | None = None,
+    items: list[dict] | None = None,
 ) -> dict:
     """管理用户持仓或删除追踪记录。
 
     **调用时机**：用户说"买入/卖出/调仓"、"设置现金"、"删除记录"时调用。
+    **批量**：一次改多只用 items，不要拆成多次调用。
     **危险操作**：会修改用户数据，请确认用户意图后再调用。
     """
     return _update_portfolio(
@@ -497,6 +499,7 @@ def update_portfolio(
         free_cash=free_cash,
         table=table,
         codes=codes,
+        items=items,
         tool_context=_ctx,
     )
 

--- a/tests/agents/test_portfolio_batch_update.py
+++ b/tests/agents/test_portfolio_batch_update.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from utils.tool_result_preview import tool_result_brief_lines
+
+
+def _isolate_local_db(monkeypatch, tmp_path):
+    from integrations import local_db
+
+    if local_db._conn is not None:
+        local_db._conn.close()
+    local_db._conn = None
+    monkeypatch.setattr("core.constants.LOCAL_DB_PATH", tmp_path / "portfolio.db")
+    local_db.init_db()
+
+
+def test_update_portfolio_batch_updates_multiple_local_positions(monkeypatch, tmp_path):
+    from agents import portfolio_tools
+
+    _isolate_local_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(portfolio_tools, "has_cloud", lambda _ctx=None: False)
+    monkeypatch.setattr(portfolio_tools, "_portfolio_id", lambda _ctx=None: "LOCAL")
+    monkeypatch.setattr(
+        portfolio_tools,
+        "code_to_name",
+        lambda code: {"002648": "卫星化学", "300628": "亿联网络"}.get(code, code),
+    )
+
+    result = portfolio_tools.update_portfolio(
+        action="update",
+        items=[
+            {"code": "002648", "name": "卫星化学", "shares": 600, "cost_price": 17.9},
+            {"code": "300628", "name": "亿联网络", "shares": 100, "cost_price": 29.47},
+        ],
+    )
+
+    assert result.get("success") is True
+    assert result["updated_count"] == 2
+    assert result["failed_count"] == 0
+    assert result["position_count"] == 2
+    assert any("002648" in line and "17.9" in line for line in result["positions_summary"])
+
+
+def test_update_portfolio_batch_reports_partial_failures(monkeypatch, tmp_path):
+    from agents import portfolio_tools
+
+    _isolate_local_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(portfolio_tools, "has_cloud", lambda _ctx=None: False)
+    monkeypatch.setattr(portfolio_tools, "_portfolio_id", lambda _ctx=None: "LOCAL")
+    monkeypatch.setattr(portfolio_tools, "code_to_name", lambda code: code)
+
+    result = portfolio_tools.update_portfolio(
+        action="update",
+        items=[
+            {"code": "600018", "name": "上港集团", "shares": 1100, "cost_price": 5.5},
+            {"code": "123", "name": "无效", "shares": 1, "cost_price": 1},
+        ],
+    )
+
+    assert result.get("success") is True
+    assert result["updated_count"] == 1
+    assert result["failed_count"] == 1
+    assert result["failures"][0]["code"] == "123"
+
+
+def test_update_portfolio_batch_rejects_empty_items():
+    from agents.portfolio_tools import update_portfolio
+
+    result = update_portfolio(action="update", items=[])
+    assert "非空" in result["error"]
+
+
+def test_update_portfolio_brief_lines_for_batch():
+    lines = tool_result_brief_lines(
+        "update_portfolio",
+        {
+            "success": True,
+            "message": "批量update成功 2 只",
+            "updated_count": 2,
+            "failed_count": 0,
+            "position_count": 7,
+            "free_cash": 43442.31,
+        },
+    )
+    assert lines[0].startswith("批量调仓: 成功2只")
+    assert "持仓7只" in lines[1]

--- a/utils/tool_result_preview.py
+++ b/utils/tool_result_preview.py
@@ -89,6 +89,8 @@ def tool_result_brief_lines(tool_name: str, result: Any, *, max_lines: int = 3) 
         lines = _screen_stocks_brief_lines(result, max_lines=max_lines)
     elif tool_name == "portfolio":
         lines = _portfolio_brief_lines(result, max_lines=max_lines)
+    elif tool_name == "update_portfolio":
+        lines = _update_portfolio_brief_lines(result, max_lines=max_lines)
     elif tool_name == "analyze_stock":
         lines = _analyze_stock_brief_lines(result, max_lines=max_lines)
     elif tool_name == "generate_ai_report":
@@ -597,6 +599,36 @@ def _portfolio_brief_lines(result: dict[str, Any], *, max_lines: int) -> list[st
     if isinstance(result.get("diagnostics"), list):
         return _portfolio_diagnosis_brief_lines(result, max_lines=max_lines)
     return _portfolio_view_brief_lines(result, max_lines=max_lines)
+
+
+def _update_portfolio_brief_lines(result: dict[str, Any], *, max_lines: int) -> list[str]:
+    updated = result.get("updated_count")
+    failed = result.get("failed_count")
+    if updated is not None or failed is not None:
+        headline = f"批量调仓: 成功{int(updated or 0)}只"
+        if int(failed or 0) > 0:
+            headline += f" · 失败{int(failed)}只"
+        lines = [headline]
+    elif result.get("message"):
+        lines = [_text_excerpt(result.get("message"), 120)]
+    else:
+        lines = []
+    count = result.get("position_count")
+    cash = result.get("free_cash")
+    if count is not None or cash is not None:
+        bits = []
+        if count is not None:
+            bits.append(f"持仓{count}只")
+        if cash is not None:
+            bits.append(f"现金{_format_money(cash)}")
+        if bits:
+            lines.append(" · ".join(bits))
+    failures = result.get("failures")
+    if isinstance(failures, list) and failures:
+        first = failures[0] if isinstance(failures[0], dict) else {}
+        err = str(first.get("error") or first)[:80]
+        lines.append(f"失败样例: {first.get('code', '')} {err}".strip())
+    return [line for line in lines if line][:max_lines]
 
 
 def _portfolio_view_brief_lines(result: dict[str, Any], *, max_lines: int) -> list[str]:


### PR DESCRIPTION
## Summary
- `update_portfolio` 新增 `items`：一次 add/update/remove 多只持仓
- System prompt / tool schema 要求多只必须批量，禁止一只一轮
- TUI 确认窗展示批量摘要；工具 brief 显示成功/失败只数

## Test plan
- [ ] `pytest tests/agents/test_portfolio_batch_update.py -q`
- [ ] TUI：一次说「把这 7 只成本改成…」，应只弹一次确认，且 tool 带 `items`
- [ ] 单只调仓旧路径仍可用


Made with [Cursor](https://cursor.com)