### PR TITLE
fix(cli): OpenRouter 模型取真实上下文窗口，不再按模型名猜

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ wyckoff mcp-list
 - **Agent 分层记忆** — L1 原子记忆 + L2 场景 + L3 画像，FTS5/代码/关键词混合召回并保留来源追溯
 - **Skills 扩展** — 内置 `/screen`、`/checkup`、`/report`、`/backtest`，用户可自定义
 - **Prompt 模板** — 内置 `/daily`、`/review-l4`、`/step3-audit` 等高频投研模板，也支持 `~/.wyckoff/prompts/*.md`
-- **模型元数据与成本可见性** — `wyckoff model list/usage/cost` 展示上下文窗口、reasoning 能力和本地 token 成本估算
+- **模型元数据与成本可见性** — `wyckoff model list/usage/cost` 展示上下文窗口、reasoning 能力和本地 token 成本估算；OpenRouter 模型的上下文窗口取自其 `/models` 接口的真实值（`wyckoff model refresh` 刷新），不靠模型名猜
 - **会话分叉与导出** — `wyckoff session export/fork` 或 TUI `/fork` 把历史对话变成可复盘、可继续的新分支
 - **标准事件流** — `wyckoff trace --events <scratchpad.jsonl>` / `wyckoff diag` 产出统一 JSONL，方便复盘工具调用时间线
 - **独立边缘后端** — React 统一调用 Hono Worker；后端提供请求 ID、安全响应头、请求体上限、Redis 共享限流和白名单沙箱任务。读盘室的研究计算必须经用户确认，先进入单并发 Cloudflare Queue，再由签名的 Node 执行桥进入无网络、自动销毁的 Vercel Sandbox；每用户同时仅一个任务，并按日限制创建次数与实际 CPU 用量。Worker 与 bridge 用 `requestId`/`runId` 输出不含脚本与密钥的结构化执行日志，本地支持 VS Code 断点与 `workerd` 集成测试

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -220,6 +220,25 @@ def _cmd_auth(args):
         sys.exit(1)
 
 
+def _model_refresh():
+    """重新拉取 OpenRouter 模型目录，刷新真实上下文窗口。"""
+    from cli.auth import load_model_configs
+    from cli.model_catalog import CACHE_PATH, looks_like_openrouter, refresh_catalog
+    from cli.model_registry import infer_model_info
+
+    catalog = refresh_catalog()
+    if not catalog:
+        print("✗ 无法获取 OpenRouter 模型目录（网络或接口异常），继续使用缓存/名称推断")
+        sys.exit(1)
+    print(f"✓ 已刷新 {len(catalog)} 个模型的上下文窗口 -> {CACHE_PATH}")
+    for cfg in load_model_configs():
+        model = str(cfg.get("model", "") or "")
+        if not looks_like_openrouter(str(cfg.get("base_url", "") or "")):
+            continue
+        info = infer_model_info(cfg)
+        print(f"  {cfg['id']:<22} {model:<44} ctx={info.context_window:>9,}  ({info.window_source})")
+
+
 def _model_list():
     from cli.auth import load_default_model_id, load_fallback_model_id, load_model_configs
     from cli.model_registry import format_model_metadata, infer_model_info
@@ -363,6 +382,8 @@ def _cmd_model(args):
         save_model_entry(updated)
         print(f"✓ 模型 {args.model_id} 的成本/上下文元数据已保存")
         return
+    if sub == "refresh":
+        return _model_refresh()
     if sub == "usage":
         from cli.model_registry import summarize_model_usage
 
@@ -1876,7 +1897,9 @@ def _add_auth_model_config_parsers(sub) -> None:
     p_auth.add_argument("password", nargs="?", default="", help="密码（可省略，交互输入）")
 
     p_model = sub.add_parser("model", help="模型管理")
-    p_model.add_argument("model_cmd", nargs="?", default="list", help="list/add/set/rm/default/fallback/cost/usage")
+    p_model.add_argument(
+        "model_cmd", nargs="?", default="list", help="list/add/set/rm/default/fallback/cost/refresh/usage"
+    )
     p_model.add_argument("model_id", nargs="?", default="", help="模型 ID")
     p_model.add_argument("provider", nargs="?", default="", help="供应商 (set 时)")
     p_model.add_argument("api_key", nargs="?", default="", help="API Key (set 时)")

