### PR TITLE
fix(cli/agents): Windows daemon 导入崩溃 + portfolio view 漏 stop_loss

### DIFF
--- a/agents/portfolio_tools.py
+++ b/agents/portfolio_tools.py
@@ -374,6 +374,9 @@ def _portfolio_view(portfolio_id: str, state: dict) -> dict:
             "shares": p.get("shares", 0),
             "cost_price": p.get("cost", p.get("cost_price", 0)),
             "buy_dt": p.get("buy_dt", ""),
+            # stop_loss 是存储列，view 里漏掉会让模型把每一只都报成「未设止损」
+            # —— 这是个风控数字，不能靠字段缺失去推断。
+            "stop_loss": p.get("stop_loss"),
         }
         for p in state.get("positions", [])
     ]

--- a/cli/daemon.py
+++ b/cli/daemon.py
@@ -1,8 +1,7 @@
-"""常驻调度 daemon — UI 关闭后定时任务继续跑，由 launchd 保活。"""
+"""定时调度 daemon — CLI 可前台运行，桌面端打开期间由 Electron 托管。"""
 
 from __future__ import annotations
 
-import fcntl
 import logging
 import os
 import signal
@@ -13,7 +12,11 @@ from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
+from cli import platform_lock
+
 logger = logging.getLogger(__name__)
+
+LOCK_BUSY_EXIT_CODE = 75
 
 WYCKOFF_DIR = Path.home() / ".wyckoff"
 LOCK_PATH = WYCKOFF_DIR / "daemon.lock"
@@ -28,21 +31,21 @@ class DaemonLockBusy(RuntimeError):
 
 @contextmanager
 def single_instance_lock(lock_path: Path | None = None) -> Iterator[None]:
-    """flock 而非 PID 文件：PID 会被系统回收，导致误判进程还活着。"""
+    """内核级文件锁而非 PID 文件：PID 会被系统回收，导致误判进程还活着。"""
     path = lock_path or LOCK_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
-    handle = path.open("w")
+    handle = path.open(platform_lock.lock_mode())
     try:
+        if not platform_lock.try_acquire(handle):
+            raise DaemonLockBusy(f"daemon already running (lock held: {path})")
         try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError as exc:
-            raise DaemonLockBusy(f"daemon already running (lock held: {path})") from exc
-        handle.write(str(os.getpid()))
-        handle.flush()
-        try:
+            handle.seek(0)
+            handle.truncate()
+            handle.write(str(os.getpid()))
+            handle.flush()
             yield
         finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            platform_lock.release(handle)
     finally:
         handle.close()
 
@@ -53,15 +56,13 @@ def is_daemon_running(lock_path: Path | None = None) -> bool:
     if not path.exists():
         return False
     try:
-        handle = path.open("a")
+        handle = path.open("a+")
     except OSError:
         return False
     try:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        return True
-    else:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        if not platform_lock.try_acquire(handle):
+            return True
+        platform_lock.release(handle)
         return False
     finally:
         handle.close()
@@ -92,8 +93,15 @@ def _handle_signal(signum: int, _frame: object) -> None:
 
 
 def install_signal_handlers() -> None:
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        signal.signal(sig, _handle_signal)
+    """Windows 只支持 SIGTERM/SIGINT 的有限语义，SIGBREAK 才是 taskkill 的送达信号。"""
+    signals = [signal.SIGTERM, signal.SIGINT]
+    if platform_lock.IS_WINDOWS:  # pragma: no cover - platform-specific
+        signals.append(getattr(signal, "SIGBREAK", signal.SIGTERM))
+    for sig in signals:
+        try:
+            signal.signal(sig, _handle_signal)
+        except (OSError, ValueError):
+            logger.debug("cannot install handler for signal %s", sig)
 
 
 def run_due_schedules(last_check_at: datetime | None, now: datetime) -> datetime:
@@ -145,7 +153,7 @@ def main_loop(*, lock_path: Path | None = None, poll_seconds: float = 60.0) -> i
             return 0
     except DaemonLockBusy as exc:
         logger.error("%s", exc)
-        return 1
+        return LOCK_BUSY_EXIT_CODE
 
 
 def _sleep_interruptible(seconds: float, *, step: float = 0.5) -> None:

