### PR TITLE
fix: 稳定 system 前缀，提升 prompt cache 命中

### DIFF
--- a/cli/sub_agents.py
+++ b/cli/sub_agents.py
@@ -243,9 +243,12 @@ def run_sub_agent(
         tool_timeout_seconds=sub.tool_timeout_seconds,
         deadline=deadline,
     )
+    from core.prompts import append_beijing_time_context
+
     trimmed_context, context_truncated = _fit_context(context, sub.context_budget_tokens)
     user_content = f"{task}\n\n上下文:\n{trimmed_context}" if trimmed_context else task
-    messages: list[dict[str, Any]] = [{"role": "user", "content": user_content}]
+    # 时间挂 user，勿 prepend system，避免子 agent 多轮打爆 prompt cache。
+    messages: list[dict[str, Any]] = [{"role": "user", "content": append_beijing_time_context(user_content)}]
     tool_calls: list[str] = []
     background_task_ids: list[str] = []
     cancelled = _sub_agent_cancel_check(cancel_check, deadline)
@@ -308,10 +311,8 @@ def _run_sub_agent_loop(
     deadline: float,
     on_progress=None,
 ) -> dict[str, Any]:
-    from core.prompts import with_current_time
-
     try:
-        for event in runtime.run_stream(messages, with_current_time(sub.system_prompt)):
+        for event in runtime.run_stream(messages, sub.system_prompt):
             if cancelled():
                 raise AgentCancelled()
             if event["type"] == "tool_start":

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -146,7 +146,7 @@ from cli.tools import TOOL_SPECS
 from cli.workflows.dispatch import build_turn_runtime
 from cli.workflows.executor import WorkflowExecutor
 from cli.workflows.router import WORKFLOWS
-from core.prompts import with_current_time
+from core.prompts import append_beijing_time_context, with_current_time
 
 
 def _pop_lines(log_widget, n: int) -> None:
@@ -2639,7 +2639,8 @@ class WyckoffTUI(App):
             logger.debug("memory context injection failed", exc_info=True)
         if workflow_ctx := self._recent_workflow_context(display):
             mem_ctx = "\n\n".join(item for item in (mem_ctx, workflow_ctx) if item)
-        user_message = {"role": "user", "content": text}
+        # 时间挂在 user 尾部，system 保持静态以便跨 turn 复用 prompt cache。
+        user_message = {"role": "user", "content": append_beijing_time_context(text)}
         if mem_ctx:
             user_message["_memory_context"] = mem_ctx
         self._messages.append(user_message)
@@ -2652,7 +2653,13 @@ class WyckoffTUI(App):
     def _send_system_notification(self, text: str) -> None:
         log = self.query_one("#chat-log", ChatLog)
         log.write(Text.from_markup("  [dim]↳ 后台结果已回传给 agent[/dim]"))
-        self._messages.append({"role": "user", "content": text, "_system_notification": True})
+        self._messages.append(
+            {
+                "role": "user",
+                "content": append_beijing_time_context(text),
+                "_system_notification": True,
+            }
+        )
         if hasattr(self, "_cancel_event") and self._cancel_event is not None:
             self._cancel_event.clear()
         self._ensure_conversation().begin_turn(text, system_notification=True)

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -13,17 +13,40 @@ __all__ = [
     "CHAT_AGENT_SYSTEM_PROMPT",
     "BACKTEST_ANALYST_SYSTEM_PROMPT",
     "with_current_time",
+    "beijing_time_context_line",
+    "append_beijing_time_context",
 ]
 
+_BEIJING_TIME_MARKER = "当前北京时间："
 
-def with_current_time(base_prompt: str) -> str:
-    """在 system prompt 前注入当前北京时间，让 LLM 可靠地感知时间。"""
+
+def beijing_time_context_line() -> str:
+    """当前北京时间一行说明；供挂到 user 消息尾部，勿 prepend 进 system。"""
     from datetime import datetime, timedelta, timezone
 
     beijing = timezone(timedelta(hours=8))
     now = datetime.now(beijing)
     weekday_cn = "一二三四五六日"[now.weekday()]