--- a/cli/model_catalog.py
+++ b/cli/model_catalog.py
@@ -1,0 +1,143 @@
+"""OpenRouter model catalog: real context windows instead of name-pattern guesses.
+
+``cli.model_metadata.infer_context_window`` 按模型名正则猜窗口，每接一个新模型都要
+改一次正则表，且猜错的代价不对称：猜小会让压缩过早触发（实测 poolside/nemotron 全部
+落到 64k 默认值，而真实窗口是 262k/1M，压缩在窗口只用了 5% 时就开始丢历史）。
+
+OpenRouter 的 ``/models`` 已经报了每个模型的 ``context_length``，直接取真值。结果落盘
+缓存，避免每次启动都发网络请求；取不到时回退正则表，不阻塞启动。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+CACHE_PATH = Path.home() / ".wyckoff" / "model_catalog.json"
+CACHE_TTL_SECONDS = 7 * 24 * 3600
+FETCH_TIMEOUT_SECONDS = 10.0
+
+
+def looks_like_openrouter(base_url: str) -> bool:
+    return "openrouter.ai" in str(base_url or "").lower()
+
+
+def catalog_context_window(model_name: str, *, allow_fetch: bool = True) -> int | None:
+    """Real context window for an OpenRouter model id, or None when unknown."""
+    model = str(model_name or "").strip()
+    if not model:
+        return None
+    catalog = load_catalog(allow_fetch=allow_fetch)
+    window = catalog.get(model)
+    if window:
+        return window
+    # ``:free`` / ``:batch`` 等变体的窗口可能与基础模型不同，所以先精确匹配；
+    # 仅当变体缺失时才退到基础模型 id。
+    base = model.split(":", 1)[0]
+    return catalog.get(base)
+
+
+def load_catalog(*, allow_fetch: bool = True) -> dict[str, int]:
+    cached = _read_cache()
+    if cached is not None:
+        return cached
+    if not allow_fetch:
+        return {}
+    fetched = fetch_catalog()
+    if fetched:
+        _write_cache(fetched)
+    return fetched
+
+
+def refresh_catalog() -> dict[str, int]:
+    """Force a fetch and persist it, bypassing the TTL. Returns {} on failure."""
+    fetched = fetch_catalog()
+    if fetched:
+        _write_cache(fetched)
+    return fetched
+
+
+def fetch_catalog() -> dict[str, int]:
+    """Fetch id -> context_length from OpenRouter. Returns {} on any failure."""
+    try:
+        import httpx
+
+        response = httpx.get(OPENROUTER_MODELS_URL, timeout=FETCH_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception:
+        logger.debug("openrouter model catalog fetch failed", exc_info=True)
+        return {}
+    return _parse_catalog(payload)
+
+
+def _parse_catalog(payload: Any) -> dict[str, int]:
+    rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        return {}
+    out: dict[str, int] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        model_id = str(row.get("id") or "").strip()
+        window = row.get("context_length")
+        try:
+            window_int = int(window)
+        except (TypeError, ValueError):
+            continue
+        if model_id and window_int > 0:
+            out[model_id] = window_int
+    return out
+
+
+def _read_cache() -> dict[str, int] | None:
+    try:
+        raw = json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    try:
+        fetched_at = float(raw.get("fetched_at") or 0)
+    except (TypeError, ValueError):
+        return None
+    if time.time() - fetched_at > CACHE_TTL_SECONDS:
+        return None
+    windows = raw.get("windows")
+    if not isinstance(windows, dict):
+        return None
+    return {str(k): int(v) for k, v in windows.items() if _positive_int(v)}
+
+
+def _write_cache(windows: dict[str, int]) -> None:
+    try:
+        CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_PATH.write_text(
+            json.dumps({"fetched_at": time.time(), "windows": windows}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    except OSError:
+        logger.debug("failed to persist model catalog cache", exc_info=True)
+
+
+def _positive_int(value: Any) -> bool:
+    try:
+        return int(value) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+__all__ = [
+    "CACHE_PATH",
+    "catalog_context_window",
+    "fetch_catalog",
+    "load_catalog",
+    "looks_like_openrouter",
+    "refresh_catalog",
+]

--- a/cli/model_registry.py
+++ b/cli/model_registry.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 
+from cli.model_catalog import catalog_context_window, looks_like_openrouter
 from cli.model_metadata import infer_context_window
 
 
@@ -22,6 +23,7 @@ class ModelInfo:
     cache_read_cost_per_1m: float | None = None
     cache_write_cost_per_1m: float | None = None
     source: str = "inferred"
+    window_source: str = "inferred"
 
 
 @dataclass(frozen=True)
@@ -88,8 +90,9 @@ def infer_model_info(config: dict[str, Any]) -> ModelInfo:
     model = str(config.get("model", "") or "")
     pattern_info = next((item for item in _MODEL_PATTERNS if item.pattern.search(model)), None)
     context_window = _int_or_none(config.get("context_window"))
+    window_source = "config" if context_window is not None else ""
     if context_window is None:
-        context_window = infer_context_window(model)
+        context_window, window_source = _resolve_window(model, str(config.get("base_url", "") or ""))
     supports_reasoning = (
         bool(config.get("supports_reasoning"))
         if "supports_reasoning" in config
@@ -110,8 +113,27 @@ def infer_model_info(config: dict[str, Any]) -> ModelInfo:
         output_cost_per_1m=_float_or_none(config.get("output_cost_per_1m")),
         cache_read_cost_per_1m=_float_or_none(config.get("cache_read_cost_per_1m")),
         cache_write_cost_per_1m=_float_or_none(config.get("cache_write_cost_per_1m")),
-        source="config" if config.get("context_window") or config.get("input_cost_per_1m") else "inferred",
+        source=_metadata_source(config, window_source),
+        window_source=window_source,
     )
+
+
+def _resolve_window(model: str, base_url: str) -> tuple[int, str]:
+    """Prefer the provider-reported window; fall back to name patterns.
+
+    只对 OpenRouter 走目录：其它 base_url 的模型 id 命名空间不同，用它的目录反而会误配。
+    """
+    if looks_like_openrouter(base_url):
+        window = catalog_context_window(model)
+        if window:
+            return window, "catalog"
+    return infer_context_window(model), "inferred"
+
+
+def _metadata_source(config: dict[str, Any], window_source: str) -> str:
+    if window_source == "config" or config.get("input_cost_per_1m"):
+        return "config"
+    return window_source or "inferred"
 
 
 def estimate_cost_usd(info: ModelInfo, *, tokens_in: int = 0, tokens_out: int = 0) -> float | None:

--- a/cli/provider_factory.py
+++ b/cli/provider_factory.py
@@ -46,10 +46,26 @@ def create_provider(
     kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters}
 
     provider = cls(**kwargs)
+    window = _resolved_window(context_window, model, base_url)
+    if window > 0:
+        provider.context_window = window
+    return provider, None
+
+
+def _resolved_window(context_window: int | None, model: str, base_url: str) -> int:
+    """配置值优先；缺失时取 provider 目录报的真实窗口。
+
+    不回退到名字正则：那是 ``resolve_context_window`` 在压缩层的既有行为，
+    这里只负责「有真值就用真值」，避免两处各猜一遍且结果不一致。
+    """
     try:
         window = int(context_window or 0)
     except (TypeError, ValueError):
         window = 0
     if window > 0:
-        provider.context_window = window
-    return provider, None
+        return window
+    from cli.model_catalog import catalog_context_window, looks_like_openrouter
+
+    if not looks_like_openrouter(base_url):
+        return 0
+    return int(catalog_context_window(model) or 0)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -959,6 +959,7 @@ wyckoff model add                # 交互式添加模型
 wyckoff model set <id> ...       # 非交互式设置模型
 wyckoff model rm <id>            # 删除模型
 wyckoff model default <id>       # 设置默认模型
+wyckoff model refresh            # 刷新 OpenRouter 模型目录（真实上下文窗口）
 wyckoff config                   # 查看数据源配置
 wyckoff config tushare <token>   # 配置 Tushare
 wyckoff config tickflow <key>    # 配置 TickFlow

--- a/tests/cli/test_model_catalog.py
+++ b/tests/cli/test_model_catalog.py
@@ -1,0 +1,143 @@
+"""Tests for OpenRouter model catalog and context-window resolution."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from cli import model_catalog
+from cli.model_registry import infer_model_info
+from cli.provider_factory import _resolved_window
+
+_OPENROUTER = "https://openrouter.ai/api/v1"
+_PAYLOAD = {
+    "data": [
+        {"id": "poolside/laguna-xs-2.1", "context_length": 262144},
+        {"id": "poolside/laguna-xs-2.1:free", "context_length": 262144},
+        {"id": "nvidia/nemotron-3-ultra-550b-a55b:free", "context_length": 1000000},
+        {"id": "broken/no-window", "context_length": None},
+        {"id": "", "context_length": 1000},
+        "not-a-dict",
+    ]
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path, monkeypatch):
+    """Point the cache at tmp and block network so tests never call out."""
+    monkeypatch.setattr(model_catalog, "CACHE_PATH", tmp_path / "model_catalog.json")
+    monkeypatch.setattr(model_catalog, "fetch_catalog", lambda: {})
+
+
+def _seed_cache(path, windows: dict[str, int], *, fetched_at: float | None = None) -> None:
+    payload = {"fetched_at": time.time() if fetched_at is None else fetched_at, "windows": windows}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestParseCatalog:
+    def test_keeps_valid_rows_only(self):
+        parsed = model_catalog._parse_catalog(_PAYLOAD)
+        assert parsed["poolside/laguna-xs-2.1:free"] == 262144
+        assert parsed["nvidia/nemotron-3-ultra-550b-a55b:free"] == 1000000
+        assert "broken/no-window" not in parsed
+        assert "" not in parsed
+
+    def test_tolerates_garbage_payload(self):
+        assert model_catalog._parse_catalog({}) == {}
+        assert model_catalog._parse_catalog({"data": "nope"}) == {}
+        assert model_catalog._parse_catalog(None) == {}
+
+
+class TestCache:
+    def test_reads_fresh_cache(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"a/b": 1234})
+        assert model_catalog.load_catalog() == {"a/b": 1234}
+
+    def test_ignores_expired_cache(self, tmp_path):
+        stale = time.time() - model_catalog.CACHE_TTL_SECONDS - 60
+        _seed_cache(model_catalog.CACHE_PATH, {"a/b": 1234}, fetched_at=stale)
+        # fetch is stubbed to {}, so an expired cache must not leak through.
+        assert model_catalog.load_catalog() == {}
+
+    def test_missing_cache_without_fetch_is_empty(self):
+        assert model_catalog.load_catalog(allow_fetch=False) == {}
+
+
+class TestCatalogContextWindow:
+    def test_exact_variant_wins_over_base(self, tmp_path):
+        # :free 的窗口可能与基础模型不同，必须优先精确匹配。
+        _seed_cache(model_catalog.CACHE_PATH, {"m/x": 999_999, "m/x:free": 262_144})
+        assert model_catalog.catalog_context_window("m/x:free") == 262_144
+
+    def test_falls_back_to_base_model(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"m/x": 262_144})
+        assert model_catalog.catalog_context_window("m/x:free") == 262_144
+
+    def test_unknown_returns_none(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"m/x": 1})
+        assert model_catalog.catalog_context_window("nope/zzz") is None
+        assert model_catalog.catalog_context_window("") is None
+
+
+class TestLooksLikeOpenrouter:
+    def test_detects_host(self):
+        assert model_catalog.looks_like_openrouter(_OPENROUTER)
+        assert not model_catalog.looks_like_openrouter("https://api.deepseek.com")
+        assert not model_catalog.looks_like_openrouter("")
+
+
+class TestWindowPrecedence:
+    """config > catalog > name pattern."""
+
+    def test_config_wins(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"poolside/laguna-xs-2.1:free": 262_144})
+        info = infer_model_info(
+            {
+                "provider_name": "openai",
+                "model": "poolside/laguna-xs-2.1:free",
+                "base_url": _OPENROUTER,
+                "context_window": 4096,
+            }
+        )
+        assert (info.context_window, info.window_source) == (4096, "config")
+
+    def test_catalog_used_for_openrouter(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"poolside/laguna-xs-2.1:free": 262_144})
+        info = infer_model_info(
+            {"provider_name": "openai", "model": "poolside/laguna-xs-2.1:free", "base_url": _OPENROUTER}
+        )
+        assert (info.context_window, info.window_source) == (262_144, "catalog")
+
+    def test_non_openrouter_stays_on_patterns(self, tmp_path):
+        # 其它网关的 id 命名空间不同，用 OpenRouter 目录会误配。
+        _seed_cache(model_catalog.CACHE_PATH, {"poolside/laguna-xs-2.1:free": 262_144})
+        info = infer_model_info(
+            {"provider_name": "openai", "model": "poolside/laguna-xs-2.1:free", "base_url": "https://api.acme.com"}
+        )
+        assert (info.context_window, info.window_source) == (64_000, "inferred")
+
+    def test_known_pattern_still_wins_without_catalog(self):
+        info = infer_model_info({"provider_name": "claude", "model": "claude-sonnet-4-20260514", "base_url": ""})
+        assert (info.context_window, info.window_source) == (200_000, "inferred")
+
+
+class TestResolvedWindowForProvider:
+    def test_prefers_config(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"m/x": 262_144})
+        assert _resolved_window(8192, "m/x", _OPENROUTER) == 8192
+
+    def test_uses_catalog_when_config_missing(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"m/x": 262_144})
+        assert _resolved_window(None, "m/x", _OPENROUTER) == 262_144
+
+    def test_zero_for_unknown_so_compaction_falls_back(self, tmp_path):
+        # 返回 0 表示「不设置」，压缩层继续走 resolve_context_window 的名称推断。
+        _seed_cache(model_catalog.CACHE_PATH, {"m/x": 262_144})
+        assert _resolved_window(None, "other/y", _OPENROUTER) == 0
+        assert _resolved_window(None, "m/x", "https://api.acme.com") == 0
+
+    def test_bad_config_value_does_not_raise(self, tmp_path):
+        _seed_cache(model_catalog.CACHE_PATH, {"m/x": 262_144})
+        assert _resolved_window("garbage", "m/x", _OPENROUTER) == 262_144


