### PR TITLE
feat(us): as-of 漏斗重放，回刷美股推荐表历史交易日

### DIFF
--- a/scripts/market_funnel_backfill.py
+++ b/scripts/market_funnel_backfill.py
@@ -1,0 +1,49 @@
+"""CLI entrypoint for as-of US/HK recommendation backfill."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date, datetime, timedelta
+
+import _bootstrap  # noqa: F401
+
+from workflows.market_funnel_backfill import MarketBackfillRequest, run_market_funnel_backfill
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="按历史交易日回刷美股/港股推荐表（as-of 口径）")
+    parser.add_argument("--market", choices=["us", "hk"], required=True)
+    parser.add_argument("--dates", required=True, help="逗号分隔 YYYY-MM-DD，必须是已收盘的交易日")
+    parser.add_argument("--output-dir", default="artifacts/funnel_backfill", help="artifact 输出目录")
+    parser.add_argument("--apply", action="store_true", help="确认写库；默认只生成 artifact")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    dates = tuple(_parse_date(item) for item in args.dates.split(",") if item.strip())
+    _reject_future_dates(dates)
+    return run_market_funnel_backfill(
+        MarketBackfillRequest(
+            market=args.market,
+            dates=dates,
+            output_dir=args.output_dir,
+            apply=bool(args.apply),
+        )
+    )
+
+
+def _parse_date(raw: str) -> date:
+    return datetime.strptime(str(raw).strip(), "%Y-%m-%d").date()
+
+
+def _reject_future_dates(dates: tuple[date, ...]) -> None:
+    """当天及未来一律拒绝：盘中 K 线未收盘，写进去的是残缺 bar。"""
+    cutoff = date.today() - timedelta(days=1)
+    future = [day.isoformat() for day in dates if day > cutoff]
+    if future:
+        raise ValueError(f"目标日期必须是已收盘的过去交易日，收到: {','.join(future)}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/workflows/test_market_funnel_asof.py
+++ b/tests/workflows/test_market_funnel_asof.py
@@ -1,0 +1,86 @@
+"""Tests for as-of funnel replay (historical backfill)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+
+from workflows.market_funnel_asof import build_asof_pool, truncate_history
+from workflows.market_funnel_runtime import runtime_config_from_env
+
+
+def _frame(start: str, rows: int, *, close: float = 10.0, volume: float = 1_000_000.0) -> pd.DataFrame:
+    dates = pd.date_range(start, periods=rows, freq="B")
+    return pd.DataFrame({"date": dates, "close": close, "high": close, "low": close, "volume": volume})
+
+
+class TestTruncateHistory:
+    def test_cuts_rows_after_as_of(self):
+        out = truncate_history(_frame("2026-01-05", 10), date(2026, 1, 9))
+        assert out is not None
+        assert pd.to_datetime(out["date"]).dt.date.max() == date(2026, 1, 9)
+        assert len(out) == 5
+
+    def test_returns_none_when_as_of_absent(self):
+        # 目标日无该标的数据（停牌/未上市）时不能用前一日冒充。
+        assert truncate_history(_frame("2026-01-05", 10), date(2026, 1, 10)) is None
+
+    def test_returns_none_for_empty(self):
+        assert truncate_history(None, date(2026, 1, 9)) is None
+        assert truncate_history(pd.DataFrame(), date(2026, 1, 9)) is None
+
+
+class TestBuildAsofPool:
+    def test_ranks_by_as_of_dollar_volume_not_latest(self, monkeypatch):
+        monkeypatch.delenv("MARKET_FUNNEL_MIN_HISTORY_ROWS", raising=False)
+        monkeypatch.setenv("MARKET_FUNNEL_MIN_HISTORY_ROWS", "80")
+        runtime = runtime_config_from_env("us", None)
+
+        # BIG 在 as_of 当日成交额更大；SMALL 只在 as_of 之后放量，不应影响 as_of 排名。
+        big = _frame("2026-01-01", 120, close=10.0, volume=5_000_000.0)
+        small = _frame("2026-01-01", 120, close=10.0, volume=1_000_000.0)
+        small.loc[small.index[-1], "volume"] = 99_000_000_000.0
+
+        as_of = pd.to_datetime(small["date"]).dt.date.iloc[-5]
+        pool = build_asof_pool({"BIG.US": big, "SMALL.US": small}, {}, runtime, as_of)
+
+        assert [row["symbol"] for row in pool.ranked] == ["BIG.US", "SMALL.US"]
+        for frame in pool.df_map.values():
+            assert pd.to_datetime(frame["date"]).dt.date.max() == as_of
+
+    def test_drops_symbols_without_as_of_bar(self, monkeypatch):
+        monkeypatch.setenv("MARKET_FUNNEL_MIN_HISTORY_ROWS", "80")
+        runtime = runtime_config_from_env("us", None)
+        frame = _frame("2026-01-01", 120)
+        as_of = pd.to_datetime(frame["date"]).dt.date.iloc[-1]
+        halted = frame.iloc[:-1].copy()
+
+        pool = build_asof_pool({"OK.US": frame, "HALT.US": halted}, {}, runtime, as_of)
+
+        assert [row["symbol"] for row in pool.ranked] == ["OK.US"]
+        assert "HALT.US" not in pool.df_map
+
+    def test_applies_price_and_amount_floors(self, monkeypatch):
+        monkeypatch.setenv("MARKET_FUNNEL_MIN_HISTORY_ROWS", "80")
+        monkeypatch.setenv("MARKET_FUNNEL_MIN_QUOTE_PRICE", "1.0")
+        monkeypatch.setenv("MARKET_FUNNEL_MIN_QUOTE_AMOUNT", "1000000")
+        runtime = runtime_config_from_env("us", None)
+        rich = _frame("2026-01-01", 120, close=10.0, volume=1_000_000.0)
+        cheap = _frame("2026-01-01", 120, close=0.4, volume=1_000_000.0)
+        thin = _frame("2026-01-01", 120, close=10.0, volume=10.0)
+        as_of = pd.to_datetime(rich["date"]).dt.date.iloc[-1]
+
+        pool = build_asof_pool({"RICH.US": rich, "CHEAP.US": cheap, "THIN.US": thin}, {}, runtime, as_of)
+
+        assert [row["symbol"] for row in pool.ranked] == ["RICH.US"]
+
+    def test_name_falls_back_to_symbol(self, monkeypatch):
+        monkeypatch.setenv("MARKET_FUNNEL_MIN_HISTORY_ROWS", "80")
+        runtime = runtime_config_from_env("us", None)
+        frame = _frame("2026-01-01", 120)
+        as_of = pd.to_datetime(frame["date"]).dt.date.iloc[-1]
+
+        pool = build_asof_pool({"AAPL.US": frame}, {"AAPL.US": ""}, runtime, as_of)
+
+        assert pool.ranked[0]["name"] == "AAPL.US"