-    return f"当前北京时间：{now.strftime('%Y-%m-%d %H:%M')}（星期{weekday_cn}，UTC+8）\n\n{base_prompt}"
+    return f"{_BEIJING_TIME_MARKER}{now.strftime('%Y-%m-%d %H:%M')}（星期{weekday_cn}，UTC+8）"
+
+
+def append_beijing_time_context(text: str) -> str:
+    """把北京时间附在用户话尾部，保持 system 前缀可被 prompt cache 复用。"""
+    body = str(text or "")
+    if _BEIJING_TIME_MARKER in body:
+        return body
+    line = beijing_time_context_line()
+    if not body.strip():
+        return f"[{line}]"
+    return f"{body.rstrip()}\n\n[{line}]"
+
+
+def with_current_time(base_prompt: str) -> str:
+    """兼容旧调用：不再改写 system（分钟级时间戳会整段打爆 prompt cache）。
+
+    时间请用 ``append_beijing_time_context`` 挂到当前 user 轮次。
+    """
+    return base_prompt
 
 
 WYCKOFF_FUNNEL_SYSTEM_PROMPT = r"""# 角色设定

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,7 +102,7 @@ Worker 负责鉴权、输入校验、队列控制面和 HMAC 签名。Vercel Nod
 
 `X-RateLimit-Backend` 明确返回 `redis`、`local` 或 `local-fallback`，便于区分共享额度、未配置 Redis 和 Redis 故障降级。Redis 只承载可过期的协调状态与短期 Agent Run 结果，不承载持仓、订单、交易信号或审计真相；这些数据仍由 Supabase/RLS 管理。
 
-读盘室只在用户问题命中观察篮代码，或明确要求复盘观察篮时，从 TickFlow 拉取相关标的的最新可用行情。快照只在浏览器保存 45 秒，随请求传入 Worker 并校验代码集合、时间和数值类型；它不写入 Supabase 或 Redis，数据源不可用时模型必须明确说明缺失，不得估算价格。
+读盘室只在用户问题命中观察篮代码，或明确要求复盘观察篮时，从 TickFlow 拉取相关标的的最新可用行情。快照只在浏览器保存 45 秒，随请求传入 Worker 并校验代码集合、时间和数值类型；它不写入 Supabase 或 Redis，数据源不可用时模型必须明确说明缺失，不得估算价格。行情块以当轮额外 user 消息注入模型上下文，**不拼进 system prompt**，避免价/时间戳变动打爆 prompt cache。
 
 前端的 `web/apps/web/src/lib/api-url.ts` 统一生成 chat、portfolio 和 settings 的后端地址。本地开发默认连接 `http://127.0.0.1:8787`，生产默认连接 `https://wyckoff-api.yongkai-wang.workers.dev`；部署环境可用公开的构建变量 `VITE_API_URL` 覆盖地址。该变量只包含公开服务地址，不能放 Token。
 
@@ -456,7 +456,7 @@ TUI 启动时自动执行 `prune_memories()`，按类型清理旧记忆：L1 `de
 5. **股票作用域过滤**：当前问题有明确股票时，只保留全局记忆和同代码记忆；当前问题没有明确股票时，带 `codes` 的单股记忆不参与召回
 6. 始终拉取 L3 `persona` 和近期 `preference`，置顶显示，但同样遵守股票作用域过滤
 
-拼成两段注入 system prompt 尾部：
+拼成两段注入当前 user 轮次的记忆上下文（CLI 挂在消息元数据 / 包装层；Web 走对应召回通道），**不要**为了展示时间或行情去改写静态 system 前缀：
 
 ```
 # 用户画像

--- a/tests/cli/test_tui_rendering.py
+++ b/tests/cli/test_tui_rendering.py
@@ -1010,8 +1010,11 @@ def test_send_message_does_not_insert_blank_log_line(monkeypatch):
     WyckoffTUI._send_message(app, "你看我持仓呀")
 
     assert len(log.lines) == 2
-    assert str(log.lines[-1]) == "▌ 你看我持仓呀"
-    assert app._messages == [{"role": "user", "content": "你看我持仓呀"}]
+    assert "你看我持仓呀" in str(log.lines[-1])
+    assert "当前北京时间" not in str(log.lines[-1])
+    assert app._messages[0]["role"] == "user"
+    assert app._messages[0]["content"].startswith("你看我持仓呀")
+    assert "当前北京时间：" in app._messages[0]["content"]
 
 
 def test_send_message_resume_keeps_original_turn_user_text(monkeypatch):
@@ -1030,7 +1033,8 @@ def test_send_message_resume_keeps_original_turn_user_text(monkeypatch):
     soft = "<turn-resume-context>\n原问题: 分析宁德时代\n</turn-resume-context>\n\n分析宁德时代"
     WyckoffTUI._send_message(app, soft, turn_user_text="分析宁德时代", echo_user=False)
 
-    assert app._messages[-1]["content"] == soft
+    assert app._messages[-1]["content"].startswith(soft)
+    assert "当前北京时间：" in app._messages[-1]["content"]
     assert app._conversation.active_turn.user_text == "分析宁德时代"
     assert log.lines == ["kept"]
 
@@ -1047,7 +1051,10 @@ def test_send_system_notification_does_not_insert_blank_log_line():
 
     assert len(log.lines) == 2
     assert "后台结果已回传给 agent" in str(log.lines[-1])
-    assert app._messages == [{"role": "user", "content": "workflow done", "_system_notification": True}]
+    assert app._messages[0]["role"] == "user"
+    assert app._messages[0]["_system_notification"] is True
+    assert app._messages[0]["content"].startswith("workflow done")
+    assert "当前北京时间：" in app._messages[0]["content"]
 
 
 def test_auto_resume_notice_does_not_insert_blank_log_line():

--- a/tests/core/test_prompt_time_context.py
+++ b/tests/core/test_prompt_time_context.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from core.prompts import append_beijing_time_context, beijing_time_context_line, with_current_time
+
+
+def test_with_current_time_keeps_system_prompt_byte_stable() -> None:
+    base = "你是静态 system。"
+    assert with_current_time(base) == base
+    assert "当前北京时间" not in with_current_time(base)
+
+
+def test_append_beijing_time_context_is_idempotent() -> None:
+    once = append_beijing_time_context("帮我看看持仓")
+    assert "帮我看看持仓" in once
+    assert "当前北京时间：" in once
+    twice = append_beijing_time_context(once)
+    assert twice == once
+    assert once.count("当前北京时间：") == 1
+
+
+def test_beijing_time_context_line_format() -> None:
+    line = beijing_time_context_line()
+    assert line.startswith("当前北京时间：")
+    assert "UTC+8" in line

--- a/web/apps/api/src/routes/chat-prompt-cache.test.ts
+++ b/web/apps/api/src/routes/chat-prompt-cache.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { appendMarketWatchModelMessage, buildStableChatSystemPrompt } from '../services/chat-prompt-prefix'
+
+describe('reading-room prompt cache prefix', () => {
+  it('keeps system prompt free of market-watch quotes', () => {
+    const system = buildStableChatSystemPrompt({
+      rolePrompt: 'STATIC_SYSTEM',
+      webSearchGuidance: 'WEB_SEARCH_GUIDANCE',
+    })
+    expect(system).toBe('STATIC_SYSTEM\n\nWEB_SEARCH_GUIDANCE')
+    expect(system).not.toContain('观察篮')
+  })
+
+  it('omits empty web-search guidance', () => {
+    expect(buildStableChatSystemPrompt({ rolePrompt: 'STATIC_SYSTEM' })).toBe('STATIC_SYSTEM')
+  })
+
+  it('appends market watch as a trailing user message', () => {
+    const messages = [
+      { role: 'user' as const, content: '看看 AAPL' },
+      { role: 'assistant' as const, content: '好的' },
+      { role: 'user' as const, content: '复盘观察篮' },
+    ]
+    const next = appendMarketWatchModelMessage(messages, '## 观察篮临时行情\nAAPL.US | 最新价=200')
+    expect(next).toHaveLength(4)
+    expect(next[3]).toEqual({ role: 'user', content: '## 观察篮临时行情\nAAPL.US | 最新价=200' })
+    expect(next.slice(0, 3)).toEqual(messages)
+  })
+
+  it('skips empty market watch context', () => {
+    const messages = [{ role: 'user' as const, content: '你好' }]
+    expect(appendMarketWatchModelMessage(messages, '   ')).toEqual(messages)
+  })
+})

--- a/web/apps/api/src/routes/chat.ts
+++ b/web/apps/api/src/routes/chat.ts
@@ -49,6 +49,7 @@ import {
   decideAgentLoop,
 } from '../services/chat-agent-loop'
 import { resolveChatLanguageModel } from '../services/chat-language-model'
+import { appendMarketWatchModelMessage, buildStableChatSystemPrompt } from '../services/chat-prompt-prefix'
 
 type ChatBindings = { Bindings: Env; Variables: { auth: AuthContext } }
 
@@ -463,12 +464,12 @@ function writeLlmUsage(
   writer.write({ type: 'data-llm-usage', data: metrics, transient: true } as never)
 }
 
-function buildChatSystemPrompt(transport: 'chat' | 'responses', marketWatchContext: string): string {
-  return [
-    WYCKOFF_CHAT_SYSTEM_PROMPT,
-    transport === 'responses' ? WEB_SEARCH_GUIDANCE : '',
-    marketWatchContext,
-  ].filter(Boolean).join('\n\n')
+function buildChatSystemPrompt(transport: 'chat' | 'responses'): string {
+  // 观察篮行情不得拼进 system：价/fetchedAt 一变会打爆整段 prompt cache。
+  return buildStableChatSystemPrompt({
+    rolePrompt: WYCKOFF_CHAT_SYSTEM_PROMPT,
+    webSearchGuidance: transport === 'responses' ? WEB_SEARCH_GUIDANCE : '',
+  })
 }
 
 async function runChatAttempt(args: ChatResilienceArgs, config: ChatModelConfig, marketWatchContext: string): Promise<void> {
@@ -487,12 +488,14 @@ async function runChatAttempt(args: ChatResilienceArgs, config: ChatModelConfig,
       tools,
       ignoreIncompleteToolCalls: true,
     })
+    // 行情作为当轮额外 user 消息挂在末尾，不改写 system / 历史前缀。
+    modelMessages = appendMarketWatchModelMessage(modelMessages, marketWatchContext)
     let continuationCount = 0
     let totalSteps = 0
     let segmentIndex = 0
     let finalFinishReason = 'stop'
 
-    const system = buildChatSystemPrompt(resolved.transport, marketWatchContext)
+    const system = buildChatSystemPrompt(resolved.transport)
 
     while (true) {
       const remainingSteps = CHAT_MAX_TOTAL_STEPS - totalSteps

--- a/web/apps/api/src/services/chat-prompt-prefix.ts
+++ b/web/apps/api/src/services/chat-prompt-prefix.ts
@@ -1,0 +1,19 @@
+/**
+ * 读盘室 system / 当轮行情注入：保持 system 字节稳定，利于 prompt cache。
+ */
+
+export function buildStableChatSystemPrompt(parts: {
+  rolePrompt: string
+  webSearchGuidance?: string
+}): string {
+  return [parts.rolePrompt, parts.webSearchGuidance || ''].filter(Boolean).join('\n\n')
+}
+
+export function appendMarketWatchModelMessage<T extends { role: string }>(
+  messages: T[],
+  marketWatchContext: string,
+): Array<T | { role: 'user'; content: string }> {
+  const context = marketWatchContext.trim()
+  if (!context) return messages
+  return [...messages, { role: 'user', content: context }]
+}


### PR DESCRIPTION
## Summary
- **CLI**：`with_current_time` 不再改写 system；北京时间附在当前 user 消息尾部（主 TUI + sub-agent）
- **Web**：观察篮行情移出 `buildChatSystemPrompt`，以 trailing user 消息注入
- 文档与单测同步

## Test plan
- [x] `pytest tests/core/test_prompt_time_context.py` + 相关 TUI/sub-agent 用例
- [x] `vitest` `chat-prompt-cache.test.ts`
- [ ] 本地 TUI 连续两轮对话，底栏 cache% 应比改前更容易在同分钟/跨轮保持高位
- [ ] 读盘室带观察篮问价：仍能引用行情，且换价后 system 角色段可复用缓存


Made with [Cursor](https://cursor.com)