### PR DESCRIPTION
## Summary

`infer_context_window` 按模型名正则猜窗口，而 `_CONTEXT_WINDOW_PATTERNS` 没有一条能匹配 poolside / nemotron / glm / ling / north-mini —— 全部落到 `UNKNOWN_MODEL_CONTEXT_WINDOW = 64_000`。同时 `~/.wyckoff/wyckoff.json` 里 11 个模型的 `context_window` 均为 `None`，没有覆盖值。

后果是压缩阈值算成 **47,616**，而这些模型真实窗口是 262,144 / 1,000,000。实测单轮输入 63,626 tokens 就已越过阈值，会话几乎每轮都在压缩、反复摘要丢历史，而实际窗口用了不到 5%。

猜错的代价是不对称的：猜大会直接 400 报错，猜小则静默劣化上下文质量 —— 而这里恰好是猜小。

### 改为取真值

OpenRouter 的 `/models` 已经报了每个模型的 `context_length`，直接用：

- 新增 `cli/model_catalog.py`：拉取 `id -> context_length`，落盘 `~/.wyckoff/model_catalog.json`（TTL 7 天）。任何失败返回 `{}`，不阻塞启动。
- **精确匹配优先于基础模型 id**：`:free` / `:batch` 变体窗口可能与基础模型不同 —— 实测 `nemotron-3-ultra` free 是 1M、付费是 512,288，方向还相反。
- **只对 `base_url` 含 `openrouter.ai` 的配置走目录**：其它网关的 id 命名空间不同，拿 OpenRouter 目录反而会误配。
- 解析顺序 **config > catalog > 名称正则**，正则表保留为兜底，未动既有断言。

