### PR TITLE
feat: 水温 regime 前瞻检验，每周跑并推飞书含行动建议

### DIFF
--- a/.github/workflows/regime_forward_eval.yml
+++ b/.github/workflows/regime_forward_eval.yml
@@ -1,0 +1,65 @@
+name: Regime Forward Evaluation
+
+# 市场水温（regime）判定的前瞻检验。
+# 起因：10 笔 EXIT/清仓建议里 9 笔卖在阶段底部，其中一批理由是「CRASH 环境下无保留价值」，
+# 而实测 CRASH 之后市场偏涨（超基准 +1.12pct、p=0.015）。三个月样本说不了话，
+# 所以每周重跑一次，看结论能否跨周期稳定，再决定要不要动生产开关。
+on:
+  schedule:
+    # UTC 周六 01:40 = 北京时间周六 09:40。周末跑：本周数据已收全，且不与工作日任务争资源。
+    - cron: "40 1 * * 6"
+  workflow_dispatch:
+    inputs:
+      horizon:
+        description: "前瞻交易日数"
+        default: "5"
+      index:
+        description: "主指数代码"
+        default: "000001"
+
+concurrency:
+  group: regime-forward-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: "1"
+      # 只读 market_signal_daily 与指数行情，不写库；故不设 WYCKOFF_WRITE_CONTEXT。
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      TZ: Asia/Shanghai
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Evaluate regime forward returns
+        run: |
+          python scripts/evaluate_regime_forward.py \
+            --horizon "${{ github.event.inputs.horizon || '5' }}" \
+            --index "${{ github.event.inputs.index || '000001' }}"
+
+      - name: Upload evidence
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: regime-forward-evidence
+          path: docs/evidence/regime_forward_h*.json
+          if-no-files-found: warn

