### PR TITLE
fix(cli): 压缩失败不再静默，超窗兜底硬截断

### DIFF
--- a/cli/compaction.py
+++ b/cli/compaction.py
@@ -180,6 +180,7 @@ def _summarize_tool_result(name: str, content: str, max_len: int = 400) -> str:
 
 
 SHRINK_THRESHOLD = 800
+MIN_SUMMARY_CHARS = 20
 
 
 def shrink_stale_tool_results(messages: list[dict[str, Any]]) -> int:
@@ -581,14 +582,71 @@ def compact_messages(
 
     try:
         summary = _run_compaction_summary(provider, head_text)
-        if summary and len(summary) >= 20:
-            archive_meta = _create_archive_safely(head, summary, session_id, archive_dir, tail_start, anchors)
-            compacted = [
-                {"role": "user", "content": _format_compacted_summary(summary, archive_meta, anchors)},
-                {"role": "assistant", "content": "好的，我已了解之前的对话上下文，请继续。"},
-            ] + tail
-            return _compact_return(compacted, True, archive_meta, include_metadata)
     except Exception:
-        logger.debug("compaction LLM call failed", exc_info=True)
+        # 压缩失败是静默劣化：上下文继续增长直到被网关拒绝，所以必须可见。
+        logger.warning(
+            "上下文压缩失败：摘要请求异常，历史保持 %d 条（约 %d tokens）未压缩",
+            len(messages),
+            estimate_tokens(messages),
+            exc_info=True,
+        )
+        return _compact_return(messages, False, None, include_metadata)
 
-    return _compact_return(messages, False, None, include_metadata)
+    if not summary or len(summary) < MIN_SUMMARY_CHARS:
+        logger.warning(
+            "上下文压缩失败：摘要仅 %d 字符（低于 %d 的下限），历史保持 %d 条（约 %d tokens）未压缩",
+            len(summary or ""),
+            MIN_SUMMARY_CHARS,
+            len(messages),
+            estimate_tokens(messages),
+        )
+        return _compact_return(messages, False, None, include_metadata)
+
+    archive_meta = _create_archive_safely(head, summary, session_id, archive_dir, tail_start, anchors)
+    compacted = [
+        {"role": "user", "content": _format_compacted_summary(summary, archive_meta, anchors)},
+        {"role": "assistant", "content": "好的，我已了解之前的对话上下文，请继续。"},
+    ] + tail
+    return _compact_return(compacted, True, archive_meta, include_metadata)
+
+
+def enforce_context_limit(
+    messages: list[dict[str, Any]],
+    model_name: str = "",
+    context_window: int | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """压缩之后仍超窗口时，硬丢弃最旧消息，返回 (messages, drop_info)。
+
+    压缩不保证一定生效：摘要请求可能失败、tail 本身就可能超过窗口。此时把包原样
+    发出去只会被网关以 400 拒绝，用户看到的是一次失败的对话而非降级的对话。宁可
+    丢最旧的上下文也要让请求成立。
+
+    只丢头部、保留尾部，且不在 tool 结果上切断——孤立的 tool result 缺少配对的
+    assistant tool_calls，多数 provider 会直接报错。
+    """
+    limit = get_compact_threshold(model_name, context_window)
+    if estimate_tokens(messages) <= limit:
+        return messages, None
+
+    before_messages = len(messages)
+    before_tokens = estimate_tokens(messages)
+    kept = list(messages)
+    while len(kept) > 2 and estimate_tokens(kept) > limit:
+        kept = kept[1:]
+        while kept and kept[0].get("role") == "tool":
+            kept = kept[1:]
+    if not kept:
+        kept = messages[-1:]
+    info = {
+        "dropped_messages": before_messages - len(kept),
+        "before_tokens": before_tokens,
+        "after_tokens": estimate_tokens(kept),
+        "limit": limit,
+    }
+    logger.warning(
+        "上下文仍超出上限：压缩后约 %d tokens > %d，已硬丢弃最旧 %d 条消息",
+        before_tokens,
+        limit,
+        info["dropped_messages"],
+    )
+    return kept, info

--- a/cli/runtime.py
+++ b/cli/runtime.py
@@ -33,7 +33,7 @@ from cli.agent_loop import (
     decide_agent_loop,
     has_incomplete_tool_calls,
 )
-from cli.compaction import compact_messages
+from cli.compaction import compact_messages, enforce_context_limit
 from cli.loop_guard import (
     MAX_INCOMPLETE_TOOL_RETRIES,
     MAX_TOOL_ROUNDS,
@@ -601,6 +601,24 @@ class AgentRuntime:
             session_id=self._session_id(),
             include_metadata=True,
         )
+        # 压缩可能未生效（摘要失败）或不足（tail 本身超窗），兜底硬截断，
+        # 否则请求会被网关以 400 拒绝。
+        compacted_messages, overflow = enforce_context_limit(compacted_messages, model_name, context_window)
+        if overflow:
+            messages[:] = compacted_messages
+            if self.scratchpad:
+                self.scratchpad.record_compaction(
+                    before_messages=prev_len,
+                    after_messages=len(compacted_messages),
+                    metadata={"contextOverflow": overflow},
+                )
+            return messages, {
+                "type": "context_overflow",
+                "before_messages": prev_len,
+                "after_messages": len(compacted_messages),
+                "dropped_messages": overflow["dropped_messages"],
+                "limit": overflow["limit"],
+            }
         if not compacted:
             return compacted_messages, None
         messages[:] = compacted_messages

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -1435,6 +1435,28 @@ def _compaction_panel(event: dict[str, Any]):
     )
 
 
+def _context_overflow_panel(event: dict[str, Any]):
+    """压缩没能把上下文降到窗口内，已硬丢弃最旧消息——这是有损的，必须让用户看见。"""
+    from rich.panel import Panel
+
+    return Panel(
+        Text.assemble(
+            (" 系统状态：上下文超出窗口上限\n\n", "bold red"),
+            ("摘要压缩未能生效或不足，已直接丢弃最旧 ", "dim white"),
+            (str(event.get("dropped_messages", 0)), "bold red"),
+            (" 条消息以保证请求不被拒绝；\n当前保留 ", "dim white"),
+            (str(event.get("after_messages", 0)), "bold green"),
+            (" 条，窗口上限 ", "dim white"),
+            (f"{int(event.get('limit', 0)):,}", "bold cyan"),
+            (" tokens。被丢弃的内容不进摘要，如仍需要请重新提供。", "dim white"),
+        ),
+        border_style="red",
+        title="[bold red]CONTEXT OVERFLOW[/bold red]",
+        title_align="left",
+        padding=(1, 2),
+    )
+
+
 _PERSISTED_THINKING_MAX_CHARS = 8_000
 
 
@@ -4942,6 +4964,9 @@ class WyckoffTUI(App):
             return False
         if event_type == "compaction":
             ui.write(_compaction_panel(event))
+            ui.scroll()
+        elif event_type == "context_overflow":
+            ui.write(_context_overflow_panel(event))
             ui.scroll()
         elif event_type == "text_delta":
             _append_stream_text(stream, event["text"], ui.write_stream, ui.scroll, ui.spinner_stop)

--- a/tests/cli/test_compaction_guards.py
+++ b/tests/cli/test_compaction_guards.py
@@ -1,0 +1,175 @@
+"""Compaction failure visibility and context-overflow hard limit."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from cli.compaction import (
+    MIN_SUMMARY_CHARS,
+    compact_messages,
+    enforce_context_limit,
+    estimate_tokens,
+    get_compact_threshold,
+)
+
+_MODEL = "test-model"
+
+
+def _history(tool_rounds: int, *, chunk: int = 3000) -> list[dict]:
+    messages: list[dict] = [{"role": "user", "content": "分析持仓"}]
+    for i in range(tool_rounds):
+        messages.append({"role": "assistant", "content": "", "tool_calls": [{"id": f"c{i}", "name": "p", "args": {}}]})
+        messages.append({"role": "tool", "tool_call_id": f"c{i}", "name": "p", "content": "数据" * chunk})
+    messages.append({"role": "assistant", "content": "结论"})
+    return messages
+
+
+class _Provider:
+    """Emits `text_delta`, which is the event type _collect_stream_text reads."""
+
+    def __init__(self, text: str):
+        self.text = text
+        self.calls = 0
+
+    def chat_stream(self, *args, **kwargs):
+        self.calls += 1
+        yield {"type": "text_delta", "text": self.text}
+        yield {"type": "finish", "reason": "stop"}
+
+
+class _Boom:
+    def chat_stream(self, *args, **kwargs):
+        raise RuntimeError("gateway 500")
+
+
+class _WrongEventType:
+    """Mirrors a provider whose event names drift from what compaction expects."""
+
+    def chat_stream(self, *args, **kwargs):
+        yield {"type": "content", "text": "看起来像摘要但事件类型不对" * 5}
+        yield {"type": "finish", "reason": "stop"}
+
+
+class TestCompactionFailureIsVisible:
+    def test_warns_when_summary_request_raises(self, caplog):
+        messages = _history(11)
+        with caplog.at_level(logging.WARNING, logger="cli.compaction"):
+            out, compacted = compact_messages(list(messages), _Boom(), _MODEL, 64_000)
+        assert compacted is False
+        assert len(out) == len(messages)
+        assert "上下文压缩失败" in caplog.text
+
+    def test_warns_when_summary_too_short(self, caplog):
+        messages = _history(11)
+        with caplog.at_level(logging.WARNING, logger="cli.compaction"):
+            _, compacted = compact_messages(list(messages), _Provider("太短"), _MODEL, 64_000)
+        assert compacted is False
+        assert f"低于 {MIN_SUMMARY_CHARS}" in caplog.text
+
+    def test_warns_when_provider_event_type_drifts(self, caplog):
+        # 摘要恒为空会让压缩静默失效，上下文一路涨到被网关拒绝。
+        messages = _history(11)
+        with caplog.at_level(logging.WARNING, logger="cli.compaction"):
+            _, compacted = compact_messages(list(messages), _WrongEventType(), _MODEL, 64_000)
+        assert compacted is False
+        assert "上下文压缩失败" in caplog.text
+
+    def test_no_warning_on_success(self, caplog, tmp_path):
+        messages = _history(11)
+        provider = _Provider("这是一段足够长的压缩摘要，覆盖之前的持仓分析上下文。" * 3)
+        with caplog.at_level(logging.WARNING, logger="cli.compaction"):
+            out, compacted = compact_messages(list(messages), provider, _MODEL, 64_000, archive_dir=str(tmp_path))
+        assert compacted is True
+        assert len(out) < len(messages)
+        assert "压缩失败" not in caplog.text
+
+
+class TestEnforceContextLimit:
+    def test_noop_when_within_limit(self):
+        messages = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "你好"}]
+        out, info = enforce_context_limit(messages, _MODEL, 64_000)
+        assert out == messages
+        assert info is None
+
+    def test_drops_oldest_until_within_limit(self, caplog):
+        messages = _history(30)
+        limit = get_compact_threshold(_MODEL, 64_000)
+        assert estimate_tokens(messages) > limit
+        with caplog.at_level(logging.WARNING, logger="cli.compaction"):
+            out, info = enforce_context_limit(messages, _MODEL, 64_000)
+        assert estimate_tokens(out) <= limit
+        assert info is not None and info["dropped_messages"] > 0
+        assert "仍超出上限" in caplog.text
+
+    def test_keeps_newest_turn(self):
+        messages = _history(30)
+        messages.append({"role": "user", "content": "最新问题"})
+        out, _ = enforce_context_limit(messages, _MODEL, 64_000)
+        assert out[-1]["content"] == "最新问题"
+
+    def test_never_starts_on_tool_result(self):
+        # 孤立 tool result 缺少配对的 assistant tool_calls，provider 会直接报错。
+        messages = _history(30)
+        out, _ = enforce_context_limit(messages, _MODEL, 64_000)
+        assert out[0].get("role") != "tool"
+
+    def test_keeps_at_least_one_message(self):
+        # 单条消息就超限时也必须留点东西，不能返回空列表。
+        messages = [{"role": "user", "content": "数据" * 200_000}]
+        out, _ = enforce_context_limit(messages, _MODEL, 64_000)
+        assert len(out) >= 1
+
+    @pytest.mark.parametrize("window", [64_000, 262_144])
+    def test_respects_window_value(self, window):
+        messages = _history(30)
+        out, _ = enforce_context_limit(messages, _MODEL, window)
+        assert estimate_tokens(out) <= get_compact_threshold(_MODEL, window)
+
+
+class _RecordingScratchpad:
+    def __init__(self):
+        self.entries: list[dict] = []
+
+    def record_compaction(self, **kwargs):
+        self.entries.append(kwargs)
+
+
+class TestRuntimeWiring:
+    """压缩失败 + 仍超限时，runtime 必须截断并把有损事件透出去。"""
+
+    def _runtime(self, window: int, scratchpad=None):
+        from cli.runtime import AgentRuntime
+
+        runtime = AgentRuntime.__new__(AgentRuntime)
+        runtime.provider = _Boom()
+        runtime.provider.context_window = window
+        runtime.scratchpad = scratchpad
+        return runtime
+
+    def test_emits_context_overflow_event(self):
+        runtime = self._runtime(64_000)
+        messages = _history(30)
+        out, event = runtime._compact_if_needed(messages, _MODEL, 64_000)
+
+        assert event is not None
+        assert event["type"] == "context_overflow"
+        assert event["dropped_messages"] > 0
+        assert estimate_tokens(out) <= get_compact_threshold(_MODEL, 64_000)
+        # messages 必须就地更新，否则调用方继续用旧列表发包。
+        assert messages is out
+
+    def test_records_overflow_in_scratchpad(self):
+        pad = _RecordingScratchpad()
+        runtime = self._runtime(64_000, scratchpad=pad)
+        runtime._compact_if_needed(_history(30), _MODEL, 64_000)
+
+        assert len(pad.entries) == 1
+        assert "contextOverflow" in pad.entries[0]["metadata"]
+
+    def test_no_overflow_event_when_within_limit(self):
+        runtime = self._runtime(262_144)
+        messages = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "你好"}]
+        _, event = runtime._compact_if_needed(messages, _MODEL, 262_144)
+        assert event is None


### PR DESCRIPTION
## Summary

两处上下文劣化此前完全不可见。

### 1. 压缩失败静默

`compact_messages` 拿不到摘要就 `return ..., False`，不记任何日志。摘要为空（provider 事件类型与 `_collect_stream_text` 期望的 `text_delta` 不一致）或短于 20 字符时，压缩静默失效、上下文一路涨到被网关拒绝，日志里什么都看不到。

这个坑我自己就踩了：写验证脚本时 stub 发 `{"type": "content"}`，导致摘要恒空、`compacted` 恒 `False`，差点据此得出"窗口值不影响行为"的错误结论。真实 provider 事件名漂移时会是同样的表现。

现在异常与过短两条路径各记一条 warning，带上未压缩的消息数与 token 估算。`20` 提为具名常量 `MIN_SUMMARY_CHARS`。

### 2. 没有超限兜底

代码里没有任何地方按窗口拦请求：压缩不生效、或 tail 本身就超窗时，包照发，由网关回 400。用户看到的是一次**失败**的对话，而不是**降级**的对话。

新增 `enforce_context_limit`：压缩后仍超阈值就从头部硬丢消息，直到落回限内。

- 只丢头、保尾（最新一轮一定保留）
- 不在 `tool` result 上切断 —— 孤立的 tool result 缺少配对的 assistant `tool_calls`，多数 provider 直接报错
- 保证至少留一条，不返回空列表

`runtime` 在 `compact_messages` 之后调用兜底，`messages` 就地更新，透出 `context_overflow` 事件并写入 scratchpad（`metadata.contextOverflow`），TUI 加对应红色面板 —— 硬截断是有损的，必须让用户看见丢了多少、还剩多少。

## Validation

实测 62 条 / 180,006 tokens 且摘要请求失败的场景：

```
WARNING 上下文压缩失败：摘要请求异常，历史保持 62 条（约 180006 tokens）未压缩
WARNING 上下文仍超出上限：压缩后约 180006 tokens > 47616，已硬丢弃最旧 47 条消息
before: msgs=62 tokens=180,006
after : msgs=15 tokens=42,004
event : {'type': 'context_overflow', 'before_messages': 62, 'after_messages': 15,
         'dropped_messages': 47, 'limit': 47616}
```

保留了最新一轮、首条不是 tool result、落回限内。未超限时 `enforce_context_limit` 原样返回、不产生事件。

Gates：`pytest 2927 passed`（新增 14 个用例：三种压缩失败路径均告警、成功路径不误报、超限截断收敛到限内、保留最新轮、不在 tool 上切断、至少留一条、窗口值参数化、runtime 事件与 scratchpad 记录、未超限不发事件）、`ruff check`、`ruff format --check`、`quality_gate --check-functions`、`check_workflow_hygiene` 通过。

## 背景与一处更正

接 #254（OpenRouter 真实上下文窗口）。用户质疑"解析窗口对 agent 意义不大，只要发包就发包了"——前半句不成立：窗口值经 `provider_factory` → `runtime.py:375` → `compact_messages` 驱动阈值，实测同一份 66,006 tokens 的历史在 64,000 窗口下会被压掉 13 条消息（62% 上下文）并额外发一次摘要请求，在 262,144 下完全不压。

但后半句指出了真问题：**确实没有任何地方按窗口拦请求**，窗口只决定"压不压缩"，压完照发。本 PR 补的就是这个。

同时更正 #254 描述里的一处错误：我在那里写"单轮 63,626 tokens 越过阈值，会话几乎每轮都在压缩"。前半句对，后半句是未经验证的推断——压缩还需同时满足消息数 > `TAIL_KEEP + 2` 且 `tail_start > 2`，短会话即使 token 高也不压。

🤖 Generated with [Claude Code](https://claude.com/claude-code)