两个消费侧都接上了，否则改了不生效：`infer_model_info`（`model list` 展示）和 `provider_factory`（运行时 `provider.context_window`，**压缩实际读的是这个**）。`_resolved_window` 在未知时返回 `0` 表示"不设置"，让压缩层继续走既有的 `resolve_context_window`，避免两处各猜一遍且结果不一致。

`ModelInfo` 加 `window_source`，便于区分窗口来自 config / catalog / inferred。新增 `wyckoff model refresh` 强制重拉并打印解析结果。

## Validation

五个 OpenRouter 模型的窗口由 64,000 修正为真实值：

| 模型 | 修正前 | 修正后 | 压缩阈值 |
| --- | ---: | ---: | ---: |
| `poolside/laguna-xs-2.1:free` | 64,000 | 262,144 | 229,376 |
| `poolside/laguna-s-2.1:free` | 64,000 | 262,144 | 229,376 |
| `nvidia/nemotron-3-super-120b-a12b:free` | 64,000 | 262,144 | 229,376 |
| `inclusionai/ling-3.0-tiny:free` | 64,000 | 262,144 | 229,376 |
| `cohere/north-mini-code:free` | 64,000 | 256,000 | 224,000 |

压缩阈值 47,616 → 229,376。非 OpenRouter 路径不受影响（claude 仍 200,000、deepseek 仍 64,000）。

Gates：`pytest 2913 passed`（新增 17 个用例：目录解析容错、缓存 TTL 过期、变体优先级、三级优先级、非 OpenRouter 不误用目录、坏配置值不抛异常。`fetch_catalog` 在 fixture 里被 stub，**测试不发网络请求**）、`ruff check`、`ruff format --check`、`quality_gate --check-functions`、`check_workflow_hygiene` 通过。README 与 `docs/ARCHITECTURE.md` 同步。

## 背景

这个问题是排查"免费模型缓存命中率只有 34%–46%"时顺带发现的。缓存那件事本身不是 bug：OpenRouter 对 `:free` 变体的 `input_cache_read` 为 `None`，不提供 prompt cache，看到的浮动是上游 provider 顺带缓存的结果 —— free 层 prompt 单价为 0，命中率不影响成本，可以不管。但反复压缩是真问题，且它会让 prefix 从压缩点整段失效，换成付费模型也吃不到缓存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)