--- a/workflows/market_funnel_asof.py
+++ b/workflows/market_funnel_asof.py
@@ -1,0 +1,118 @@
+"""As-of (历史某交易日) 重放美股/港股漏斗，用于回刷推荐表。
+
+生产漏斗按 ``get_quotes`` 的实时快照排名并截断候选池，因此无法直接用于历史日期：
+今天调用报价永远返回今天的价格与成交额，用它决定"某历史日谁进候选池"等于引入未来
+信息。本模块改为纯历史口径：
+
+- 候选池排名用**目标日当天**的历史成交额（``dollar_volume_series``，美股 amount 恒为 0
+  时回退 close*volume），不使用实时报价；
+- 每个标的的历史序列在目标日**截断**，L1~L4 只能看到当日及之前的数据；
+- 名称走 universe meta，缺失时回退代码本身（美股 meta 的 name 目前为空，回刷出的
+  名称会是代码，这是取数侧限制，调用方需知情）。
+
+只做信号重建，不做收益归因；``current_price`` 由下游 performance 刷新任务负责。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+import pandas as pd
+
+from core.wyckoff_engine import dollar_volume_series, sort_by_date_if_needed
+from workflows.market_funnel_runtime import RuntimeConfig
+
+
+@dataclass(frozen=True)
+class AsOfPool:
+    """目标日的候选池与截断后的历史。"""
+
+    as_of: date
+    ranked: list[dict[str, Any]]
+    df_map: dict[str, pd.DataFrame]
+
+
+def truncate_history(df: pd.DataFrame | None, as_of: date) -> pd.DataFrame | None:
+    """把历史裁到 as_of（含）为止；目标日无数据或行数不足时返回 None。"""
+    if df is None or df.empty or "date" not in df.columns:
+        return None
+    work = sort_by_date_if_needed(df).copy()
+    stamps = pd.to_datetime(work["date"], errors="coerce")
+    work = work[stamps.dt.date <= as_of]
+    if work.empty:
+        return None
+    last = pd.to_datetime(work["date"], errors="coerce").dt.date.iloc[-1]
+    return work.reset_index(drop=True) if last == as_of else None
+
+
+def build_asof_pool(
+    df_map: dict[str, pd.DataFrame],
+    name_map: dict[str, str],
+    runtime: RuntimeConfig,
+    as_of: date,
+) -> AsOfPool:
+    """用目标日历史成交额重建候选池，替代实时报价排名。"""
+    rows: list[dict[str, Any]] = []
+    truncated: dict[str, pd.DataFrame] = {}
+    for symbol, raw in df_map.items():
+        frame = truncate_history(raw, as_of)
+        if frame is None or len(frame) < runtime.min_history_rows:
+            continue
+        row = _asof_rank_row(symbol, frame, name_map, runtime)
+        if row is None:
+            continue
+        truncated[symbol] = frame
+        rows.append(row)
+    rows.sort(key=lambda item: (item["amount"], item["volume"]), reverse=True)
+    ranked = rows[: runtime.max_symbols]
+    kept = {str(item["symbol"]) for item in ranked}
+    return AsOfPool(as_of=as_of, ranked=ranked, df_map={k: v for k, v in truncated.items() if k in kept})
+
+
+def _asof_rank_row(
+    symbol: str,
+    frame: pd.DataFrame,
+    name_map: dict[str, str],
+    runtime: RuntimeConfig,
+) -> dict[str, Any] | None:
+    close = pd.to_numeric(frame["close"], errors="coerce").dropna()
+    if close.empty:
+        return None
+    last_price = float(close.iloc[-1])
+    if last_price <= 0 or last_price < runtime.min_quote_price:
+        return None
+    dollar_volume = dollar_volume_series(frame)
+    amount = float(dollar_volume.iloc[-1]) if not dollar_volume.empty else 0.0
+    if amount < runtime.min_quote_amount:
+        return None
+    volume = _numeric_column(frame, "volume")
+    return {
+        "symbol": symbol,
+        "name": str(name_map.get(symbol) or symbol).strip() or symbol,
+        "last_price": last_price,
+        "amount": amount,
+        "volume": float(volume.iloc[-1]) if not volume.empty else 0.0,
+        "change_pct": _latest_change_pct(frame),
+        "sector": "",
+    }
+
+
+def _numeric_column(frame: pd.DataFrame, column: str) -> pd.Series:
+    if column not in frame.columns:
+        return pd.Series(dtype=float)
+    return pd.to_numeric(frame[column], errors="coerce").dropna()
+
+
+def _latest_change_pct(frame: pd.DataFrame) -> float:
+    pct = _numeric_column(frame, "pct_chg")
+    if not pct.empty:
+        return float(pct.iloc[-1])
+    close = pd.to_numeric(frame["close"], errors="coerce").dropna()
+    if len(close) < 2 or float(close.iloc[-2]) <= 0:
+        return 0.0
+    return (float(close.iloc[-1]) / float(close.iloc[-2]) - 1.0) * 100.0
+
+
+__all__ = ["AsOfPool", "build_asof_pool", "truncate_history"]

--- a/workflows/market_funnel_backfill.py
+++ b/workflows/market_funnel_backfill.py
@@ -1,0 +1,233 @@
+"""按历史交易日回刷美股/港股推荐表（as-of 口径）。
+
+与 A 股 ``recommendation_backfill`` 同样的安全语义：默认 dry-run 只出 artifact，
+``--apply`` 才写库；写前把目标日期的旧行备份进 artifact，便于回滚。
+
+一次取数、多日重放：历史日 K 拉一次，按每个目标日分别截断，避免重复打满限流。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+from integrations.market_universe import load_hk_symbols, load_us_symbols
+from integrations.recommendation_global import resolve_global_table, upsert_global_recommendations
+from integrations.recommendation_tracking_common import chunked, fetch_records_from_table
+from integrations.supabase_base import create_admin_client, is_admin_configured, require_server_write_context
+from integrations.tickflow_client import TickFlowClient
+from workflows.market_funnel_asof import build_asof_pool, truncate_history
+from workflows.market_funnel_data import (
+    fetch_benchmark_history,
+    fetch_daily_histories,
+    fetch_quotes,
+    quote_name,
+)
+from workflows.market_funnel_job import run_funnel_for_ranked
+from workflows.market_funnel_runtime import RuntimeConfig, runtime_config_from_env
+
+_LOADERS = {"us": load_us_symbols, "hk": load_hk_symbols}
+
+
+@dataclass(frozen=True)
+class MarketBackfillRequest:
+    market: str
+    dates: tuple[date, ...]
+    output_dir: str
+    apply: bool = False
+
+
+def run_market_funnel_backfill(request: MarketBackfillRequest) -> int:
+    market = request.market.lower()
+    if market not in _LOADERS:
+        raise ValueError(f"unsupported market: {market}, must be 'us' or 'hk'")
+    target_dates = tuple(sorted(set(request.dates)))
+    if not target_dates:
+        raise ValueError("dates 不能为空")
+    if not is_admin_configured():
+        raise ValueError("SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY 未配置")
+    if request.apply:
+        require_server_write_context(f"backfill {resolve_global_table(market)}")
+
+    output_dir = Path(request.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    runtime = runtime_config_from_env(market, None)
+    print(f"[funnel-backfill] market={market} dates={','.join(d.isoformat() for d in target_dates)}")
+
+    day_rows = _replay_dates(market, runtime, target_dates)
+    client = create_admin_client()
+    old_rows = _fetch_target_rows(client, market, target_dates)
+    _write_artifacts(output_dir, market, target_dates, day_rows, old_rows)
+
+    if not request.apply:
+        total = sum(len(rows) for rows in day_rows.values())
+        print(f"[funnel-backfill] dry-run 完成，未写库。候选合计 {total} 行，核对 artifact 后加 --apply。")
+        return 0
+    return _apply(client, market, day_rows, old_rows)
+
+
+def _replay_dates(
+    market: str,
+    runtime: RuntimeConfig,
+    target_dates: tuple[date, ...],
+) -> dict[int, list[dict[str, Any]]]:
+    symbols, name_map = _LOADERS[market]()
+    client = TickFlowClient(api_key=_require_api_key())
+    name_map = _augment_names(client, symbols, name_map, runtime)
+    bench_df, bench_symbol = fetch_benchmark_history(client, runtime)
+    print(f"[funnel-backfill] 取历史日K symbols={len(symbols)} count={runtime.kline_count}")
+    df_map, _ = fetch_daily_histories(client, symbols, runtime)
+    print(f"[funnel-backfill] 历史可用 {len(df_map)}/{len(symbols)}")
+
+    out: dict[int, list[dict[str, Any]]] = {}
+    for as_of in target_dates:
+        pool = build_asof_pool(df_map, name_map, runtime, as_of)
+        bench_asof = truncate_history(bench_df, as_of)
+        _, candidates = run_funnel_for_ranked(pool.ranked, pool.df_map, runtime, bench_asof, bench_symbol)
+        rows = [_tracking_row(item) for item in candidates]
+        out[_date_int(as_of)] = rows
+        print(f"[funnel-backfill] {as_of.isoformat()} pool={len(pool.ranked)} candidates={len(rows)}")
+    return out
+
+
+def _augment_names(
+    client: TickFlowClient,
+    symbols: list[str],
+    name_map: dict[str, str],
+    runtime: RuntimeConfig,
+) -> dict[str, str]:
+    """用实时报价补名称。
+
+    美股/港股 universe meta 的 name 字段为空，若直接回落成代码，回刷后线上表的
+    名称会从「爱彼迎」退化成「ABNB.US」。名称不参与 as-of 判定（只是展示字段），
+    所以用今天的报价补名不会引入未来信息；标的改名属极少数，可接受。
+    """
+    out = {code: name for code, name in name_map.items() if str(name or "").strip()}
+    quotes = fetch_quotes(client, symbols, runtime)
+    for code, row in quotes.items():
+        name = quote_name(row or {}, code)
+        if name and name.upper() != code.upper():
+            out[code] = name
+    print(f"[funnel-backfill] 名称补齐 {len(out)}/{len(symbols)}（meta 为空，取自实时报价）")
+    return out
+
+
+def _tracking_row(candidate: dict[str, Any]) -> dict[str, Any]:
+    """与生产 ``market_funnel_tracking._tracking_row`` 同构；日期由 upsert 的参数决定。"""
+    return {
+        "code": str(candidate.get("symbol", "")).strip(),
+        "name": str(candidate.get("name", "")).strip(),
+        "tag": ",".join(candidate.get("triggers") or []),
+        "score": float(candidate.get("score") or 0),
+        "latest_close": float(candidate.get("latest_close") or 0),
+    }
+
+
+def _apply(
+    client,
+    market: str,
+    day_rows: dict[int, list[dict[str, Any]]],
+    old_rows: list[dict[str, Any]],
+) -> int:
+    table = resolve_global_table(market)
+    upserted = 0
+    for recommend_date, rows in sorted(day_rows.items()):
+        if not rows:
+            print(f"[funnel-backfill] {recommend_date} 无候选，跳过写入（旧行保留）")
+            continue
+        if not upsert_global_recommendations(recommend_date, rows, market):
+            raise RuntimeError(f"DB write failed: market={market} date={recommend_date}")
+        upserted += len(rows)
+        print(f"[funnel-backfill] wrote date={recommend_date} rows={len(rows)}")
+    stale = _stale_row_ids(day_rows, old_rows)
+    for batch in chunked(stale, 500):
+        client.table(table).delete().in_("id", batch).execute()
+    print(f"[funnel-backfill] done upserted={upserted} stale_deleted={len(stale)}")
+    return 0
+
+
+def _stale_row_ids(day_rows: dict[int, list[dict[str, Any]]], old_rows: list[dict[str, Any]]) -> list[Any]:
+    """目标日旧行里、新结果不再包含的代码：删掉，避免旧口径残留。
+
+    某目标日新结果为空时不删该日旧行——空结果更可能是取数异常而非真的无候选。
+    """
+    fresh = {date_int: {str(row["code"]).strip() for row in rows} for date_int, rows in day_rows.items() if rows}
+    stale: list[Any] = []
+    for row in old_rows:
+        try:
+            recommend_date = int(row.get("recommend_date"))
+        except (TypeError, ValueError):
+            continue
+        codes = fresh.get(recommend_date)
+        if codes is not None and str(row.get("code") or "").strip() not in codes and row.get("id") is not None:
+            stale.append(row["id"])
+    return stale
+
+
+def _fetch_target_rows(client, market: str, target_dates: tuple[date, ...]) -> list[dict[str, Any]]:
+    wanted = {_date_int(day) for day in target_dates}
+    rows = fetch_records_from_table(client, resolve_global_table(market), "*")
+    return [row for row in rows if _safe_int(row.get("recommend_date")) in wanted]
+
+
+def _write_artifacts(
+    output_dir: Path,
+    market: str,
+    target_dates: tuple[date, ...],
+    day_rows: dict[int, list[dict[str, Any]]],
+    old_rows: list[dict[str, Any]],
+) -> None:
+    stamp = datetime.now(UTC).isoformat()
+    summary = {
+        "generated_at": stamp,
+        "market": market,
+        "table": resolve_global_table(market),
+        "target_dates": [day.isoformat() for day in target_dates],
+        "new_counts": {str(k): len(v) for k, v in sorted(day_rows.items())},
+        "old_counts": _counts_by_date(old_rows),
+        "stale_to_delete": len(_stale_row_ids(day_rows, old_rows)),
+    }
+    (output_dir / f"{market}_backfill_summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (output_dir / f"{market}_backfill_new_rows.json").write_text(
+        json.dumps({str(k): v for k, v in sorted(day_rows.items())}, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (output_dir / f"{market}_backfill_old_rows_backup.json").write_text(
+        json.dumps(old_rows, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+    print(f"[funnel-backfill] artifacts -> {output_dir}")
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+
+
+def _counts_by_date(rows: list[dict[str, Any]]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for row in rows:
+        key = str(_safe_int(row.get("recommend_date")))
+        out[key] = out.get(key, 0) + 1
+    return dict(sorted(out.items()))
+
+
+def _require_api_key() -> str:
+    api_key = os.getenv("TICKFLOW_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError("TICKFLOW_API_KEY 未配置")
+    return api_key
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _date_int(day: date) -> int:
+    return int(day.strftime("%Y%m%d"))
+
+
+__all__ = ["MarketBackfillRequest", "run_market_funnel_backfill"]

--- a/workflows/market_funnel_data.py
+++ b/workflows/market_funnel_data.py
@@ -132,7 +132,7 @@ def _quote_rank_row(
         return None
     return {
         "symbol": symbol,
-        "name": _quote_name(row, symbol),
+        "name": quote_name(row, symbol),
         "last_price": float(last_price),
         "amount": float(amount),
         "volume": float(_row_float(row, "volume") or 0.0),
@@ -166,7 +166,8 @@ def _quote_change_pct(row: dict[str, Any]) -> float:
     return (last_price / prev_close - 1.0) * 100.0
 
 
-def _quote_name(row: dict[str, Any], symbol: str) -> str:
+def quote_name(row: dict[str, Any], symbol: str) -> str:
+    """报价行里的名称；美股/港股实际落在 ``ext.name``，顶层 ``name`` 为 None。"""
     ext = row.get("ext") if isinstance(row.get("ext"), dict) else {}
     for value in (row.get("name"), row.get("ext.name"), ext.get("name")):
         text = str(value or "").strip()

--- a/workflows/market_funnel_job.py
+++ b/workflows/market_funnel_job.py
@@ -260,7 +260,7 @@ def _build_funnel_result(
     }
 
 
-def _run_funnel_for_ranked(
+def run_funnel_for_ranked(
     ranked: list[dict[str, Any]],
     df_map: dict[str, pd.DataFrame],
     runtime: RuntimeConfig,
@@ -310,7 +310,7 @@ def run_market_funnel(
     quotes, ranked, bench_df, bench_symbol, df_map, fetch_stats = fetch_market_inputs(tf, universe_symbols, runtime)
     symbols = [str(item["symbol"]) for item in ranked]
     report_path = market_funnel_report_path(runtime.output_path)
-    metrics, candidates = _run_funnel_for_ranked(ranked, df_map, runtime, bench_df, bench_symbol)
+    metrics, candidates = run_funnel_for_ranked(ranked, df_map, runtime, bench_df, bench_symbol)
     result = _build_funnel_result(
         runtime,
         universe_symbols,


### PR DESCRIPTION
## Summary

生产漏斗按 `get_quotes` 的**实时快照**排名并截断候选池，无法直接用于历史日期 —— 今天调报价永远返回今天的价格与成交额，用它决定「某历史日谁进候选池」等于引入未来信息。另有两处会让"直接重跑 5 次"得到错的结果：

- `recommend_date` 取自历史序列**最后一根 K 线**，所以跑 5 次会把 5 天全部盖成同一天
- 名称若不走报价会退化成代码（universe meta 的 name 全为空）

### 新增 `workflows/market_funnel_asof.py`

候选池排名改用**目标日当天**的历史成交额（`dollar_volume_series`，美股 `amount` 恒为 0 时回退 `close*volume`），每个标的的历史在目标日截断，L1~L4 只能看到当日及之前的数据。目标日无 bar 的标的（停牌/未上市）**直接丢弃**，不用前一日冒充。

### 新增 `workflows/market_funnel_backfill.py`

一次取数、多日重放（历史日 K 拉一次，按各目标日分别截断，避免重复打满限流）。安全语义对齐 A 股的 `recommendation_backfill`：

- 默认 dry-run 只出 artifact，`--apply` 才写库
- 写前把目标日旧行备份进 artifact，便于回滚
- 某日新结果为空时**不删**该日旧行 —— 空结果更可能是取数异常而非真的无候选
- CLI 拒绝当天及未来日期：盘中 K 线未收盘，写进去是残缺 bar

### 名称修复

实测报价的名称在 `ext.name` 而非顶层 `name`（顶层恒为 `None`）。复用生产的 `quote_name`（原 `_quote_name`，改为公开 —— 现有两个正当调用方）补齐，避免线上表名称从「爱彼迎」退化成「ABNB.US」。名称不参与 as-of 判定，所以用今天的报价补名不引入未来信息。

`market_funnel_job._run_funnel_for_ranked` 改为公开 `run_funnel_for_ranked`，回刷复用同一套 L1~L4，不复制打分逻辑。

## Validation

**已回刷线上 `recommendation_tracking_us`**（8/03–8/07 五个交易日）。先 dry-run 核对 artifact，再 `--apply`：

| 日期 | 旧行数 | 新行数 |
| --- | ---: | ---: |
| 20260803 | 87 | 52 |
| 20260804 | 80 | 54 |
| 20260805 | 24 | 66 |
| 20260806 | 23 | 58 |
| 20260807 | 18 | 57 |

`upserted=287`、`stale_deleted=135`、区间内 `name==code` 为 `0/287`。

随后跑 `us_recommendation_performance_job`：`rows_updated=2061`、`codes_no_data=0`。

**低价股 16 只进入**（最低 `ENSC.US` \$0.52）。区间整体均值 `+0.20%`、胜率 50%；其中低价股均值 `-6.00%`、中位 `-8.91%`、胜率 38%。

Gates：`pytest 2663 passed`（含新增 7 个 as-of 用例，覆盖截断边界、停牌日丢弃、价格/成交额地板、名称回退）、`ruff check`、`ruff format --check`、`quality_gate --check-functions` 通过。`test_architecture_boundaries` 抓到 `core._price_math` 属私有，已改从 `core.wyckoff_engine` 导入公开的 `sort_by_date_if_needed`。

## 已知口径限制

1. **8/05–8/07 行数反而变多**（24/23/18 → 66/58/57），因为这三天原本就是旧口径（1500 容量 + \$5M 门槛）下的产出。这次是按新口径重建，不是修复旧数据。
2. **低价股那 16 行收益为负**（均值 −6%），与 L4 形态信号在 A 股五窗口全负的既有结论方向一致。且回测侧仍**无交易成本模型**，\$1–2 的票价差常有 5%–15%，实际结果只会更差。这批数据可以看分布，不足以支撑"放开仙股有 alpha"。
3. `sector_coverage=0`、L3 板块共振层对美股**完全空转**（812 进 812 出），因为报价不返回行业字段。这是既有状态，非本 PR 引入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)