### PR TITLE
fix(cli): 工具 schema 的 description 必须是字符串

### DIFF
--- a/cli/tools.py
+++ b/cli/tools.py
@@ -292,7 +292,7 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                     "type": "array",
                     "description": (
                         "批量 add/update/remove：一次传入多只。"
-                        "每项含 code；add/update 另需 shares、cost_price；add 必须有合法 buy_dt，update 改股数/成本时不要传 buy_dt，且不会在空账本新建。",
+                        "每项含 code；add/update 另需 shares、cost_price；add 必须有合法 buy_dt，update 改股数/成本时不要传 buy_dt，且不会在空账本新建。"
                     ),
                     "items": {
                         "type": "object",
@@ -651,6 +651,19 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
 ]
 
 
+def stringify_json_schema_descriptions(node: Any) -> Any:
+    """JSON Schema 的 description 必须是 string；括号里多一个逗号就会变成 tuple。"""
+    if isinstance(node, dict):
+        out = {key: stringify_json_schema_descriptions(value) for key, value in node.items()}
+        desc = out.get("description")
+        if isinstance(desc, (list, tuple)):
+            out["description"] = " ".join(str(item) for item in desc)
+        return out
+    if isinstance(node, list):
+        return [stringify_json_schema_descriptions(item) for item in node]
+    return node
+
+
 @dataclass(frozen=True)
 class ToolSpec:
     """Runtime behavior metadata for one tool."""
@@ -938,10 +951,10 @@ class ToolRegistry:
     def schemas(self, allowed_tools: set[str] | tuple[str, ...] | None = None) -> list[dict[str, Any]]:
         """返回工具 JSON Schema；allowed_tools 存在时只暴露当前 workflow 范围。"""
         merged = TOOL_SCHEMAS + self._external_schemas()
-        if not allowed_tools:
-            return merged
-        allowed = set(allowed_tools)
-        return [schema for schema in merged if schema["name"] in allowed]
+        if allowed_tools:
+            allowed = set(allowed_tools)
+            merged = [schema for schema in merged if schema["name"] in allowed]
+        return [stringify_json_schema_descriptions(schema) for schema in merged]
 
     def has_tool(self, name: str) -> bool:
         return name in self._tools or self._external_tool(name) is not None

--- a/tests/cli/test_tool_specs.py
+++ b/tests/cli/test_tool_specs.py
@@ -14,7 +14,19 @@ from cli.tools import (
     TOOL_SPECS,
     ToolRegistry,
     ask_user_question,
+    stringify_json_schema_descriptions,
 )
+
+
+def _iter_descriptions(node):
+    if isinstance(node, dict):
+        if "description" in node:
+            yield node["description"]
+        for value in node.values():
+            yield from _iter_descriptions(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_descriptions(item)
 
 
 def test_tool_specs_cover_all_public_schemas():
@@ -22,6 +34,21 @@ def test_tool_specs_cover_all_public_schemas():
 
     assert set(TOOL_SPECS) == schema_names
     assert "ask_user" not in schema_names
+
+
+def test_tool_schema_descriptions_are_strings():
+    """NVIDIA / Cohere 会拒掉 description 为 array 的 JSON Schema；括号尾逗号就会变成 tuple。"""
+    for schema in TOOL_SCHEMAS:
+        for description in _iter_descriptions(schema):
+            assert isinstance(description, str), schema["name"]
+    items = next(s for s in TOOL_SCHEMAS if s["name"] == "update_portfolio")["parameters"]["properties"]["items"]
+    assert isinstance(items["description"], str)
+    assert "批量 add/update/remove" in items["description"]
+    coerced = stringify_json_schema_descriptions({"description": ("a", "b")})
+    assert coerced["description"] == "a b"
+    for schema in ToolRegistry().schemas():
+        for description in _iter_descriptions(schema):
+            assert isinstance(description, str), schema.get("name")
 
 
 def test_legacy_tool_sets_are_derived_from_specs():


### PR DESCRIPTION
## Summary
- `update_portfolio.items` 的 `description` 括号尾逗号会让 Python 收成 tuple，发给模型后变成 JSON 数组。
- NVIDIA / Cohere 按 JSON Schema 规范直接 400/422；发出工具 schema 前统一把 description 压成字符串。

## Validation
- `.venv/bin/ruff check cli/tools.py tests/cli/test_tool_specs.py`
- `.venv/bin/ruff format --check cli/tools.py tests/cli/test_tool_specs.py`
- `.venv/bin/python -m pytest tests/cli/test_tool_specs.py -q`


Made with [Cursor](https://cursor.com)