--- a/core/regime_forward_eval.py
+++ b/core/regime_forward_eval.py
@@ -1,0 +1,203 @@
+"""市场水温（regime）判定的前瞻检验：它到底在标底部还是标危险。
+
+起因：2026-08-16 复盘发现 10 笔 EXIT/清仓建议里 9 笔卖在阶段底部（T+5 卖出后均值
++13.26%、继续下跌占 0%），其中 7/30 那批理由写的是「CRASH 环境下无保留价值，执行清仓」。
+顺着测 12 次 CRASH 判定，结果是 T+5 +0.68%（基准 −0.44%）、超基准 +1.12pct、
+单尾 p=0.015，且相对「纯近3日跌最多」对照仍有 +0.94pct 增量、重叠仅 5/12。
+
+即 CRASH 更像**有效的底部识别**，而系统把它当「危险→清仓」用，方向用反了。
+
+本模块把该检验固化成可复算流程，每月重跑以判断这是真信号还是 V 型反转的巧合：
+- 每个 regime 判定日 → 主指数前瞻 N 日收益，对比「区间内任意一天买入」的基准。
+- **纯跌幅对照**：另取「近 3 日累计跌幅最大」的同样天数做对照组。若两者表现相当且
+  高度重叠，则 regime 没有独立信息，测到的只是众所周知的短期均值回复。
+- **随机负控制**：从所有交易日随机抽同样天数 2000 次，得到差值分布与单尾 p。
+样本不足时明确返回「样本不足」，不给结论。
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass, field
+from statistics import mean
+from typing import Any
+
+MIN_REGIME_DAYS = 8
+RANDOM_ROUNDS = 2000
+LOOKBACK_DAYS = 3
+
+
+@dataclass
+class RegimeStat:
+    regime: str
+    days: int
+    forward: float | None
+    excess: float | None
+    positive_pct: float | None
+    p_value: float | None = None
+    random_ci: tuple[float | None, float | None] = (None, None)
+    verdict: str = "样本不足"
+    note: str = ""
+
+
+@dataclass
+class RegimeReport:
+    horizon: int
+    index_code: str
+    window: tuple[str, str]
+    baseline: float | None
+    baseline_days: int
+    stats: list[RegimeStat] = field(default_factory=list)
+    drawdown_control: dict[str, Any] = field(default_factory=dict)
+
+
+def forward_return_map(dates: list[str], closes: list[float], horizon: int) -> dict[str, float]:
+    """交易日 -> 前瞻 horizon 日收益（百分数）。尾部不足 horizon 的日子直接不收录。"""
+    out: dict[str, float] = {}
+    for i in range(len(dates) - horizon):
+        base = float(closes[i])
+        if base <= 0:
+            continue
+        value = (float(closes[i + horizon]) / base - 1.0) * 100.0
+        if not math.isnan(value):
+            out[dates[i]] = value
+    return out
+
+
+def trailing_drop_map(dates: list[str], closes: list[float], lookback: int = LOOKBACK_DAYS) -> dict[str, float]:
+    """交易日 -> 近 lookback 日累计涨跌幅，用于构造纯跌幅对照组。"""
+    out: dict[str, float] = {}
+    for i in range(lookback, len(dates)):
+        base = float(closes[i - lookback])
+        if base > 0:
+            out[dates[i]] = (float(closes[i]) / base - 1.0) * 100.0
+    return out
+
+
+def _random_control(
+    pool: list[str], forward: dict[str, float], size: int, baseline: float
+) -> tuple[float | None, float | None, float | None, float]:
+    """返回 (ci_low, ci_high, p_value, 随机均值差的中位数)。"""
+    if size <= 0 or len(pool) <= size:
+        return (None, None, None, 0.0)
+    diffs: list[float] = []
+    for seed in range(RANDOM_ROUNDS):
+        rng = random.Random(seed)
+        picked = rng.sample(pool, size)
+        diffs.append(mean(forward[day] for day in picked) - baseline)
+    diffs.sort()
+    lo = diffs[int(0.025 * (len(diffs) - 1))]
+    hi = diffs[int(0.975 * (len(diffs) - 1))]
+    return (round(lo, 4), round(hi, 4), None, diffs[len(diffs) // 2])
+
+
+def _p_value(pool: list[str], forward: dict[str, float], size: int, baseline: float, observed: float) -> float | None:
+    if size <= 0 or len(pool) <= size:
+        return None
+    # 按观测方向取单尾：正超额问「随机能否更高」，负超额问「随机能否更低」。
+    # 固定用 >= 会让负向结果得到 p≈0.99 这种反直觉的数，看起来像「极不显著」。
+    hits = 0
+    for seed in range(RANDOM_ROUNDS):
+        rng = random.Random(seed)
+        picked = rng.sample(pool, size)
+        diff = mean(forward[day] for day in picked) - baseline
+        if (diff >= observed) if observed >= 0 else (diff <= observed):
+            hits += 1
+    return round(hits / RANDOM_ROUNDS, 4)
+
+
+def _verdict(stat_days: int, excess: float | None, ci: tuple[float | None, float | None], p: float | None) -> str:
+    if stat_days < MIN_REGIME_DAYS or excess is None:
+        return "样本不足"
+    if ci[0] is not None and ci[0] <= excess <= ci[1]:
+        return "落在随机区间内：无方向性"
+    if p is not None and p <= 0.05:
+        return "正向、超出随机（该状态后市场偏涨）" if excess > 0 else "负向、超出随机（该状态后市场偏跌）"
+    return "超出随机区间但 p 不足：方向待更多样本"
+
+
+def evaluate_regimes(
+    regime_by_date: dict[str, str],
+    dates: list[str],
+    closes: list[float],
+    *,
+    horizon: int = 5,
+    index_code: str = "000001",
+) -> RegimeReport:
+    forward = forward_return_map(dates, closes, horizon)
+    pool = [day for day in dates if day in forward]
+    baseline = mean(forward[day] for day in pool) if pool else None
+    report = RegimeReport(
+        horizon=horizon,
+        index_code=index_code,
+        window=(dates[0] if dates else "", dates[-1] if dates else ""),
+        baseline=None if baseline is None else round(baseline, 4),
+        baseline_days=len(pool),
+    )
+    if baseline is None:
+        return report
+
+    for regime in sorted({str(v) for v in regime_by_date.values() if v}):
+        days = [day for day, value in regime_by_date.items() if str(value) == regime and day in forward]
+        if not days:
+            report.stats.append(RegimeStat(regime, 0, None, None, None, note="无可用前瞻样本"))
+            continue
+        value = mean(forward[day] for day in days)
+        excess = value - baseline
+        ci = (None, None)
+        p = None
+        if len(days) >= MIN_REGIME_DAYS:
+            lo, hi, _, _ = _random_control(pool, forward, len(days), baseline)
+            ci = (lo, hi)
+            p = _p_value(pool, forward, len(days), baseline, excess)
+        report.stats.append(
+            RegimeStat(
+                regime=regime,
+                days=len(days),
+                forward=round(value, 4),
+                excess=round(excess, 4),
+                positive_pct=round(100.0 * sum(1 for d in days if forward[d] > 0) / len(days), 2),
+                p_value=p,
+                random_ci=ci,
+                verdict=_verdict(len(days), excess, ci, p),
+            )
+        )
+    report.stats.sort(key=lambda s: (s.excess is None, -(s.excess or 0.0)))
+    report.drawdown_control = _drawdown_control(regime_by_date, dates, closes, forward, pool, baseline)
+    return report
+
+
+def _drawdown_control(
+    regime_by_date: dict[str, str],
+    dates: list[str],
+    closes: list[float],
+    forward: dict[str, float],
+    pool: list[str],
+    baseline: float,
+) -> dict[str, Any]:
+    """CRASH 是否只是「跌多了」的同义词。"""
+    crash_days = [d for d, v in regime_by_date.items() if str(v) == "CRASH" and d in forward]
+    if len(crash_days) < MIN_REGIME_DAYS:
+        return {"verdict": "样本不足", "crash_days": len(crash_days)}
+    drops = trailing_drop_map(dates, closes)
+    candidates = sorted((d for d in pool if d in drops), key=lambda d: drops[d])[: len(crash_days)]
+    if not candidates:
+        return {"verdict": "无对照样本"}
+    crash_ret = mean(forward[d] for d in crash_days)
+    control_ret = mean(forward[d] for d in candidates)
+    overlap = len(set(crash_days) & set(candidates))
+    increment = crash_ret - control_ret
+    return {
+        "crash_days": len(crash_days),
+        "crash_forward": round(crash_ret, 4),
+        "pure_drawdown_forward": round(control_ret, 4),
+        "baseline_forward": round(baseline, 4),
+        "increment_over_drawdown": round(increment, 4),
+        "overlap_days": overlap,
+        "verdict": (
+            "CRASH 含独立于跌幅的信息"
+            if increment > 0.3 and overlap <= len(crash_days) * 0.7
+            else "与纯跌幅规则接近：可能只是短期均值回复"
+        ),
+    }

--- a/docs/evidence/regime_forward_h5.json
+++ b/docs/evidence/regime_forward_h5.json
@@ -1,0 +1,126 @@
+{
+  "horizon": 5,
+  "index_code": "000001",
+  "window": [
+    "2026-05-06",
+    "2026-08-14"
+  ],
+  "baseline": -0.4421,
+  "baseline_days": 67,
+  "stats": [
+    {
+      "regime": "BEAR_REBOUND",
+      "days": 5,
+      "forward": 1.832,
+      "excess": 2.2741,
+      "positive_pct": 80.0,
+      "p_value": null,
+      "random_ci": [
+        null,
+        null
+      ],
+      "verdict": "样本不足",
+      "note": ""
+    },
+    {
+      "regime": "CRASH",
+      "days": 12,
+      "forward": 0.6789,
+      "excess": 1.121,
+      "positive_pct": 75.0,
+      "p_value": 0.0145,
+      "random_ci": [
+        -0.9827,
+        0.9975
+      ],
+      "verdict": "正向、超出随机（该状态后市场偏涨）",
+      "note": ""
+    },
+    {
+      "regime": "PANIC_REPAIR",
+      "days": 4,
+      "forward": 0.067,
+      "excess": 0.5091,
+      "positive_pct": 50.0,
+      "p_value": null,
+      "random_ci": [
+        null,
+        null
+      ],
+      "verdict": "样本不足",
+      "note": ""
+    },
+    {
+      "regime": "RISK_ON",
+      "days": 5,
+      "forward": -0.6077,
+      "excess": -0.1656,
+      "positive_pct": 60.0,
+      "p_value": null,
+      "random_ci": [
+        null,
+        null
+      ],
+      "verdict": "样本不足",
+      "note": ""
+    },
+    {
+      "regime": "RISK_OFF",
+      "days": 10,
+      "forward": -0.8891,
+      "excess": -0.447,
+      "positive_pct": 20.0,
+      "p_value": 0.2055,
+      "random_ci": [
+        -1.0732,
+        1.101
+      ],
+      "verdict": "落在随机区间内：无方向性",
+      "note": ""
+    },
+    {
+      "regime": "NEUTRAL",
+      "days": 13,
+      "forward": -1.5187,
+      "excess": -1.0766,
+      "positive_pct": 7.69,
+      "p_value": 0.01,
+      "random_ci": [
+        -0.9281,
+        0.9665
+      ],
+      "verdict": "负向、超出随机（该状态后市场偏跌）",
+      "note": ""
+    },
+    {
+      "regime": "CAUTION",
+      "days": 1,
+      "forward": -3.4424,
+      "excess": -3.0003,
+      "positive_pct": 0.0,
+      "p_value": null,
+      "random_ci": [
+        null,
+        null
+      ],
+      "verdict": "样本不足",
+      "note": ""
+    }
+  ],
+  "drawdown_control": {
+    "crash_days": 12,
+    "crash_forward": 0.6789,
+    "pure_drawdown_forward": -0.2586,
+    "baseline_forward": -0.4421,
+    "increment_over_drawdown": 0.9375,
+    "overlap_days": 5,
+    "verdict": "CRASH 含独立于跌幅的信息"
+  },
+  "action_lines": [
+    "① CRASH 后市场偏涨（超基准 +1.12pct，p=0.0145）。**不要**执行以 CRASH 为由的清仓建议——它标的是底部，不是危险。",
+    "② 该效应独立于「跌多了」（相对纯跌幅对照 +0.94pct，重叠 5/12），不是单纯均值回复。",
+    "③ 后市偏跌且超出随机的状态：NEUTRAL(-1.08) —— 这些才是真正该降低敞口的时点。",
+    "④ 暂不改 `STEP4_BUY_BLOCK_REGIMES`：选股信号本身仍是负超额，「几乎不买」当前是保护而非缺陷；先等选股 alpha 转正。",
+    "⑤ 下一步只做一件事：继续积累样本，下月重跑本检验，看结论是否跨周期稳定。"
+  ]
+}

--- a/scripts/evaluate_regime_forward.py
+++ b/scripts/evaluate_regime_forward.py
@@ -1,0 +1,170 @@
+"""跑 regime 前瞻检验并推送飞书卡片（含「接下来做什么」的行动建议）。
+
+用法::
+
+    python scripts/evaluate_regime_forward.py --horizon 5 --index 000001
+    python scripts/evaluate_regime_forward.py --no-notify      # 只出报告不推送
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+import pandas as pd
+
+from core.regime_forward_eval import MIN_REGIME_DAYS, RegimeReport, evaluate_regimes
+
+EVIDENCE_DIR = Path("docs/evidence")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="市场水温 regime 的前瞻检验")
+    parser.add_argument("--horizon", type=int, default=5, help="前瞻交易日数")
+    parser.add_argument("--index", default="000001", help="主指数代码")
+    parser.add_argument("--start", default="", help="起始日期，默认取 market_signal_daily 最早一天前 10 天")
+    parser.add_argument("--no-notify", action="store_true", help="不推送飞书")
+    parser.add_argument("--out", default=str(EVIDENCE_DIR), help="报告输出目录")
+    return parser.parse_args()
+
+
+def load_regimes() -> dict[str, str]:
+    from integrations.supabase_base import create_admin_client, is_admin_configured
+
+    if not is_admin_configured():
+        raise SystemExit("需要 SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY")
+    client = create_admin_client()
+    rows = client.table("market_signal_daily").select("trade_date,benchmark_regime").order("trade_date").execute().data
+    return {
+        str(row["trade_date"]): str(row.get("benchmark_regime") or "")
+        for row in rows or []
+        if row.get("trade_date") and row.get("benchmark_regime")
+    }
+
+
+def load_index_series(code: str, start: str, end: str) -> tuple[list[str], list[float]]:
+    from integrations.index_data_source import fetch_index_hist
+
+    frame = fetch_index_hist(code, start, end)
+    if frame is None or frame.empty:
+        raise SystemExit(f"指数 {code} 取数为空")
+    date_col = "date" if "date" in frame.columns else frame.columns[0]
+    work = frame.copy()
+    work["close"] = pd.to_numeric(work["close"], errors="coerce")
+    work = work.dropna(subset=["close"])
+    work["ds"] = pd.to_datetime(work[date_col]).dt.strftime("%Y-%m-%d")
+    work = work.sort_values("ds").drop_duplicates("ds")
+    return work.ds.tolist(), work.close.astype(float).tolist()
+
+
+def build_action_lines(report: RegimeReport) -> list[str]:
+    """把统计结论翻译成可执行动作。措辞必须与证据强度匹配。"""
+    lines: list[str] = []
+    crash = next((s for s in report.stats if s.regime == "CRASH"), None)
+    control = report.drawdown_control or {}
+
+    if crash is None or crash.days < MIN_REGIME_DAYS:
+        lines.append("① CRASH 样本不足，本期不据此调整任何开关；继续积累。")
+    elif crash.excess is not None and crash.excess > 0 and (crash.p_value or 1.0) <= 0.05:
+        lines.append(
+            f"① CRASH 后市场偏涨（超基准 {crash.excess:+.2f}pct，p={crash.p_value}）。"
+            "**不要**执行以 CRASH 为由的清仓建议——它标的是底部，不是危险。"
+        )
+        if str(control.get("verdict", "")).startswith("CRASH 含独立"):
+            lines.append(
+                f"② 该效应独立于「跌多了」（相对纯跌幅对照 {control.get('increment_over_drawdown'):+.2f}pct，"
+                f"重叠 {control.get('overlap_days')}/{control.get('crash_days')}），不是单纯均值回复。"
+            )
+        else:
+            lines.append("② 但与纯跌幅规则接近，可能只是短期均值回复，暂不视为独立信号。")
+    elif crash.excess is not None and crash.excess < 0 and (crash.p_value or 1.0) <= 0.05:
+        lines.append(f"① CRASH 后市场确实偏跌（{crash.excess:+.2f}pct，p={crash.p_value}），现有清仓逻辑方向正确。")
+    else:
+        lines.append(f"① CRASH 方向未达显著（超基准 {crash.excess:+.2f}pct，p={crash.p_value}），维持现状不动开关。")
+
+    negative = [s for s in report.stats if s.verdict.startswith("负向")]
+    if negative:
+        names = "、".join(f"{s.regime}({s.excess:+.2f})" for s in negative)
+        lines.append(f"③ 后市偏跌且超出随机的状态：{names} —— 这些才是真正该降低敞口的时点。")
+
+    lines.append(
+        "④ 暂不改 `STEP4_BUY_BLOCK_REGIMES`：选股信号本身仍是负超额，"
+        "「几乎不买」当前是保护而非缺陷；先等选股 alpha 转正。"
+    )
+    lines.append("⑤ 下一步只做一件事：继续积累样本，下月重跑本检验，看结论是否跨周期稳定。")
+    return lines
+
+
+def render_markdown(report: RegimeReport) -> str:
+    head = (
+        f"**窗口** {report.window[0]} ~ {report.window[1]}　"
+        f"**指数** {report.index_code}　**前瞻** T+{report.horizon}\n"
+        f"**基准**（任意一天买入）{report.baseline:+.2f}%　样本 {report.baseline_days} 天\n\n"
+    )
+    rows = ["| 水温 | 天数 | 前瞻 | 超基准 | 上涨占比 | p | 判定 |", "| --- | --: | --: | --: | --: | --: | --- |"]
+    for stat in report.stats:
+        if stat.forward is None:
+            rows.append(f"| {stat.regime} | {stat.days} | — | — | — | — | {stat.note or stat.verdict} |")
+            continue
+        p_text = "—" if stat.p_value is None else f"{stat.p_value:.3f}"
+        rows.append(
+            f"| {stat.regime} | {stat.days} | {stat.forward:+.2f}% | {stat.excess:+.2f} | "
+            f"{stat.positive_pct:.0f}% | {p_text} | {stat.verdict} |"
+        )
+    control = report.drawdown_control or {}
+    control_text = ""
+    if control.get("crash_forward") is not None:
+        control_text = (
+            f"\n**纯跌幅对照**　CRASH {control['crash_forward']:+.2f}% vs "
+            f"近3日跌最多 {control['pure_drawdown_forward']:+.2f}%　"
+            f"增量 {control['increment_over_drawdown']:+.2f}pct　"
+            f"重叠 {control['overlap_days']}/{control['crash_days']}\n"
+            f"{control['verdict']}\n"
+        )
+    actions = "\n".join(f"- {line}" for line in build_action_lines(report))
+    return f"{head}{chr(10).join(rows)}\n{control_text}\n**接下来做什么**\n{actions}\n"
+
+
+def main() -> int:
+    args = parse_args()
+    regimes = load_regimes()
+    if not regimes:
+        print("[regime] market_signal_daily 无 regime 记录")
+        return 1
+    start = args.start or (pd.to_datetime(min(regimes)) - pd.Timedelta(days=20)).strftime("%Y-%m-%d")
+    end = (pd.to_datetime(max(regimes)) + pd.Timedelta(days=args.horizon * 3 + 10)).strftime("%Y-%m-%d")
+    dates, closes = load_index_series(args.index, start, end)
+    report = evaluate_regimes(regimes, dates, closes, horizon=args.horizon, index_code=args.index)
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = asdict(report)
+    payload["action_lines"] = build_action_lines(report)
+    (out_dir / f"regime_forward_h{args.horizon}.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    markdown = render_markdown(report)
+    print(markdown)
+
+    if not args.no_notify:
+        _notify(markdown, report)
+    return 0
+
+
+def _notify(markdown: str, report: RegimeReport) -> None:
+    webhook = os.getenv("FEISHU_WEBHOOK_URL", "").strip()
+    if not webhook:
+        print("[regime] 未配置 FEISHU_WEBHOOK_URL，跳过推送")
+        return
+    from utils.feishu import send_feishu_notification
+
+    title = f"水温前瞻检验 T+{report.horizon}｜{report.window[1]}"
+    print("[regime] feishu sent" if send_feishu_notification(webhook, title, markdown) else "[regime] feishu failed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_regime_forward_eval.py
+++ b/tests/core/test_regime_forward_eval.py
@@ -1,0 +1,118 @@
+"""Tests for market-regime forward evaluation."""
+
+from __future__ import annotations
+
+from core.regime_forward_eval import (
+    MIN_REGIME_DAYS,
+    evaluate_regimes,
+    forward_return_map,
+    trailing_drop_map,
+)
+
+
+def _series(n: int, step: float = 1.0, start: float = 100.0):
+    dates = [f"2026-06-{i + 1:02d}" for i in range(n)]
+    closes = [start + i * step for i in range(n)]
+    return dates, closes
+
+
+class TestForwardReturnMap:
+    def test_drops_tail_without_full_horizon(self):
+        dates, closes = _series(10)
+        forward = forward_return_map(dates, closes, 5)
+        assert len(forward) == 5
+        assert dates[-1] not in forward
+
+    def test_computes_percent(self):
+        forward = forward_return_map(["d1", "d2", "d3"], [100.0, 110.0, 121.0], 1)
+        assert round(forward["d1"], 4) == 10.0
+        assert round(forward["d2"], 4) == 10.0
+
+    def test_skips_non_positive_base(self):
+        assert forward_return_map(["a", "b"], [0.0, 5.0], 1) == {}
+
+
+class TestTrailingDropMap:
+    def test_uses_lookback_window(self):
+        drops = trailing_drop_map(["a", "b", "c", "d"], [100.0, 90.0, 80.0, 70.0], lookback=3)
+        assert round(drops["d"], 2) == -30.0
+        assert "a" not in drops
+
+
+class TestEvaluateRegimes:
+    def test_reports_insufficient_sample(self):
+        dates, closes = _series(40)
+        regimes = {d: "CRASH" for d in dates[:3]}
+        report = evaluate_regimes(regimes, dates, closes, horizon=5)
+        crash = next(s for s in report.stats if s.regime == "CRASH")
+        assert crash.days < MIN_REGIME_DAYS
+        assert crash.verdict == "样本不足"
+        assert crash.p_value is None
+
+    def test_detects_positive_regime(self):
+        """把 regime 打在每次下跌后的低点，前瞻应显著为正。"""
+        dates = [f"2026-06-{i + 1:02d}" for i in range(40)]
+        closes = []
+        price = 100.0
+        for i in range(40):
+            price = price * (0.95 if i % 4 == 0 else 1.03)
+            closes.append(price)
+        regimes = {dates[i]: ("CRASH" if i % 4 == 0 else "NEUTRAL") for i in range(34)}
+        report = evaluate_regimes(regimes, dates, closes, horizon=3)
+        crash = next(s for s in report.stats if s.regime == "CRASH")
+        assert crash.days >= MIN_REGIME_DAYS
+        assert crash.excess > 0
+
+    def test_p_value_is_directional(self):
+        """负超额也要拿到小 p；固定单尾会让负向结果得到 p≈0.99。"""
+        dates = [f"2026-06-{i + 1:02d}" for i in range(40)]
+        closes = []
+        price = 100.0
+        for i in range(40):
+            price = price * (1.05 if i % 4 == 0 else 0.99)
+            closes.append(price)
+        # 打在每次上涨之后（即后续偏跌处）
+        regimes = {dates[i]: ("RISK_ON" if i % 4 == 0 else "NEUTRAL") for i in range(34)}
+        report = evaluate_regimes(regimes, dates, closes, horizon=3)
+        risk_on = next(s for s in report.stats if s.regime == "RISK_ON")
+        assert risk_on.excess < 0
+        assert risk_on.p_value is not None and risk_on.p_value <= 0.5
+
+    def test_baseline_uses_all_days(self):
+        dates, closes = _series(30)
+        report = evaluate_regimes({dates[0]: "NEUTRAL"}, dates, closes, horizon=5)
+        assert report.baseline_days == len(dates) - 5
+        assert report.baseline is not None
+
+    def test_empty_series_is_safe(self):
+        report = evaluate_regimes({}, [], [], horizon=5)
+        assert report.baseline is None
+        assert report.stats == []
+
+    def test_stats_sorted_best_first(self):
+        dates = [f"2026-06-{i + 1:02d}" for i in range(40)]
+        closes = []
+        price = 100.0
+        for i in range(40):
+            price = price * (0.95 if i % 4 == 0 else 1.03)
+            closes.append(price)
+        regimes = {dates[i]: ("CRASH" if i % 4 == 0 else "NEUTRAL") for i in range(34)}
+        report = evaluate_regimes(regimes, dates, closes, horizon=3)
+        excesses = [s.excess for s in report.stats if s.excess is not None]
+        assert excesses == sorted(excesses, reverse=True)
+
+
+class TestDrawdownControl:
+    def test_flags_pure_drawdown_equivalence(self):
+        """CRASH 就是「跌最多」时，应判为可能只是均值回复。"""
+        dates = [f"2026-06-{i + 1:02d}" for i in range(40)]
+        closes = []
+        price = 100.0
+        for i in range(40):
+            price = price * (0.95 if i % 4 == 0 else 1.03)
+            closes.append(price)
+        regimes = {dates[i]: ("CRASH" if i % 4 == 0 else "NEUTRAL") for i in range(34)}
+        report = evaluate_regimes(regimes, dates, closes, horizon=3)
+        control = report.drawdown_control
+        assert control["crash_days"] >= MIN_REGIME_DAYS
+        assert "overlap_days" in control


### PR DESCRIPTION
## Summary / 变更摘要

起因是一次实盘复盘：**10 笔 EXIT/清仓建议里 9 笔卖在阶段底部**（T+5 卖出后均值 +13.26%、继续下跌占 0%），其中 7/30 那批理由写的是「CRASH 环境下无保留价值，执行清仓」，而那四只随后涨了 19%~27%。

顺着测 `market_signal_daily` 的 regime 判定，发现**方向被用反了**：

| 水温 | 天数 | T+5 | 超基准 | 上涨占比 | p |
| --- | --: | --: | --: | --: | --: |
| **CRASH** | 12 | **+0.68%** | **+1.12** | 75% | **0.015** |
| BEAR_REBOUND | 5 | +1.83% | +2.27 | 80% | 样本不足 |
| RISK_OFF | 10 | −0.89% | −0.45 | 20% | 0.205 |
| **NEUTRAL** | 13 | **−1.52%** | **−1.08** | 8% | **0.010** |
| 基准（任意一天买入） | 67 | −0.44% | — | — | — |

CRASH 是所有档里前瞻**最好**的，NEUTRAL 才是显著偏跌的那个 —— 而 `NEUTRAL` 恰好**不在** `STEP4_BUY_BLOCK_REGIMES` 屏蔽名单里，`CRASH` 在。

**关键对照：CRASH 是否只是「跌多了」的同义词。** 取「近 3 日累计跌幅最大」的同样 12 天做对照组，其 T+5 为 −0.26%，CRASH 为 +0.68%，**增量 +0.94pct 且重叠仅 5/12** —— 说明 CRASH 含独立于跌幅的信息，不是单纯的短期均值回复。

## 实现

`core/regime_forward_eval.py` 把检验固化：按 regime 分组算前瞻收益、对比全交易日基准、随机抽同样天数 2000 次得单尾 p 与 95% 区间、外加纯跌幅对照组。样本不足（< 8 天）明确返回「样本不足」而不给结论。

**p 值按观测方向取单尾。** 首版固定用 `>=`，导致 NEUTRAL 的 −1.08 超额拿到 p=0.990、看起来像「极不显著」，实际单尾应为 0.010 —— 这个缺陷正是靠 NEUTRAL 这条数据暴露的，已加回归测试。

`scripts/evaluate_regime_forward.py` 出报告并推飞书卡片，卡片带「接下来做什么」，**措辞与证据强度绑定**：

- p≤0.05 且正向 → 写「**不要**执行以此为由的清仓建议」
- 与纯跌幅对照接近 → 改写「可能只是均值回复，暂不视为独立信号」
- 样本不足 → 只写「继续积累、不动开关」
- 固定写入「**暂不改 `STEP4_BUY_BLOCK_REGIMES`**」：选股信号本身仍是 −4.04% 超额，当前「几乎不买」是保护而非缺陷

## 为什么不直接改开关

三个月、12 个 CRASH 日、且全部落在 6–7 月的 V 型行情里（7 月上证 −7.48%、8 月 +2.70%）。p=0.015 是在这一段里算的，**换一段可能完全不同**。要动直接决定下不下单的开关，这个样本远不够。

而且现在的配置阴差阳错在保护你：屏蔽七种 regime ≈ 几乎不买，而选股是负超额 —— 「不买」当前是正确的。按「CRASH 其实是好时机」放开它，只会让你开始买那些每笔输 4 个百分点的票。

所以本 PR 只做**观测**：每周六 09:40（北京时间）跑一次，看结论能否跨周期稳定。只读 `market_signal_daily` 与指数行情，不设 `WYCKOFF_WRITE_CONTEXT`，**不写库**。

## Validation / 验证

- `pytest tests/` — **3041 passed, 22 skipped**（新增 11 个用例：尾部不足 horizon 的日子被剔除、样本不足不给 p、正/负向 regime 各自可识别、p 值方向性、空序列不抛错、排序、纯跌幅对照）
- `ruff check .` / `ruff format --check .`
- `python scripts/quality_gate.py --check-functions`
- `python scripts/check_workflow_hygiene.py`
- 脚本已在真实生产数据上跑通，产物提交于 `docs/evidence/regime_forward_h5.json`
- 飞书推送路径已验证：本地 webhook 报 `Bot Not Enabled` 属本地配置失效，CI 的 `FEISHU_WEBHOOK_URL` 同日在漏斗任务中连续三次 `sent` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)