### PR TITLE
fix(cli): token 估算对中文改为保守，超限兜底此前会放过超窗请求

### DIFF
--- a/cli/compaction.py
+++ b/cli/compaction.py
@@ -79,15 +79,47 @@ def get_recent_keep_tokens(model_name: str = "", context_window: int | None = No
 # ---------------------------------------------------------------------------
 
 
+def estimate_text_tokens(text: str) -> int:
+    """字符级 token 估算，对 CJK 取保守（偏大）值。
+
+    实测 poolside/laguna-xs-2.1 上原式 ``max(len//2, utf8_len//3)`` 的估算/实际比：
+    纯中文 0.79x、中英混合 0.86x、JSON 0.97x、纯英文 2.87x。英文侧高估无害（只是
+    压缩早触发），但**中文侧低估会让超限兜底放过真正超窗的请求**——实测一份估算
+    228,014 的纯中文历史实际是 274,938 tokens，直接被网关 400 拒绝。
+
+    因此 CJK 字符按每字 1.3 token 计（覆盖实测最差 0.79x ≈ 1.27 倍缺口），
+    其余字符沿用 utf8/3 与 len/2 的较大值。
+    """
+    if not text:
+        return 0
+    cjk = sum(1 for ch in text if _is_cjk(ch))
+    rest = text if cjk == 0 else "".join(ch for ch in text if not _is_cjk(ch))
+    rest_tokens = max(len(rest) // 2, len(rest.encode("utf-8")) // 3)
+    return int(cjk * _CJK_TOKENS_PER_CHAR) + rest_tokens
+
+
+def _is_cjk(ch: str) -> bool:
+    code = ord(ch)
+    return (
+        0x4E00 <= code <= 0x9FFF  # CJK 统一汉字
+        or 0x3400 <= code <= 0x4DBF  # 扩展 A
+        or 0xF900 <= code <= 0xFAFF  # 兼容汉字
+        or 0x3000 <= code <= 0x303F  # CJK 标点
+        or 0xFF00 <= code <= 0xFFEF  # 全角字符
+        or 0x3040 <= code <= 0x30FF  # 日文假名
+        or 0xAC00 <= code <= 0xD7AF  # 韩文音节
+    )
+
+
 def estimate_tokens(messages: list[dict[str, Any]]) -> int:
     total = 0
     for m in messages:
         content = m.get("content", "")
         if isinstance(content, str):
-            total += max(len(content) // 2, len(content.encode("utf-8")) // 3)
+            total += estimate_text_tokens(content)
         for tc in m.get("tool_calls", []):
             args_str = json.dumps(tc.get("args", {}), ensure_ascii=False)
-            total += len(args_str) // 3
+            total += estimate_text_tokens(args_str)
     return total
 
 
@@ -181,6 +213,7 @@ def _summarize_tool_result(name: str, content: str, max_len: int = 400) -> str:
 
 SHRINK_THRESHOLD = 800
 MIN_SUMMARY_CHARS = 20
+_CJK_TOKENS_PER_CHAR = 1.3
 
 
 def shrink_stale_tool_results(messages: list[dict[str, Any]]) -> int:

--- a/tests/cli/test_compaction_guards.py
+++ b/tests/cli/test_compaction_guards.py
@@ -10,11 +10,22 @@ from cli.compaction import (
     MIN_SUMMARY_CHARS,
     compact_messages,
     enforce_context_limit,
+    estimate_text_tokens,
     estimate_tokens,
     get_compact_threshold,
 )
 
 _MODEL = "test-model"
+
+# 实测于 poolside/laguna-xs-2.1（OpenRouter），(文本, 真实 input_tokens)。
+# 估算必须 >= 真实值：低估会让超限兜底放过真正超窗的请求，直接吃 400。
+_REAL_TOKEN_SAMPLES = [
+    ("纯中文", "华勤技术奕瑞科技持仓复盘主力放量出货震荡洗盘吸筹派发" * 200, 6_622),
+    ("中文长句", "今天大盘出现明显下杀，创业板指数跌幅扩大，市场宽度急剧收窄，主力资金转入派发阶段。" * 80, 3_541),
+    ("纯英文", "The composite man accumulates supply before markup begins in earnest. " * 120, 1_461),
+    ("中英混合", "华勤技术 603296 close=76.02 vol_ratio=3.2 SOS triggered 主力放量出货 " * 120, 4_101),
+    ("JSON", '{"symbol":"603296.SH","close":76.02,"名称":"华勤技术"},' * 150, 3_772),
+]
 
 
 def _history(tool_rounds: int, *, chunk: int = 3000) -> list[dict]:
@@ -126,6 +137,51 @@ class TestEnforceContextLimit:
         messages = _history(30)
         out, _ = enforce_context_limit(messages, _MODEL, window)
         assert estimate_tokens(out) <= get_compact_threshold(_MODEL, window)
+
+
+class TestEstimatorIsConservative:
+    """估算必须 >= 真实 token 数，否则兜底形同虚设。"""
+
+    @pytest.mark.parametrize(("label", "text", "actual"), _REAL_TOKEN_SAMPLES)
+    def test_never_underestimates_real_tokens(self, label, text, actual):
+        assert estimate_text_tokens(text) >= actual, f"{label} 低估：兜底会放过超窗请求"
+
+    def test_cjk_counted_above_one_token_per_char(self):
+        # 原式 len//2 把中文按 0.5 token/字算，实测约 1.27，低估 2.5 倍。
+        assert estimate_text_tokens("持仓复盘" * 100) > 400
+
+    def test_ascii_not_regressed(self):
+        text = "The composite man accumulates supply. " * 50
+        assert estimate_text_tokens(text) == max(len(text) // 2, len(text.encode("utf-8")) // 3)
+
+    def test_empty_and_mixed(self):
+        assert estimate_text_tokens("") == 0
+        # 混合文本必须两部分都计入，不能只算一边。
+        assert estimate_text_tokens("持仓abc") > estimate_text_tokens("abc")
+
+    def test_tool_call_args_use_same_estimator(self):
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [{"name": "p", "args": {"名称": "华勤技术" * 50}}]}
+        ]
+        assert estimate_tokens(messages) > 200
+
+
+class TestOverflowRegression:
+    def test_history_that_gateway_rejected_is_now_truncated(self):
+        """回归：这份历史旧估算 228,014 < 阈值被放行，实际 274,938 tokens 被网关 400。"""
+        unit = "华勤技术奕瑞科技持仓复盘主力放量出货震荡洗盘吸筹派发形态确认"
+        messages: list[dict] = [{"role": "user", "content": "起始"}]
+        for i in range(76):
+            messages.append(
+                {"role": "assistant", "content": "", "tool_calls": [{"id": f"c{i}", "name": "p", "args": {}}]}
+            )
+            messages.append({"role": "tool", "tool_call_id": f"c{i}", "name": "p", "content": unit * 100})
+
+        limit = get_compact_threshold(_MODEL, 262_144)
+        assert estimate_tokens(messages) > limit, "新估算应识别出这份历史超窗"
+        kept, info = enforce_context_limit(messages, _MODEL, 262_144)
+        assert info is not None
+        assert estimate_tokens(kept) <= limit
 
 
 class _RecordingScratchpad:


### PR DESCRIPTION
## Summary

实测发现 #255 的兜底有真 bug。用真实 OpenRouter 请求验证时，一份估算 **228,014** tokens（阈值 229,376）的纯中文历史被兜底放行，实际却是 **274,938** tokens，直接被网关 400 拒绝：

```
兜底: 放行未截断  msgs=154
RESULT: 兜底放行了但请求仍被拒 -> 400 Input length 274938 exceeds the maximum allowed input length of 262144
```

兜底没有起到它声称的作用。

### 根因

`estimate_tokens` 的 `max(len//2, utf8_len//3)` 对中文低估。实测 `poolside/laguna-xs-2.1` 上的估算/实际比：

| 内容类型 | 估算 | 实际 | 比值 |
| --- | ---: | ---: | ---: |
| 纯中文 | 5,200 | 6,622 | **0.79x** |
| 中英混合 | 3,540 | 4,101 | **0.86x** |
| 中文长句 | 3,280 | 3,541 | **0.93x** |
| JSON（含中文） | 3,675 | 3,772 | **0.97x** |
| 纯英文 | 4,200 | 1,461 | 2.87x |

英文侧高估无害（只让压缩早触发），**中文侧低估则让兜底失效** —— 而这个项目的对话、工具结果、持仓快照几乎全是中文，是常态而非边缘情况。

### 改法

抽出 `estimate_text_tokens`：CJK 字符按 1.3 token/字计（覆盖实测最差 0.79x 约 1.27 倍的缺口），其余字符沿用原式。`tool_calls` 的 args 也改用同一函数 —— 它此前单独用 `len//3`，中文参数同样低估。

修正后五个样本比值全部 ≥ 1.0（最小 1.02x），那份被 400 拒的历史新估算 296,478 > 阈值，会被正确截断（153 → 116 条）。

## Validation

**本轮改用真实请求验证，不再只靠 stub**（stub 事件类型写错正是我先前踩的坑）：

- 三个 provider（openai / claude / gemini）均发 `text_delta`，`_collect_stream_text` 的事件名是对的
- 真实模型压缩成功：24 条 / 73,347 tokens → 9 条 / 21,138 tokens，摘要内容合理可用
- 兜底截断后的请求**被网关接受并正常回复**；对照组不截断则 400 —— 证明兜底是必需的
- 上述边界用例即在此过程中暴露

`pytest 2937 passed`（新增 10 个用例：五个真实 token 样本参数化断言估算不低估、CJK 计数下限、ASCII 路径不回归、空串与混合文本、`tool_calls` args 同口径，以及那份触发 400 的历史的回归测试）。`ruff check`、`ruff format --check`、`quality_gate --check-functions`、`check_workflow_hygiene` 通过。

## 已知限制

1.3 token/字是基于 poolside 分词器的实测值，其它模型的分词器不同，比例会有出入。真正精确需要接各家 tokenizer，成本不小。当前取值偏保守，代价是中文场景压缩比理论上略早触发 —— 这个方向的错是安全的（少用一点窗口），反方向的错是 400。

验证过程中 OpenRouter free 层的每日 50 次配额被打满，后续断言改用已采集的真实 token 数作为固定样本，所以测试不发网络请求。

🤖 Generated with [Claude Code](https://claude.com/claude-code)