### PR TITLE
fix: PR policy 支持双语标题，批量 remove 不再要求股数

### DIFF
--- a/agents/portfolio_tools.py
+++ b/agents/portfolio_tools.py
@@ -180,7 +180,7 @@ def _update_portfolio_batch(
     ok_messages: list[str] = []
     failures: list[dict[str, Any]] = []
     for index, raw in enumerate(items):
-        row = _batch_item_row(index, raw, failures)
+        row = _batch_item_row(index, raw, failures, action=action)
         if row is None:
             continue
         msg = _apply_portfolio_action(
@@ -218,16 +218,29 @@ def _update_portfolio_batch(
     return summary
 
 
-def _batch_item_row(index: int, raw: Any, failures: list[dict[str, Any]]) -> dict[str, Any] | None:
+def _batch_item_row(
+    index: int, raw: Any, failures: list[dict[str, Any]], *, action: str = "add"
+) -> dict[str, Any] | None:
     if not isinstance(raw, dict):
         failures.append({"index": index, "error": "item 必须是对象"})
         return None
+    # remove 只按 code 清仓，股数与成本无意义；只有 add/update 才要求显式股数，
+    # 否则省略会被当成 0 静默清零仓位。
+    if action == "remove":
+        return _batch_row(raw, shares=0, cost_price=0.0)
+    if "shares" not in raw or "cost_price" not in raw:
+        failures.append({"index": index, "code": raw.get("code"), "error": "shares/cost_price 不能省略"})
+        return None
     try:
-        shares = int(raw.get("shares") or 0)
-        cost_price = float(raw.get("cost_price") or 0)
+        shares = int(raw["shares"])
+        cost_price = float(raw["cost_price"])
     except (TypeError, ValueError):
         failures.append({"index": index, "code": raw.get("code"), "error": "shares/cost_price 无效"})
         return None
+    return _batch_row(raw, shares=shares, cost_price=cost_price)
+
+
+def _batch_row(raw: dict[str, Any], *, shares: int, cost_price: float) -> dict[str, Any]:
     return {
         "code": str(raw.get("code") or "").strip(),
         "name": str(raw.get("name") or "").strip(),

--- a/scripts/check_pr_policy.py
+++ b/scripts/check_pr_policy.py
@@ -57,12 +57,23 @@ class PolicyResult:
     warnings: tuple[str, ...]
 
 
+_HEADING_SPLIT_RE = re.compile(r"[/|｜、]|\s+/\s+")
+
+
 def _heading_names(body: str) -> set[str]:
+    """标题名集合；双语标题按分隔符拆开分别登记。
+
+    ``## Summary / 变更摘要`` 此前被当成单个名字 ``summary / 变更摘要``，与
+    SUMMARY_HEADINGS 精确匹配失败，导致合规的双语 PR 被判缺少章节。
+    """
     headings: set[str] = set()
     for line in body.splitlines():
         match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
-        if match:
-            headings.add(match.group(1).strip().lower())
+        if not match:
+            continue
+        raw = match.group(1).strip().lower()
+        headings.add(raw)
+        headings.update(part.strip() for part in _HEADING_SPLIT_RE.split(raw) if part.strip())
     return headings
 
 

--- a/tests/agents/test_portfolio_batch_update.py
+++ b/tests/agents/test_portfolio_batch_update.py
@@ -133,6 +133,26 @@ def test_update_portfolio_batch_rejects_empty_items():
     assert "非空" in result["error"]
 
 
+def test_update_portfolio_batch_remove_needs_only_code(monkeypatch, tmp_path):
+    """remove 按 code 清仓，股数/成本无意义；要求它们会让批量清仓整批失败。"""
+    from agents import portfolio_tools
+    from integrations import local_db
+
+    _isolate_local_db(monkeypatch, tmp_path)
+    monkeypatch.setattr(portfolio_tools, "has_cloud", lambda _ctx=None: False)
+    monkeypatch.setattr(portfolio_tools, "_portfolio_id", lambda _ctx=None: "LOCAL")
+    monkeypatch.setattr(portfolio_tools, "code_to_name", lambda code: code)
+
+    portfolio_tools.update_portfolio(
+        action="add",
+        items=[{"code": "600519", "name": "贵州茅台", "shares": 100, "cost_price": 1500, "buy_dt": "2026-07-01"}],
+    )
+    removed = portfolio_tools.update_portfolio(action="remove", items=[{"code": "600519"}])
+
+    assert removed.get("success") is True, removed
+    assert local_db.load_portfolio("LOCAL")["positions"] == []
+
+
 def test_update_portfolio_brief_lines_for_batch():
     lines = tool_result_brief_lines(
         "update_portfolio",

--- a/tests/test_ci_policy_gates.py
+++ b/tests/test_ci_policy_gates.py
@@ -14,6 +14,28 @@ def test_pr_policy_accepts_bilingual_summary_and_validation():
     assert result.ok is True
 
 
+def test_pr_policy_accepts_slash_separated_bilingual_headings():
+    """``## Summary / 变更摘要`` 曾被当成单个标题名而误判缺少章节（PR #266 因此 CI 红）。"""
+    body = "## Summary / 变更摘要\n\n- fix\n\n## Validation / 验证\n\n- pytest"
+
+    assert validate_policy(body, ["agents/portfolio_tools.py"]).ok is True
+
+
+def test_pr_policy_accepts_pipe_separated_bilingual_headings():
+    body = "## Summary | 变更摘要\n\n- fix\n\n## Validation ｜ 验证\n\n- pytest"
+
+    assert validate_policy(body, ["agents/portfolio_tools.py"]).ok is True
+
+
+def test_pr_policy_still_rejects_missing_sections_after_split():
+    """拆分不能放宽判定：真的缺章节仍须 FAIL。"""
+    result = validate_policy("## Notes / 备注\n\n- nothing", ["agents/portfolio_tools.py"])
+
+    assert result.ok is False
+    assert any("Summary" in item for item in result.failures)
+    assert any("Validation" in item for item in result.failures)
+
+
 def test_pr_policy_blocks_logs_and_secret_like_body():
     body = "## Summary\n\nUses Bearer eyJabc.def.ghi\n\n## Validation\n\n- pytest"
 


### PR DESCRIPTION
## Summary / 变更摘要

两处实测复现的确定性缺陷。（本 PR 标题本身就是第 1 项的回归验证。）

**1. `check_pr_policy` 误判双语标题**

`_heading_names` 把 `## Summary / 变更摘要` 整行当成一个标题名 `summary / 变更摘要`，再与 `SUMMARY_HEADINGS` 精确集合匹配，必然不命中：

```
标题: ['summary / 变更摘要', 'validation / 验证']
命中 summary   : set()
命中 validation: set()
```

合规的双语 PR 因此被判 `missing a Summary section` —— **#266 的 pr-policy 红灯就是这个原因，与其代码改动无关**。

改为登记原标题的同时按 `/`、`|`、`｜`、`、` 拆分分别登记。拆分不放宽判定：真缺章节仍 FAIL（已加断言）。

**2. 批量 `remove` 被显式性要求打断**

`_batch_item_row` 被 add/update/remove 共用。#266 为阻止「省略 `shares` 被 `int(raw.get("shares") or 0)` 当成 0 静默清零仓位」而强制要求 `shares`/`cost_price`，但 `remove` 只按 code 清仓、这两个字段无意义，于是批量清仓整批失败。

实测对照：

| 分支 | `remove items=[{"code":"600519"}]` |
| --- | --- |
| main | 成功 |
| #266 | 失败：`shares/cost_price 不能省略` |

按 action 分派：`remove` 只取 code，add/update 保留 #266 的显式性要求（那个修复本身是对的，静默清零是真实的数据丢失路径）。顺带抽出 `_batch_row` 消除重复的行构造。

先确认过 `shares=0` 并非清仓约定：清仓走 `remove` action 与 `record_fill`（「卖光时清仓」），所以 #266 把 `< 0` 收紧为 `<= 0` 是安全的。

## Validation / 验证

逐项实测，修复前后对照：

| 用例 | 结果 |
| --- | --- |
| `## Summary / 变更摘要` | PASS（修复前 FAIL） |
| `## Summary \| 变更摘要` | PASS |
| 纯中文 `## 变更摘要` | PASS（不回归） |
| 纯英文 `## Summary` | PASS（不回归） |
| `## Notes / 备注`（真缺章节） | FAIL（正确） |
| `remove` 仅传 code | 成功，持仓被清空 |
| `update` 省略 `shares` | 被拒，股数保持 100 未清零 |

- `pytest tests/` — 2982 passed, 22 skipped
- `ruff check .` / `ruff format --check .`
- `python scripts/quality_gate.py --check-functions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)