### PR TITLE
fix(llm): 推理型模型耗尽 max_tokens 时记录根因并放大重试

### DIFF
--- a/integrations/llm_client.py
+++ b/integrations/llm_client.py
@@ -38,6 +38,12 @@ GEMINI_MAX_OUTPUT_TOKENS_DEFAULT = 32768
 GEMINI_MAX_RETRIES = 3
 GEMINI_RETRY_DELAY = 2.0
 
+# 推理型模型思考耗尽 max_tokens 时的放大重试。放大 2 倍是按生产实测取的：
+# deepseek-v4-flash 在 6000 下 100% 返回空正文，12000 下可返回。上限设 32768
+# 防止无界放大——真需要更大预算的提示应该拆分，不是无限抬预算。
+OPENAI_COMPATIBLE_BUDGET_RETRY_FACTOR = 2
+OPENAI_COMPATIBLE_MAX_BUDGET = 32768
+
 
 def get_provider_credentials(provider: str) -> tuple[str, str, str]:
     """
@@ -276,21 +282,51 @@ def _call_openai_compatible(
     max_output_tokens: int | None,
 ) -> str:
     """通过 OpenAI 兼容的 /chat/completions 接口调用（OpenAI/智谱/DeepSeek/Qwen 等）。"""
-    import requests
-
     url = base_url.rstrip("/") + "/chat/completions"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    max_tokens = int(max_output_tokens) if max_output_tokens is not None else 8192
+    max_tokens = max(256, int(max_output_tokens) if max_output_tokens is not None else 8192)
+    text, retry_budget = _openai_compatible_attempt(
+        url, headers, model, system_prompt, user_message, timeout, max_tokens
+    )
+    if text:
+        return text
+    # 推理型模型（deepseek-v4-flash 等）把思考写进 reasoning_content，与正文共用 max_tokens。
+    # 思考吃满预算时 content 为空、finish_reason=length，此前只报「返回内容为空」，
+    # 既看不出根因也无法自救。这里放大一次预算重试——生产实测 flash 在 6000 下 100% 失败、
+    # 12000 下可返回正文。
+    if retry_budget:
+        text, _ = _openai_compatible_attempt(
+            url, headers, model, system_prompt, user_message, timeout, retry_budget, is_retry=True
+        )
+        if text:
+            return text
+    raise RuntimeError("OpenAI 兼容接口返回内容为空")
+
+
+def _openai_compatible_attempt(
+    url: str,
+    headers: dict[str, str],
+    model: str,
+    system_prompt: str,
+    user_message: str,
+    timeout: int,
+    max_tokens: int,
+    *,
+    is_retry: bool = False,
+) -> tuple[str, int]:
+    """发一次请求。返回 (正文, 建议的重试预算)；正文非空时重试预算为 0。"""
+    import requests
+
     payload = {
         "model": model,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
         ],
-        "max_tokens": max(256, max_tokens),
+        "max_tokens": max_tokens,
         "temperature": 0.4,
     }
     resp = requests.post(url, headers=headers, json=payload, timeout=timeout)
@@ -300,11 +336,40 @@ def _call_openai_compatible(
     choices = data.get("choices") or []
     if not choices:
         raise RuntimeError("OpenAI 兼容接口返回无 choices")
-    msg = choices[0].get("message") or {}
-    text = (msg.get("content") or "").strip()
-    if not text:
-        raise RuntimeError("OpenAI 兼容接口返回内容为空")
-    return text
+    choice = choices[0] or {}
+    msg = choice.get("message") or {}
+    text = str(msg.get("content") or "").strip()
+    finish_reason = str(choice.get("finish_reason") or "unknown")
+    usage = data.get("usage") or {}
+    reasoning_tokens = int((usage.get("completion_tokens_details") or {}).get("reasoning_tokens") or 0)
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    if text:
+        return text, 0
+
+    logger.error(
+        "openai_compatible model=%s 返回空正文: finish_reason=%s max_tokens=%s "
+        "completion_tokens=%s reasoning_tokens=%s reasoning_len=%s is_retry=%s",
+        model,
+        finish_reason,
+        max_tokens,
+        completion_tokens,
+        reasoning_tokens,
+        len(str(msg.get("reasoning_content") or "")),
+        is_retry,
+    )
+    if is_retry or finish_reason.lower() != "length" or reasoning_tokens <= 0:
+        return "", 0
+    retry_budget = min(max_tokens * OPENAI_COMPATIBLE_BUDGET_RETRY_FACTOR, OPENAI_COMPATIBLE_MAX_BUDGET)
+    if retry_budget <= max_tokens:
+        return "", 0
+    logger.warning(
+        "openai_compatible model=%s 推理耗尽预算(%s/%s)，放大到 %s 重试一次",
+        model,
+        reasoning_tokens,
+        max_tokens,
+        retry_budget,
+    )
+    return "", retry_budget
 
 
 def _gemini_http_options(timeout: int, base_url: str) -> dict:

--- a/tests/integrations/test_llm_reasoning_budget.py
+++ b/tests/integrations/test_llm_reasoning_budget.py
@@ -1,0 +1,129 @@
+"""推理型模型耗尽 max_tokens 时的诊断与放大重试。
+
+背景：deepseek-v4-flash 把思考写进 reasoning_content，与正文共用 max_tokens。
+生产 2026-08-09/10 两次漏斗失败即此形态——Step4 报「返回内容为空」而无任何可定性信息。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations import llm_client
+
+
+class _Resp:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status
+        self.text = "err"
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _body(content: str, finish: str = "stop", reasoning_tokens: int = 0, reasoning: str = "") -> dict:
+    return {
+        "choices": [{"finish_reason": finish, "message": {"content": content, "reasoning_content": reasoning}}],
+        "usage": {
+            "completion_tokens": reasoning_tokens + len(content),
+            "completion_tokens_details": {"reasoning_tokens": reasoning_tokens},
+        },
+    }
+
+
+def _patch_post(monkeypatch: pytest.MonkeyPatch, responses: list[_Resp]) -> list[dict]:
+    calls: list[dict] = []
+
+    def _post(url, headers=None, json=None, timeout=None):  # noqa: A002
+        calls.append(dict(json or {}))
+        return responses[min(len(calls) - 1, len(responses) - 1)]
+
+    monkeypatch.setattr("requests.post", _post)
+    return calls
+
+
+def _call(max_output_tokens: int | None = 6000) -> str:
+    return llm_client._call_openai_compatible(
+        "https://api.example.com/v1", "k", "deepseek-v4-flash", "sys", "user", 60, max_output_tokens
+    )
+
+
+def test_normal_response_returns_content_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _patch_post(monkeypatch, [_Resp(_body("正文"))])
+
+    assert _call() == "正文"
+    assert len(calls) == 1
+
+
+def test_reasoning_exhausted_budget_retries_with_larger_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """回归：flash 在 6000 下推理占满、content 空；放大到 12000 后应拿到正文。"""
+    calls = _patch_post(
+        monkeypatch,
+        [_Resp(_body("", finish="length", reasoning_tokens=6000, reasoning="想" * 500)), _Resp(_body("正文"))],
+    )
+
+    assert _call(6000) == "正文"
+    assert [c["max_tokens"] for c in calls] == [6000, 12000]
+
+
+def test_retry_happens_only_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    empty = _Resp(_body("", finish="length", reasoning_tokens=6000, reasoning="想"))
+    calls = _patch_post(monkeypatch, [empty])
+
+    with pytest.raises(RuntimeError, match="返回内容为空"):
+        _call(6000)
+    assert len(calls) == 2
+
+
+def test_no_retry_when_finish_reason_is_not_length(monkeypatch: pytest.MonkeyPatch) -> None:
+    """空正文但正常结束属别的故障，放大预算无意义，不该多花一次调用。"""
+    calls = _patch_post(monkeypatch, [_Resp(_body("", finish="stop", reasoning_tokens=0))])
+
+    with pytest.raises(RuntimeError, match="返回内容为空"):
+        _call(6000)
+    assert len(calls) == 1
+
+
+def test_no_retry_when_model_is_not_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非推理模型截断说明正文本身太长，加预算前应先怀疑提示，不自动放大。"""
+    calls = _patch_post(monkeypatch, [_Resp(_body("", finish="length", reasoning_tokens=0))])
+
+    with pytest.raises(RuntimeError, match="返回内容为空"):
+        _call(6000)
+    assert len(calls) == 1
+
+
+def test_budget_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """已达上限时不再放大，避免无界抬预算。"""
+    cap = llm_client.OPENAI_COMPATIBLE_MAX_BUDGET
+    calls = _patch_post(monkeypatch, [_Resp(_body("", finish="length", reasoning_tokens=cap))])
+
+    with pytest.raises(RuntimeError, match="返回内容为空"):
+        _call(cap)
+    assert len(calls) == 1
+
+
+def test_diagnosis_is_logged(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """报错必须带 finish_reason 与推理占用——缺了它们无法定性，这正是本次排查的痛点。"""
+    _patch_post(monkeypatch, [_Resp(_body("", finish="length", reasoning_tokens=6000, reasoning="想" * 10))])
+
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError):
+        _call(6000)
+
+    blob = caplog.text
+    assert "finish_reason=length" in blob
+    assert "reasoning_tokens=6000" in blob
+
+
+def test_http_error_still_raises_with_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_post(monkeypatch, [_Resp({}, status=500)])
+
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        _call()
+
+
+def test_missing_choices_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_post(monkeypatch, [_Resp({"choices": []})])
+
+    with pytest.raises(RuntimeError, match="无 choices"):
+        _call()


### PR DESCRIPTION
## Summary

生产 **2026-08-09 与 08-10 两次 Wyckoff Funnel 失败**,Step4 私人再平衡 `reason=llm_failed`,唯一线索是「OpenAI 兼容接口返回内容为空」。

### 根因

`EFFICIENCY_MODEL` 在 **08-08 03:29** 改为 `deepseek-v4-flash`。它是**推理型模型**,把思考写进 `message.reasoning_content`,而该字段与正文**共用 `max_tokens` 预算**。长提示下推理吃满预算,`content` 为空、`finish_reason=length`。

实测同一长提示:

| max_tokens | finish_reason | content | reasoning_tokens |
|---|---|---|---|
| 6000 | `length` | **0** | **6000/6000**(必然失败) |
| 12000 | `stop` | 220 | 3275 |

**短提示不受影响** —— 所以手动验证模型「可用」也是真的,只是撞不上这个形态。时间线也吻合:08-08 改 secret,08-04/05/06 三次运行 efficiency 报错 0 次,08-09 起开始失败。

原实现 `raise` 时不带 `finish_reason`、不带 `usage`,排查只能靠猜。**本次定位中我先误判为「`reasoning_content` 字段未处理」**,实测短提示下 `content` 有值才转向预算方向 —— 这个弯路正是缺少诊断信息造成的。

### 改动

1. **空正文时记录诊断**:`finish_reason` / `max_tokens` / `completion_tokens` / `reasoning_tokens` / `reasoning_len` / `is_retry`,与 gemini 侧日志格式对齐。
2. **仅在确属推理耗尽时放大预算重试一次**:条件是 `finish_reason=length` **且** `reasoning_tokens>0`,放大 2 倍、上限 32768。

不重试的两种情况有意为之:非推理模型截断(`reasoning_tokens=0`)说明正文本身太长,该怀疑提示;正常结束却空正文是别的故障,放大预算无意义。两者都不该多花一次调用。

### 真实接口验证

```
ERROR openai_compatible model=deepseek-v4-flash 返回空正文: finish_reason=length
      max_tokens=6000 completion_tokens=6000 reasoning_tokens=6000 reasoning_len=9985
WARNING openai_compatible model=deepseek-v4-flash 推理耗尽预算(6000/6000)，放大到 12000 重试一次
结果: 成功，正文 286 字
```

**原本必然失败的调用现在自救成功。** pro 直接成功不触发重试。

### 关于模型选择(本 PR 不改)

`EFFICIENCY_MODEL` 已由用户改为 `deepseek-v4-pro`。实测它在生产 Step4 量级下 5/5 成功、推理占用 370~1606(最坏 27% 预算)。但**推理与正文共用预算**,合计最坏 3390/6000 ≈ **56%,余量 1.8x 而非 3.7x**;而 `deepseek-chat` 推理占用恒为 0,结构上免疫。本 PR 让两者都更安全,不替用户做选择。

## Validation

- 新增 `tests/integrations/test_llm_reasoning_budget.py`(9 项:正常返回不重试、推理耗尽后放大成功、只重试一次、`finish_reason` 非 length 不重试、非推理模型不重试、预算上限、诊断字段入日志、HTTP 错误、无 choices)
- `pytest tests/ -x -q` → **2638 passed**
- `ruff check .` / `ruff format --check .` → 通过
- `quality_gate.py --ci` → 无新增违规
- 已对真实 DeepSeek 接口验证 flash 与 pro 两种路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)