### PR TITLE
fix(web): 升级 nanoid 到 3.3.17

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
   "packageManager": "pnpm@10.33.2",
   "pnpm": {
     "overrides": {
-      "undici": "7.29.0"
+      "undici": "7.29.0",
+      "nanoid": "3.3.17"
     }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   undici: 7.29.0
+  nanoid: 3.3.17
 
 importers:
 
@@ -2064,8 +2065,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4408,7 +4409,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -4459,7 +4460,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary
- 修复 Dependabot 高危告警 #112：`nanoid` custom generator 在 `size=0` 时可能死循环
- 通过 `pnpm.overrides` 将间接依赖从 `3.3.16` 钉到已修复的 `3.3.17`

## Test plan
- [ ] CI `web-check` 通过
- [ ] Dependabot alert #112 关闭或标记 fixed


Made with [Cursor](https://cursor.com)