--- a/cli/platform_lock.py
+++ b/cli/platform_lock.py
@@ -1,0 +1,71 @@
+"""跨平台排他文件锁 — daemon 单例保护。
+
+用文件锁而非 PID 文件：PID 会被系统回收，导致误判进程还活着。
+POSIX 用 fcntl.flock，Windows 用 msvcrt.locking —— 两者都是内核级锁，
+进程崩溃时由操作系统自动释放，不会留下需要人工清理的僵尸锁。
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import IO
+
+IS_WINDOWS = sys.platform == "win32"
+
+# 两个模块都按可选处理：任何一边缺失都不该让 import cli.daemon 直接失败，
+# 否则 `wyckoff daemon` 在该平台上连启动都做不到。
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt
+except ImportError:  # POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+_USE_MSVCRT = msvcrt is not None and fcntl is None
+
+# Windows 的 msvcrt.locking 需要显式字节数；锁首字节即可实现互斥。
+_LOCK_BYTES = 1
+
+
+class LockBusy(RuntimeError):
+    """锁已被其他进程持有。"""
+
+
+def available() -> bool:
+    """当前平台是否有可用的锁实现。"""
+    return fcntl is not None or msvcrt is not None
+
+
+def try_acquire(handle: IO) -> bool:
+    """尝试非阻塞加锁。成功返回 True，已被占用返回 False。"""
+    if not available():
+        raise RuntimeError("no file-locking primitive available on this platform")
+    try:
+        if _USE_MSVCRT:  # pragma: no cover - Windows
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, _LOCK_BYTES)
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        return False
+    return True
+
+
+def release(handle: IO) -> None:
+    """释放锁；已经释放或句柄失效时静默返回。"""
+    try:
+        if _USE_MSVCRT:  # pragma: no cover - Windows
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, _LOCK_BYTES)
+        elif fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+def lock_mode() -> str:
+    """Windows 的 msvcrt.locking 要求句柄可读写，POSIX 只需可写。"""
+    return "a+" if _USE_MSVCRT else "w"

--- a/scripts/daemon_install.ps1
+++ b/scripts/daemon_install.ps1
@@ -1,0 +1,79 @@
+# 安装 Wyckoff 定时调度 daemon 为 Windows 计划任务。
+# 装完后关掉 UI，定时任务仍会跑。
+#
+# 用法（普通 PowerShell，不需要管理员）：
+#   powershell -ExecutionPolicy Bypass -File scripts\daemon_install.ps1
+
+$ErrorActionPreference = "Stop"
+
+$TaskName = "WyckoffDaemon"
+$RepoDir  = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$LogDir   = Join-Path $env:USERPROFILE ".wyckoff\logs"
+
+function Info($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Ok($msg)   { Write-Host "==> $msg" -ForegroundColor Green }
+function Fail($msg) { Write-Host "==> $msg" -ForegroundColor Red; exit 1 }
+
+# 优先用仓库内的 venv，退回 PATH 上的 python
+$Python = Join-Path $RepoDir ".venv\Scripts\python.exe"
+if (-not (Test-Path $Python)) {
+    $cmd = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $cmd) { Fail "未找到 Python。先建 venv：uv venv; uv sync" }
+    $Python = $cmd.Source
+}
+
+Info "仓库:   $RepoDir"
+Info "Python: $Python"
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+# 已存在则先删，否则 Register 会失败
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Info "移除已有任务..."
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+# pythonw.exe 没有控制台窗口；没有它就用 python.exe
+$Runner = $Python -replace 'python\.exe$', 'pythonw.exe'
+if (-not (Test-Path $Runner)) { $Runner = $Python }
+
+$action = New-ScheduledTaskAction `
+    -Execute $Runner `
+    -Argument "-m cli daemon --foreground" `
+    -WorkingDirectory $RepoDir
+
+# 登录时启动；daemon 自身有 flock 单例保护，重复触发不会跑出两个
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 3 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -ExecutionTimeLimit (New-TimeSpan -Days 0)
+
+Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Description "Wyckoff 定时调度 daemon — 关闭 UI 后定时任务继续运行" | Out-Null
+
+Info "已注册计划任务 $TaskName"
+
+Start-ScheduledTask -TaskName $TaskName
+Start-Sleep -Seconds 3
+
+$state = (Get-ScheduledTask -TaskName $TaskName).State
+if ($state -eq "Running" -or $state -eq "Ready") {
+    Ok "daemon 已启动（状态：$state）"
+    & $Python -m cli daemon --status
+    Write-Host ""
+    Write-Host "查看日志:  Get-Content -Wait $LogDir\daemon.log"
+    Write-Host "待批准项:  $Python -m cli approve list"
+    Write-Host "停止:      Stop-ScheduledTask -TaskName $TaskName"
+    Write-Host "卸载:      powershell -File scripts\daemon_uninstall.ps1"
+} else {
+    Fail "启动失败（状态：$state）。查看 $LogDir\daemon.log"
+}

--- a/scripts/daemon_uninstall.ps1
+++ b/scripts/daemon_uninstall.ps1
@@ -1,0 +1,28 @@
+# 卸载 Wyckoff 定时调度 daemon（Windows 计划任务）。日志和待批准队列保留。
+
+$ErrorActionPreference = "Stop"
+
+$TaskName = "WyckoffDaemon"
+
+function Info($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Ok($msg)   { Write-Host "==> $msg" -ForegroundColor Green }
+
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Info "停止任务..."
+    Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Info "已移除计划任务 $TaskName"
+} else {
+    Info "任务未注册"
+}
+
+# Windows 上 SIGTERM 不是真信号；残留进程用 taskkill 收掉
+$procs = Get-CimInstance Win32_Process -Filter "Name like '%python%'" |
+    Where-Object { $_.CommandLine -like "*cli daemon*" }
+foreach ($p in $procs) {
+    Info "结束残留进程 PID $($p.ProcessId)"
+    taskkill /PID $p.ProcessId /F 2>$null | Out-Null
+}
+
+Ok "已卸载。定时任务现在只在 UI 打开时运行。"
+Write-Host "日志保留在 ~\.wyckoff\logs\，待批准队列保留在 ~\.wyckoff\approvals.db"

--- a/tests/agents/test_portfolio_tools.py
+++ b/tests/agents/test_portfolio_tools.py
@@ -61,3 +61,38 @@ class TestFetchIntradayIfExtremeDay:
         df = _df([10.0, 9.0])
         result = portfolio_tools._fetch_intraday_if_extreme_day("600519", df)
         assert result is None
+
+
+class TestPortfolioViewStopLoss:
+    """view 必须带出 stop_loss。
+
+    模型只能看到工具返回的字段：漏掉它，「哪些持仓没设止损」就会全部答错，
+    而且答得很自信 —— 这是风控数字，不能靠字段缺失去推断。
+    """
+
+    def test_view_includes_stop_loss(self) -> None:
+        state = {
+            "positions": [{"code": "002270", "name": "A", "shares": 100, "cost": 30.0, "stop_loss": 27.5}],
+            "free_cash": 1000.0,
+        }
+        view = portfolio_tools._portfolio_view("pid", state)
+        assert view["positions"][0]["stop_loss"] == 27.5
+
+    def test_missing_stop_loss_stays_none_not_zero(self) -> None:
+        """真的没设过要是 None；给成 0 会被读成「止损价 0 元」。"""
+        state = {"positions": [{"code": "002270", "shares": 100, "cost": 30.0}], "free_cash": 0}
+        view = portfolio_tools._portfolio_view("pid", state)
+        assert view["positions"][0]["stop_loss"] is None
+
+    def test_stop_loss_survives_the_tool_boundary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """端到端走 portfolio(mode="view")：TUI 与 MCP 都经过这条路径。"""
+        state = {
+            "positions": [{"code": "002270", "shares": 100, "cost": 30.0, "stop_loss": 27.5}],
+            "free_cash": 0,
+        }
+        monkeypatch.setattr(portfolio_tools, "_portfolio_id", lambda _ctx: "pid")
+        monkeypatch.setattr(portfolio_tools, "_load_portfolio_state", lambda _pid, _ctx: state)
+
+        result = portfolio_tools.portfolio(mode="view")
+
+        assert result["positions"][0]["stop_loss"] == 27.5

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -57,6 +57,10 @@ class TestSingleInstance:
         lock.write_text("99999", encoding="utf-8")
         assert daemon.is_daemon_running(lock) is False
 
+    def test_main_loop_has_distinct_lock_busy_exit_code(self, lock):
+        with daemon.single_instance_lock(lock):
+            assert daemon.main_loop(lock_path=lock, poll_seconds=0) == daemon.LOCK_BUSY_EXIT_CODE
+
 
 class TestDueSchedules:
     def _sched(self, **kwargs):

--- a/tests/cli/test_platform_lock.py
+++ b/tests/cli/test_platform_lock.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+from cli import platform_lock
+
+
+class TestPosixPath:
+    def test_acquire_and_release(self, tmp_path):
+        path = tmp_path / "a.lock"
+        with path.open(platform_lock.lock_mode()) as handle:
+            assert platform_lock.try_acquire(handle) is True
+            platform_lock.release(handle)
+
+    def test_second_handle_refused_while_held(self, tmp_path):
+        """同一进程内两个句柄：POSIX flock 按句柄计，可验证互斥语义。"""
+        path = tmp_path / "b.lock"
+        first = path.open(platform_lock.lock_mode())
+        second = path.open("a+")
+        try:
+            assert platform_lock.try_acquire(first) is True
+            assert platform_lock.try_acquire(second) is False
+        finally:
+            platform_lock.release(first)
+            first.close()
+            second.close()
+
+    def test_release_after_release_is_silent(self, tmp_path):
+        path = tmp_path / "c.lock"
+        with path.open(platform_lock.lock_mode()) as handle:
+            platform_lock.try_acquire(handle)
+            platform_lock.release(handle)
+            platform_lock.release(handle)
+
+    def test_lock_mode_is_writable(self):
+        assert "a" in platform_lock.lock_mode() or "w" in platform_lock.lock_mode()
+
+
+class TestWindowsImportSafety:
+    """Windows 上 fcntl 不存在。旧代码在 cli/daemon.py 顶层 import fcntl，
+    导致 `wyckoff daemon` 在 Windows 上连启动都做不到。"""
+
+    def test_daemon_imports_without_fcntl(self):
+        script = textwrap.dedent(
+            """
+            import builtins, sys
+            real_import = builtins.__import__
+
+            def fake_import(name, *args, **kwargs):
+                if name == "fcntl":
+                    raise ImportError("No module named 'fcntl'")
+                return real_import(name, *args, **kwargs)
+
+            builtins.__import__ = fake_import
+            for mod in [m for m in sys.modules if m.startswith(("cli.", "fcntl"))]:
+                sys.modules.pop(mod, None)
+
+            import cli.daemon  # must not raise
+            print("IMPORT_OK")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert "IMPORT_OK" in result.stdout, result.stderr[-2000:]
+
+    def test_msvcrt_branch_selected_when_only_msvcrt_present(self, monkeypatch):
+        """模拟 Windows：fcntl 缺失、msvcrt 存在时必须走 msvcrt 分支。"""
+        calls: list[tuple[int, int]] = []
+
+        class _FakeMsvcrt:
+            LK_NBLCK = 1
+            LK_UNLCK = 0
+
+            @staticmethod
+            def locking(fileno, mode, nbytes):
+                calls.append((mode, nbytes))
+
+        monkeypatch.setattr(platform_lock, "fcntl", None)
+        monkeypatch.setattr(platform_lock, "msvcrt", _FakeMsvcrt)
+        monkeypatch.setattr(platform_lock, "_USE_MSVCRT", True)
+
+        assert platform_lock.available() is True
+        assert platform_lock.lock_mode() == "a+"
+
+        class _Handle:
+            def seek(self, _n):
+                pass
+
+            def fileno(self):
+                return 3
+
+        handle = _Handle()
+        assert platform_lock.try_acquire(handle) is True
+        platform_lock.release(handle)
+        assert calls == [(1, 1), (0, 1)]
+
+    def test_no_primitive_raises_clearly(self, monkeypatch):
+        monkeypatch.setattr(platform_lock, "fcntl", None)
+        monkeypatch.setattr(platform_lock, "msvcrt", None)
+        monkeypatch.setattr(platform_lock, "_USE_MSVCRT", False)
+        assert platform_lock.available() is False
+        try:
+            platform_lock.try_acquire(object())
+        except RuntimeError as exc:
+            assert "no file-locking primitive" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+    def test_platform_lock_imports_without_fcntl(self):
+        script = textwrap.dedent(
+            """
+            import builtins, sys
+            real_import = builtins.__import__
+
+            def fake_import(name, *args, **kwargs):
+                if name == "fcntl":
+                    raise ImportError("No module named 'fcntl'")
+                return real_import(name, *args, **kwargs)
+
+            builtins.__import__ = fake_import
+            sys.modules.pop("cli.platform_lock", None)
+            sys.modules.pop("fcntl", None)
+
+            import cli.platform_lock  # must not raise on the POSIX branch import
+            print("IMPORT_OK")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        # POSIX 分支确实需要 fcntl；这个测试记录当前行为，Windows 走 msvcrt 分支。
+        assert "IMPORT_OK" in result.stdout or "fcntl" in result.stderr
+
+
+class TestDaemonUsesPlatformLock:
+    def test_daemon_has_no_direct_fcntl_reference(self):
+        """daemon 不应再直接引用 fcntl，平台差异收敛在 platform_lock。"""
+        from pathlib import Path
+
+        source = Path("cli/daemon.py").read_text(encoding="utf-8")
+        assert "import fcntl" not in source
+        assert "fcntl." not in source
+
+    def test_lock_still_enforces_single_instance(self, tmp_path):
+        from cli.daemon import DaemonLockBusy, single_instance_lock
+
+        lock = tmp_path / "d.lock"
+        with single_instance_lock(lock):
+            try:
+                with single_instance_lock(lock):
+                    raise AssertionError("second acquisition should fail")
+            except DaemonLockBusy:
+                pass
+
+    def test_pid_written_and_truncated(self, tmp_path):
+        import os
+
+        from cli.daemon import read_lock_pid, single_instance_lock
+
+        lock = tmp_path / "e.lock"
+        lock.write_text("999999999", encoding="utf-8")
+        with single_instance_lock(lock):
+            assert read_lock_pid(lock) == os.getpid()


### PR DESCRIPTION
## 变更摘要

从桌面端 PR #262 里拆出两个与桌面端无关的修复,让它们能独立合并。两个都影响今天正在用 TUI / CLI / MCP 的人,不需要等那个大 PR。

**一、daemon 在 Windows 上无法导入**

`cli/daemon.py` 顶层 `import fcntl`,而 Windows 没有这个模块。影响面比"daemon 起不来"更大:

- `wyckoff daemon` / `wyckoff daemon --status` 在 Windows 上直接失败
- `cli/tui.py:4533` 在 `_check_schedules` 里导入 `cli.daemon`,而它挂在 **60 秒定时器**上(`tui.py:2408`)且没有 try/except —— Windows 用户只要开着 TUI,就每分钟抛一次

抽出 `cli/platform_lock.py` 做平台分发:POSIX 用 `fcntl.flock`,Windows 用 `msvcrt.locking`。仍然是内核级文件锁而不是 PID 文件 —— PID 会被系统回收,导致误判进程还活着。

顺带补了 Windows 的 Task Scheduler 安装/卸载脚本(对应 macOS 的 launchd),跑 `python -m cli daemon --foreground`,与 Electron 无关。

**二、`portfolio(view)` 漏了 `stop_loss`**

`_portfolio_view` 构造的字典里没有 `stop_loss`,而它是实际存在的存储列(`_local_position` 一直带着)。模型只能看到工具返回的字段,所以问"哪些持仓没设止损"时会把**每一只**都算进去,而且答得很自信。

这条路径两个非桌面入口都走:

- **TUI** — `cli/runtime.py` 经 `ToolRegistry` 调 `agents.portfolio_tools.portfolio`
- **MCP** — `mcp_server.py:394` 直接暴露 `portfolio(mode="view")`

缺省值用 `None` 而不是 `0`:真的没设过要能区分,给成 0 会被读成"止损价 0 元"。

## 验证

**Windows 崩溃做了对照实验**,不是推测 —— 用 `meta_path` hook 屏蔽 `fcntl` 模拟 Windows:

- `origin/main` 版本:`ImportError: No module named fcntl`
- 本分支版本:正常导入

**测试**:3029 passed / 22 skipped。ruff / format / quality-gate 全绿。新增 `tests/cli/test_platform_lock.py`,以及 3 个 `stop_loss` 断言(含一条端到端走 `portfolio(mode="view")` 的边界测试)。

## 与 #262 的关系

零重叠代码依赖,可以先合这个。#262 里对应的提交会在 rebase 时自然消解。

同一批调查里还看过但**故意没拆**的东西:

- `cli/approval_policy.py` 的 `explain()` / `nav_ratio()` 与 `approval_queue` 的两个新列 —— 可以干净摘出来,但非桌面端没有任何地方渲染它们,拆出来就是死代码。等 `wyckoff approve list` 也显示理由时再说。
- `annotate_chart` —— 它在共享的 `TOOL_SCHEMAS` 里,所以 TUI 的模型看得见、也能调,但标注只有桌面端能渲染。在 CLI 下它会**写入成功却没人能看**,模型会把这当成完成。这需要的是加门禁,不是拆分,所以留在 #262 一起处理。

## 未覆盖

Windows 锁的行为只在 macOS 上通过屏蔽 `fcntl` 做了导入层验证,`msvcrt.locking` 的实际互斥语义没有在真 Windows 机器上跑过。
