### PR TITLE
feat(workflows): 净值快照独立成日任务，不再依赖 Step4 成败

### DIFF
--- a/.github/workflows/nav_snapshot.yml
+++ b/.github/workflows/nav_snapshot.yml
@@ -1,0 +1,66 @@
+name: Daily NAV Snapshot
+
+# 净值是账户事实，不该因为漏斗或 Step4 失败而缺失。
+# 实测 daily_nav 曾缺 2026-08-07 / 08-10 / 08-17 三个交易日（覆盖率 77%）：
+# 08-10 被 FUNNEL_DATA_FRESHNESS_HARD_FAIL 拦下（那是故意的护栏），08-07 与 08-17 压根没触发。
+# 根因是净值快照挂在 Step4 的工单写入之后，信号链路一挂账户估值就跟着消失。
+# 本作业独立运行，与漏斗成败无关。
+on:
+  schedule:
+    # UTC 08:05 周一至周五 = 北京时间 16:05，A 股收盘后、早于其它盘后任务。
+    - cron: "5 8 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "交易日 YYYY-MM-DD，留空取当天"
+        default: ""
+      apply:
+        description: "true 才写库"
+        default: "true"
+
+concurrency:
+  group: nav-snapshot-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: "1"
+      WYCKOFF_WRITE_CONTEXT: "server_job"
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_USER_ID: ${{ secrets.SUPABASE_USER_ID }}
+      TICKFLOW_API_KEY: ${{ secrets.TICKFLOW_API_KEY }}
+      TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
+      TZ: Asia/Shanghai
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Record NAV snapshot
+        run: |
+          python scripts/nav_snapshot_job.py \
+            ${{ github.event.inputs.date && format('--date {0}', github.event.inputs.date) || '' }} \
+            ${{ github.event.inputs.apply == 'false' && '' || '--apply' }}
+
+      - name: Report NAV gaps (last 30 days)
+        if: always()
+        run: |
+          START=$(date -d '30 days ago' +%Y-%m-%d)
+          END=$(date +%Y-%m-%d)
+          python scripts/nav_snapshot_job.py --check "$START" "$END"

--- a/core/signal_lifecycle.py
+++ b/core/signal_lifecycle.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import pandas as pd
 
 from core._price_math import to_numeric as _to_numeric
+from core.trade_friction import net_return_pct
 
 
 @dataclass(frozen=True)
@@ -16,6 +17,9 @@ class HorizonOutcome:
     status: str
     return_pct: float | None
     max_drawdown_pct: float | None
+    # 扣除双边交易成本后的收益。return_pct 保持毛收益不动，便于与历史数据对比；
+    # 所有「这个信号值不值得做」的判断都应该看 net_return_pct。
+    net_return_pct: float | None = None
 
 
 @dataclass(frozen=True)
@@ -82,7 +86,13 @@ def _horizon_outcome(
     min_path_price = min(base_price, float(path.min()) if not path.empty else float(future_close))
     ret = (float(future_close) - base_price) / base_price * 100.0
     mdd = (min_path_price - base_price) / base_price * 100.0
-    return HorizonOutcome(horizon=horizon, status="done", return_pct=float(ret), max_drawdown_pct=float(mdd))
+    return HorizonOutcome(
+        horizon=horizon,
+        status="done",
+        return_pct=float(ret),
+        max_drawdown_pct=float(mdd),
+        net_return_pct=net_return_pct(float(ret)),
+    )
 
 
 def _horizon_outcomes(

--- a/core/trade_friction.py
+++ b/core/trade_friction.py
@@ -1,0 +1,93 @@
+"""信号级交易成本：把毛收益折成扣费后的净收益。
+
+为什么需要这个：``signal_outcomes.return_pct`` 一直是纯毛收益
+（``(exit_close - entry) / entry``，见 core/signal_lifecycle.py），不含佣金、印花税、
+过户费与滑点。于是所有基于它的结论都偏乐观——2026-08 复盘时 T+5 超额 −4.04%、
+T+20 −16.23% 都是**未扣成本**的数字，真实更差。
+
+``core.cash_portfolio`` 里已有一套完整且正确的 A 股费率（佣金含最低收费、卖出单边
+印花税、双边过户费），但它只服务组合回测，信号层没有接上。本模块复用同一套费率，
+避免两处各写一份而漂移。
+
+滑点单独给默认值：A 股主板双边合计约 0.1%~0.3%，小盘与低价股显著更高。这里取
+0.05% 单边作保守默认。**这不是实测值**，真实滑点取决于委托方式与流动性；把它显式化
+的意义在于让成本可见、可调，而不是假装为零。
+
+按 core 层的架构约束（tests/test_architecture_boundaries.py），本模块不读环境变量：
+滑点由运行时通过 ``configure_slippage`` 注入，见 utils.runtime_friction。
+"""
+
+from __future__ import annotations
+
+from core.cash_portfolio import CashPortfolioConfig, calc_trade_cost
+
+DEFAULT_SLIPPAGE_BPS_PER_SIDE = 5.0
+# 每笔按此名义金额估算佣金最低收费的影响。A 股佣金常有 5 元门槛，
+# 金额越小、费率占比越高；用一个代表性单笔金额把它折成百分比。
+DEFAULT_NOTIONAL_YUAN = 20_000.0
+
+
+_slippage_bps_per_side = DEFAULT_SLIPPAGE_BPS_PER_SIDE
+
+
+def configure_slippage(bps_per_side: float | None) -> None:
+    """由运行时（utils.env / 脚本入口）注入滑点，core 不直接读环境变量。
+
+    传 None 或非法值时回落到默认值，保证 core 始终有可用配置。
+    """
+    global _slippage_bps_per_side
+    try:
+        _slippage_bps_per_side = max(0.0, float(bps_per_side))
+    except (TypeError, ValueError):
+        _slippage_bps_per_side = DEFAULT_SLIPPAGE_BPS_PER_SIDE
+
+
+def slippage_bps_per_side() -> float:
+    return _slippage_bps_per_side
+
+
+def round_trip_cost_pct(
+    notional: float = DEFAULT_NOTIONAL_YUAN,
+    config: CashPortfolioConfig | None = None,
+) -> float:
+    """一次完整买卖的成本占名义金额的百分比。
+
+    含买入佣金+过户费、卖出佣金+过户费+印花税，以及双边滑点。
+    """
+    cfg = config or CashPortfolioConfig()
+    gross = max(float(notional), 1.0)
+    fees = calc_trade_cost(gross, cfg, side="buy") + calc_trade_cost(gross, cfg, side="sell")
+    slippage = gross * (slippage_bps_per_side() / 10_000.0) * 2.0
+    return (fees + slippage) / gross * 100.0
+
+
+def net_return_pct(
+    gross_return_pct: float | None,
+    *,
+    notional: float = DEFAULT_NOTIONAL_YUAN,
+    config: CashPortfolioConfig | None = None,
+) -> float | None:
+    """毛收益 -> 扣除双边成本后的净收益（百分数）。"""
+    if gross_return_pct is None:
+        return None
+    return round(float(gross_return_pct) - round_trip_cost_pct(notional, config), 6)
+
+
+def friction_breakdown(
+    notional: float = DEFAULT_NOTIONAL_YUAN,
+    config: CashPortfolioConfig | None = None,
+) -> dict[str, float]:
+    """成本构成，用于报告与文档，避免「总成本」变成不可追溯的魔法数字。"""
+    cfg = config or CashPortfolioConfig()
+    gross = max(float(notional), 1.0)
+    buy_fee = calc_trade_cost(gross, cfg, side="buy")
+    sell_fee = calc_trade_cost(gross, cfg, side="sell")
+    slippage = gross * (slippage_bps_per_side() / 10_000.0) * 2.0
+    return {
+        "notional_yuan": gross,
+        "buy_fee_pct": round(buy_fee / gross * 100.0, 6),
+        "sell_fee_pct": round(sell_fee / gross * 100.0, 6),
+        "slippage_pct": round(slippage / gross * 100.0, 6),
+        "round_trip_pct": round((buy_fee + sell_fee + slippage) / gross * 100.0, 6),
+        "slippage_bps_per_side": slippage_bps_per_side(),
+    }

--- a/integrations/supabase_portfolio.py
+++ b/integrations/supabase_portfolio.py
@@ -365,7 +365,7 @@ def refresh_portfolio_total_equity(
             return EquityRefreshResult(False, None, f"未找到组合 {portfolio_id}")
         positions = list(state.get("positions") or [])
         if positions:
-            api_key = _portfolio_tickflow_key(portfolio_id, client)
+            api_key = portfolio_tickflow_key(portfolio_id, client)
             if not api_key:
                 return EquityRefreshResult(False, None, "未配置 TickFlow API Key")
             prices, rates = load_portfolio_marks(positions, api_key)
@@ -380,7 +380,7 @@ def refresh_portfolio_total_equity(
         return EquityRefreshResult(False, None, str(exc))
 
 
-def _portfolio_tickflow_key(portfolio_id: str, client: Client) -> str:
+def portfolio_tickflow_key(portfolio_id: str, client: Client) -> str:
     fallback = os.getenv("TICKFLOW_API_KEY", "").strip()
     prefix, separator, user_id = str(portfolio_id or "").partition(":")
     if prefix != "USER_LIVE" or not separator or not user_id:

--- a/scripts/evaluate_capital_context_alpha.py
+++ b/scripts/evaluate_capital_context_alpha.py
@@ -35,6 +35,8 @@ from typing import Any
 import _bootstrap  # noqa: F401
 import pandas as pd
 
+from core.trade_friction import net_return_pct, round_trip_cost_pct
+
 MIN_GROUP = 30
 BOOTSTRAP_ROUNDS = 2000
 CONTROL_SEEDS = 20
@@ -218,6 +220,10 @@ def build_report(
         "window": {"start": str(matured.trade_date.min()), "end": str(matured.trade_date.max())},
         "matured_outcomes": len(matured),
         "baseline_ret": None if _day_weighted(matured) is None else round(_day_weighted(matured), 4),
+        # 净收益：signal_outcomes.return_pct 是毛收益，不含佣金/印花税/过户费/滑点。
+        # 判断「值不值得做」必须看这一行。
+        "baseline_net_ret": net_return_pct(_day_weighted(matured)),
+        "round_trip_cost_pct": round(round_trip_cost_pct(), 4),
         "baseline_win_rate_pct": round(100.0 * float((matured.return_pct > 0).mean()), 2),
         "health": {
             "matched_outcomes": len(merged),

--- a/scripts/nav_snapshot_job.py
+++ b/scripts/nav_snapshot_job.py
@@ -1,0 +1,89 @@
+"""每日净值快照作业，兼历史空洞回补。
+
+净值是账户事实，不该因为漏斗或 Step4 失败而缺失。本作业独立于信号链路运行。
+
+用法::
+
+    python scripts/nav_snapshot_job.py                          # 记录今天
+    python scripts/nav_snapshot_job.py --check 2026-07-30 2026-08-17   # 只报空洞
+    python scripts/nav_snapshot_job.py --date 2026-08-17        # 指定日期（dry-run）
+    python scripts/nav_snapshot_job.py --date 2026-08-17 --apply
+
+写入需要 ``WYCKOFF_WRITE_CONTEXT=server_job``；默认 dry-run，只打印不落库。
+
+**不回补历史行情**：``build_nav_snapshot`` 用的是**最新**报价，所以指定过去日期只在
+当天盘后补记当日净值时才正确。真正的历史空洞（如 08-07/08-10）无法用现价重算——
+那需要按当日收盘价重估，而 TickFlow 的历史快照不保证可得。故 --check 只报告缺口，
+不假装能把它们填上：宁可留下可见的空洞，也不要写入一个用错价格算出的净值。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime
+
+import _bootstrap  # noqa: F401
+
+from utils.trading_clock import CN_TZ
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="每日净值快照")
+    parser.add_argument("--portfolio-id", default="", help="组合 ID，默认取 MY_PORTFOLIO_ID 或 USER_LIVE")
+    parser.add_argument("--date", default="", help="交易日 YYYY-MM-DD，默认今天（北京时间）")
+    parser.add_argument("--apply", action="store_true", help="真正写库；缺省仅打印")
+    parser.add_argument("--check", nargs=2, metavar=("START", "END"), help="报告区间内缺失净值的交易日")
+    return parser.parse_args()
+
+
+def _default_portfolio_id() -> str:
+    for key in ("MY_PORTFOLIO_ID", "PORTFOLIO_ID"):
+        value = os.getenv(key, "").strip()
+        if value:
+            return value
+    return "USER_LIVE"
+
+
+def main() -> int:
+    args = parse_args()
+    from utils.runtime_friction import apply_friction_config_from_env
+
+    apply_friction_config_from_env()
+    portfolio_id = args.portfolio_id.strip() or _default_portfolio_id()
+
+    if args.check:
+        from workflows.nav_snapshot import missing_nav_dates
+
+        start, end = args.check
+        missing = missing_nav_dates(portfolio_id, start, end)
+        total = len(missing)
+        print(f"[nav] {portfolio_id} {start}~{end} 缺失 {total} 个交易日")
+        for day in missing:
+            print(f"  - {day}")
+        if total:
+            print("\n注：历史空洞需按当日收盘价重估，现价重算会写入错误净值，故此处只报告不回补。")
+        return 0
+
+    trade_date = args.date.strip() or datetime.now(CN_TZ).date().isoformat()
+    from workflows.nav_snapshot import build_nav_snapshot, persist_nav_snapshot
+
+    snapshot = build_nav_snapshot(portfolio_id, trade_date)
+    if not snapshot.ok:
+        print(f"[nav] 快照失败 {portfolio_id} {trade_date}: {snapshot.message}")
+        return 1
+    print(f"[nav] {portfolio_id} {trade_date}  {snapshot.message}")
+    print(
+        f"      total_equity={snapshot.total_equity:,.2f}  "
+        f"free_cash={snapshot.free_cash:,.2f}  positions_value={snapshot.positions_value:,.2f}"
+    )
+    if not args.apply:
+        print("[nav] dry-run，未写库；加 --apply 落库")
+        return 0
+    result = persist_nav_snapshot(snapshot)
+    print("[nav] 已写入 daily_nav" if result.written else "[nav] 写入失败")
+    return 0 if result.written else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_trade_friction.py
+++ b/tests/core/test_trade_friction.py
@@ -1,0 +1,115 @@
+"""Tests for signal-level trade friction (net vs gross returns)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.cash_portfolio import CashPortfolioConfig
+from core.trade_friction import (
+    DEFAULT_SLIPPAGE_BPS_PER_SIDE,
+    configure_slippage,
+    friction_breakdown,
+    net_return_pct,
+    round_trip_cost_pct,
+    slippage_bps_per_side,
+)
+
+
+class TestRoundTripCost:
+    def test_positive_and_bounded(self):
+        cost = round_trip_cost_pct()
+        # A 股双边合计应在 0.1%~1% 这个量级；超出说明费率或滑点配错了。
+        assert 0.1 < cost < 1.0
+
+    def test_includes_stamp_duty_on_sell_only(self):
+        """印花税只在卖出侧征收，所以卖出费率应高于买入。"""
+        parts = friction_breakdown()
+        assert parts["sell_fee_pct"] > parts["buy_fee_pct"]
+
+    def test_breakdown_sums_to_total(self):
+        parts = friction_breakdown()
+        total = parts["buy_fee_pct"] + parts["sell_fee_pct"] + parts["slippage_pct"]
+        assert parts["round_trip_pct"] == pytest.approx(total, abs=1e-6)
+
+    def test_small_notional_costs_more(self):
+        """佣金有 5 元最低收费，小额交易的百分比成本更高。"""
+        assert round_trip_cost_pct(2_000.0) > round_trip_cost_pct(200_000.0)
+
+    def test_respects_custom_rates(self):
+        zero = CashPortfolioConfig(commission_rate=0.0, min_commission=0.0, stamp_duty_rate=0.0, transfer_fee_rate=0.0)
+        # 费率归零后仍应剩下滑点，不能变成 0。
+        assert round_trip_cost_pct(20_000.0, zero) == pytest.approx(
+            DEFAULT_SLIPPAGE_BPS_PER_SIDE / 10_000.0 * 2.0 * 100.0, abs=1e-6
+        )
+
+
+class TestNetReturn:
+    def test_subtracts_cost(self):
+        gross = 5.0
+        assert net_return_pct(gross) == pytest.approx(gross - round_trip_cost_pct(), abs=1e-6)
+
+    def test_none_passes_through(self):
+        assert net_return_pct(None) is None
+
+    def test_marginal_positive_turns_negative(self):
+        """回归：accumulation_ready 的 +0.10% 毛收益扣费后应转负。
+
+        这是接成本模型的核心动机——微弱正收益撑不过摩擦。
+        """
+        assert net_return_pct(0.10) < 0
+
+    def test_loss_gets_worse(self):
+        assert net_return_pct(-4.47) < -4.47
+
+
+class TestSlippageConfig:
+    """core 不读 env（架构约束），滑点由 utils.runtime_friction 注入。"""
+
+    @pytest.fixture(autouse=True)
+    def _restore(self):
+        yield
+        configure_slippage(DEFAULT_SLIPPAGE_BPS_PER_SIDE)
+
+    def test_configure(self):
+        configure_slippage(25.0)
+        assert slippage_bps_per_side() == 25.0
+
+    def test_invalid_falls_back(self):
+        configure_slippage("abc")
+        assert slippage_bps_per_side() == DEFAULT_SLIPPAGE_BPS_PER_SIDE
+
+    def test_none_falls_back(self):
+        configure_slippage(None)
+        assert slippage_bps_per_side() == DEFAULT_SLIPPAGE_BPS_PER_SIDE
+
+    def test_negative_clamped(self):
+        configure_slippage(-5)
+        assert slippage_bps_per_side() == 0.0
+
+    def test_env_injection_via_utils(self, monkeypatch):
+        from utils.runtime_friction import apply_friction_config_from_env
+
+        monkeypatch.setenv("WYCKOFF_SLIPPAGE_BPS_PER_SIDE", "30")
+        assert apply_friction_config_from_env() == 30.0
+        assert slippage_bps_per_side() == 30.0
+
+
+class TestLifecycleIntegration:
+    def test_outcome_carries_net_return(self):
+        import pandas as pd
+
+        from core.signal_lifecycle import evaluate_signal_lifecycle
+
+        dates = pd.date_range("2026-06-01", periods=12, freq="D")
+        frame = pd.DataFrame(
+            {
+                "date": dates,
+                "close": [10.0] * 6 + [11.0] * 6,
+                "low": [9.5] * 12,
+            }
+        )
+        lifecycle = evaluate_signal_lifecycle(frame, code="000001", signal_date="2026-06-06", horizons=(5,))
+        outcome = lifecycle.outcomes[0]
+        assert outcome.status == "done"
+        assert outcome.net_return_pct is not None
+        assert outcome.net_return_pct < outcome.return_pct

--- a/tests/integrations/test_portfolio_equity_refresh.py
+++ b/tests/integrations/test_portfolio_equity_refresh.py
@@ -35,7 +35,7 @@ def test_refresh_portfolio_total_equity_persists_latest_multi_market_value(monke
     }
     client = _UpdateClient()
     monkeypatch.setattr(supabase_portfolio, "load_portfolio_state", lambda *_args, **_kwargs: state)
-    monkeypatch.setattr(supabase_portfolio, "_portfolio_tickflow_key", lambda *_args: "key")
+    monkeypatch.setattr(supabase_portfolio, "portfolio_tickflow_key", lambda *_args: "key")
     monkeypatch.setattr(
         portfolio_market_value,
         "load_portfolio_marks",
@@ -55,7 +55,7 @@ def test_refresh_does_not_overwrite_total_when_a_quote_is_missing(monkeypatch) -
     state = {"free_cash": 25_000, "positions": [{"code": "600519", "shares": 10}]}
     client = _UpdateClient()
     monkeypatch.setattr(supabase_portfolio, "load_portfolio_state", lambda *_args, **_kwargs: state)
-    monkeypatch.setattr(supabase_portfolio, "_portfolio_tickflow_key", lambda *_args: "key")
+    monkeypatch.setattr(supabase_portfolio, "portfolio_tickflow_key", lambda *_args: "key")
     monkeypatch.setattr(portfolio_market_value, "load_portfolio_marks", lambda *_args: ({}, {"CNY": 1}))
 
     result = supabase_portfolio.refresh_portfolio_total_equity("USER_LIVE:u1", client=client)  # type: ignore[arg-type]

--- a/tests/workflows/test_nav_snapshot.py
+++ b/tests/workflows/test_nav_snapshot.py
@@ -1,0 +1,143 @@
+"""Tests for the standalone daily NAV snapshot."""
+
+from __future__ import annotations
+
+import pytest
+
+from workflows import nav_snapshot
+from workflows.nav_snapshot import NavSnapshotResult, build_nav_snapshot, persist_nav_snapshot
+
+
+@pytest.fixture
+def _state(monkeypatch):
+    """把外部依赖收敛成可控替身：Supabase 客户端、组合状态、行情、TickFlow key。"""
+
+    holder = {
+        "positions": [{"code": "600519", "shares": 100}],
+        "free_cash": 5_000.0,
+        "prices": {"600519": 1_500.0},
+        "rates": {"CNY": 1.0},
+        "api_key": "k",
+    }
+    monkeypatch.setattr("integrations.supabase_base.create_admin_client", lambda: object())
+    monkeypatch.setattr(
+        "integrations.supabase_portfolio.load_portfolio_state",
+        lambda pid, client=None: {"positions": holder["positions"], "free_cash": holder["free_cash"]},
+    )
+    monkeypatch.setattr("integrations.supabase_portfolio.portfolio_tickflow_key", lambda pid, client: holder["api_key"])
+    monkeypatch.setattr(
+        "integrations.portfolio_market_value.load_portfolio_marks",
+        lambda positions, api_key: (holder["prices"], holder["rates"]),
+    )
+    return holder
+
+
+class TestBuildSnapshot:
+    def test_values_positions_at_market(self, _state):
+        result = build_nav_snapshot("USER_LIVE", "2026-08-17")
+        assert result.ok is True
+        assert result.positions_value == 150_000.0
+        assert result.total_equity == 155_000.0
+        assert result.free_cash == 5_000.0
+
+    def test_empty_position_still_records(self, _state):
+        """空仓也要记：净值曲线不能因为清仓而断档。"""
+        _state["positions"] = []
+        result = build_nav_snapshot("USER_LIVE", "2026-08-17")
+        assert result.ok is True
+        assert result.positions_value == 0.0
+        assert result.total_equity == _state["free_cash"]
+
+    def test_refuses_partial_valuation(self, _state):
+        """行情缺失时不写部分估值——偏低的净值比没有净值更有害。"""
+        _state["prices"] = {}
+        result = build_nav_snapshot("USER_LIVE", "2026-08-17")
+        assert result.ok is False
+        assert "估值不完整" in result.message
+
+    def test_requires_trade_date(self, _state):
+        assert build_nav_snapshot("USER_LIVE", "").ok is False
+
+    def test_missing_portfolio(self, monkeypatch, _state):
+        monkeypatch.setattr("integrations.supabase_portfolio.load_portfolio_state", lambda pid, client=None: None)
+        result = build_nav_snapshot("NOPE", "2026-08-17")
+        assert result.ok is False
+        assert "未找到组合" in result.message
+
+    def test_missing_api_key(self, _state):
+        _state["api_key"] = ""
+        result = build_nav_snapshot("USER_LIVE", "2026-08-17")
+        assert result.ok is False
+        assert "TickFlow" in result.message
+
+    def test_ignores_zero_share_rows(self, _state):
+        _state["positions"] = [{"code": "600519", "shares": 0}]
+        result = build_nav_snapshot("USER_LIVE", "2026-08-17")
+        # 全是 0 股等价于空仓，不应因缺该标的报价而失败。
+        assert result.ok is True
+        assert result.positions_value == 0.0
+
+
+class TestPersist:
+    def test_writes_and_reports(self, monkeypatch):
+        captured = {}
+
+        def fake_upsert(**kwargs):
+            captured.update(kwargs)
+            return True
+
+        monkeypatch.setattr("integrations.supabase_portfolio.upsert_daily_nav", fake_upsert)
+        snapshot = NavSnapshotResult(True, "USER_LIVE", "2026-08-17", 155_000.0, 5_000.0, 150_000.0, "ok")
+        result = persist_nav_snapshot(snapshot)
+        assert result.written is True
+        assert captured["total_equity"] == 155_000.0
+        assert captured["trade_date"] == "2026-08-17"
+
+    def test_skips_failed_snapshot(self, monkeypatch):
+        called = {"n": 0}
+
+        def fake_upsert(**kwargs):
+            called["n"] += 1
+            return True
+
+        monkeypatch.setattr("integrations.supabase_portfolio.upsert_daily_nav", fake_upsert)
+        snapshot = NavSnapshotResult(False, "USER_LIVE", "2026-08-17", message="估值不完整")
+        assert persist_nav_snapshot(snapshot).written is False
+        assert called["n"] == 0
+
+    def test_write_failure_is_not_fatal(self, monkeypatch):
+        monkeypatch.setattr("integrations.supabase_portfolio.upsert_daily_nav", lambda **kwargs: False)
+        snapshot = NavSnapshotResult(True, "USER_LIVE", "2026-08-17", 1.0, 1.0, 0.0, "ok")
+        result = persist_nav_snapshot(snapshot)
+        assert result.written is False
+        assert result.ok is True
+
+
+class TestMissingDates:
+    def test_reports_gaps_only(self, monkeypatch):
+        class _Table:
+            def select(self, *_a):
+                return self
+
+            def eq(self, *_a):
+                return self
+
+            def gte(self, *_a):
+                return self
+
+            def lte(self, *_a):
+                return self
+
+            def execute(self):
+                return type("R", (), {"data": [{"trade_date": "2026-08-06"}]})()
+
+        monkeypatch.setattr(
+            "integrations.supabase_base.create_admin_client",
+            lambda: type("C", (), {"table": lambda self, name: _Table()})(),
+        )
+        monkeypatch.setattr(
+            "integrations.fetch_a_share_csv.cached_trade_dates",
+            lambda: ["2026-08-06", "2026-08-07", "2026-08-10"],
+        )
+        gaps = nav_snapshot.missing_nav_dates("USER_LIVE", "2026-08-06", "2026-08-10")
+        assert gaps == ["2026-08-07", "2026-08-10"]

--- a/utils/runtime_friction.py
+++ b/utils/runtime_friction.py
@@ -1,0 +1,27 @@
+"""把滑点配置从环境变量注入 core.trade_friction。
+
+core 层不允许直接读环境变量（tests/test_architecture_boundaries.py 会拦），
+所以环境读取放在 utils 侧，由脚本／作业入口调用一次。
+"""
+
+from __future__ import annotations
+
+import os
+
+from core.trade_friction import DEFAULT_SLIPPAGE_BPS_PER_SIDE, configure_slippage
+
+ENV_KEY = "WYCKOFF_SLIPPAGE_BPS_PER_SIDE"
+
+
+def apply_friction_config_from_env() -> float:
+    """读取 env 并注入 core，返回生效的单边滑点（bps）。"""
+    raw = os.getenv(ENV_KEY, "").strip()
+    if not raw:
+        configure_slippage(DEFAULT_SLIPPAGE_BPS_PER_SIDE)
+        return DEFAULT_SLIPPAGE_BPS_PER_SIDE
+    try:
+        value = max(0.0, float(raw))
+    except ValueError:
+        value = DEFAULT_SLIPPAGE_BPS_PER_SIDE
+    configure_slippage(value)
+    return value

--- a/workflows/nav_snapshot.py
+++ b/workflows/nav_snapshot.py
@@ -1,0 +1,125 @@
+"""独立的每日净值快照：不依赖漏斗或 Step4 是否跑成功。
+
+为什么要解耦：``daily_nav`` 只有 10 行，缺 2026-08-07、08-10、08-17 三个交易日
+（覆盖率 77%）。根因不是写入逻辑坏了，而是 ``_save_step4_nav_snapshot`` 挂在
+Step4 的工单写入之后（workflows/step4_results.py:54-59）——只要漏斗没跑或 Step4
+中断，当天净值就永久缺失。实测 08-10 是 ``FUNNEL_DATA_FRESHNESS_HARD_FAIL`` 拦下
+（那是**故意的护栏**，数据不新鲜宁可整条失败），08-07 与 08-17 压根没触发。
+
+但净值是**账户事实**，与「今天有没有生成工单」无关。信号链路可以失败，账户估值不该
+跟着消失——否则你永远无法自证盈亏，而信号级统计既不含仓位也不含现金拖累与交易成本。
+
+沿用 Step4 里那条已想清楚的原则：净值记账户**当前真实状态**，不记 OMS「假设你照单
+执行后」的模拟现金。工单未被执行时两者会持续背离。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NavSnapshotResult:
+    ok: bool
+    portfolio_id: str
+    trade_date: str
+    total_equity: float | None = None
+    free_cash: float | None = None
+    positions_value: float | None = None
+    message: str = ""
+    written: bool = False
+
+
+def build_nav_snapshot(portfolio_id: str, trade_date: str) -> NavSnapshotResult:
+    """按最新行情重估持仓，返回当日净值快照（不写库）。"""
+    from core.portfolio_valuation import PortfolioValuationError, calculate_portfolio_valuation
+    from integrations.portfolio_market_value import load_portfolio_marks
+    from integrations.supabase_base import create_admin_client
+    from integrations.supabase_portfolio import load_portfolio_state, portfolio_tickflow_key
+
+    if not trade_date:
+        return NavSnapshotResult(False, portfolio_id, trade_date, message="缺少 trade_date")
+    try:
+        client = create_admin_client()
+        state = load_portfolio_state(portfolio_id, client=client)
+    except Exception as exc:
+        return NavSnapshotResult(False, portfolio_id, trade_date, message=f"读取组合失败: {exc}")
+    if state is None:
+        return NavSnapshotResult(False, portfolio_id, trade_date, message=f"未找到组合 {portfolio_id}")
+
+    positions = [row for row in (state.get("positions") or []) if int(row.get("shares", 0) or 0) > 0]
+    free_cash = float(state.get("free_cash", 0.0) or 0.0)
+    if not positions:
+        # 空仓也要记：净值曲线不能因为清仓而断档。
+        return NavSnapshotResult(True, portfolio_id, trade_date, free_cash, free_cash, 0.0, "空仓，净值等于现金")
+    api_key = portfolio_tickflow_key(portfolio_id, client)
+    if not api_key:
+        return NavSnapshotResult(False, portfolio_id, trade_date, message="未配置 TickFlow API Key")
+    try:
+        prices, rates = load_portfolio_marks(positions, api_key)
+        valuation = calculate_portfolio_valuation(free_cash, positions, prices, rates)
+    except PortfolioValuationError as exc:
+        # 行情缺失时**不写**部分估值：一个偏低的净值比没有净值更有害。
+        return NavSnapshotResult(False, portfolio_id, trade_date, message=f"估值不完整: {exc}")
+    except Exception as exc:
+        return NavSnapshotResult(False, portfolio_id, trade_date, message=f"估值失败: {exc}")
+    return NavSnapshotResult(
+        True,
+        portfolio_id,
+        trade_date,
+        valuation.total_equity,
+        free_cash,
+        valuation.positions_value,
+        f"总权益 {valuation.total_equity:,.2f}（现金 {free_cash:,.2f}）",
+    )
+
+
+def persist_nav_snapshot(snapshot: NavSnapshotResult) -> NavSnapshotResult:
+    """把快照写入 daily_nav；写入失败不抛异常，由调用方决定是否致命。"""
+    from integrations.supabase_portfolio import upsert_daily_nav
+
+    if not snapshot.ok or snapshot.total_equity is None:
+        return snapshot
+    written = upsert_daily_nav(
+        portfolio_id=snapshot.portfolio_id,
+        trade_date=snapshot.trade_date,
+        free_cash=float(snapshot.free_cash or 0.0),
+        total_equity=float(snapshot.total_equity),
+        positions_value=float(snapshot.positions_value or 0.0),
+    )
+    if not written:
+        logger.warning("[nav] 写入失败 portfolio=%s date=%s", snapshot.portfolio_id, snapshot.trade_date)
+    return NavSnapshotResult(
+        snapshot.ok,
+        snapshot.portfolio_id,
+        snapshot.trade_date,
+        snapshot.total_equity,
+        snapshot.free_cash,
+        snapshot.positions_value,
+        snapshot.message,
+        written=written,
+    )
+
+
+def missing_nav_dates(portfolio_id: str, start: str, end: str) -> list[str]:
+    """区间内缺失净值的交易日。用于发现空洞，不做回补。"""
+    from integrations.fetch_a_share_csv import cached_trade_dates
+    from integrations.supabase_base import create_admin_client
+
+    client = create_admin_client()
+    rows = (
+        client.table("daily_nav")
+        .select("trade_date")
+        .eq("portfolio_id", portfolio_id)
+        .gte("trade_date", start)
+        .lte("trade_date", end)
+        .execute()
+        .data
+        or []
+    )
+    have = {str(row.get("trade_date")) for row in rows}
+    sessions = [str(day) for day in cached_trade_dates() if start <= str(day) <= end]
+    return [day for day in sessions if day not in have]

--- a/workflows/signal_feedback_job.py
+++ b/workflows/signal_feedback_job.py
@@ -226,5 +226,7 @@ def _outcome_row(obs: dict[str, Any], outcome) -> dict[str, Any]:
         "horizon_days": outcome.horizon,
         "status": outcome.status,
         "return_pct": outcome.return_pct,
+        # 不写 net_return_pct：线上 signal_outcomes 无该列，写未知键会让整批 upsert 失败。
+        # 净收益在读取侧由 core.trade_friction.net_return_pct 换算，口径一致且无需迁移。
         "max_drawdown_pct": outcome.max_drawdown_pct,
     }


### PR DESCRIPTION
## Summary / 变更摘要

> 基于 #277（信号级成本模型），待其合并后本 PR 的 diff 会自动收敛为仅 NAV 相关改动。

`daily_nav` 只有 10 行，缺 **2026-08-07 / 08-10 / 08-17** 三个交易日，覆盖率 **77%**。

根因不是写入逻辑坏了 —— `_save_step4_nav_snapshot` 挂在 Step4 的工单写入之后（`step4_results.py:54-59`），**只要漏斗没跑或 Step4 中断，当天净值就永久缺失**：

| 日期 | 漏斗 | NAV |
| --- | --- | --- |
| 08-07 | 没触发 | 缺 |
| 08-10 | **failure** | 缺 |
| 08-17 | 没触发 | 缺 |

08-10 是被 `FUNNEL_DATA_FRESHNESS_HARD_FAIL` 拦下的 —— 那是**故意的护栏**（数据不新鲜宁可整条失败，该设计正确），不该顺带把净值也弄丢。

但净值是**账户事实**，与「今天有没有生成工单」无关。现状是 **27,240 条 `signal_outcomes` 对 10 天净值**，而信号级统计既不含仓位、也不含现金拖累与交易成本 —— 只有净值能回答「这套系统对我的钱做了什么」。

## 实现

新增 `workflows/nav_snapshot.py` + `scripts/nav_snapshot_job.py`，独立每日运行。复用既有的 `calculate_portfolio_valuation` 与 `load_portfolio_marks`，不重写估值逻辑。沿用 Step4 里那条已想清楚的原则：记账户**当前真实状态**，不记 OMS「假设照单执行后」的模拟现金。

三个刻意的行为选择：

- **空仓也写** —— 净值曲线不能因为清仓而断档
- **行情缺失时不写部分估值** —— 一个偏低的净值比没有净值更有害
- **`--check` 只报告历史空洞、不回补** —— `build_nav_snapshot` 用的是**最新**报价，拿它重算过去某天会写入用错价格的净值。宁可留下可见的空洞

顺带把 `_portfolio_tickflow_key` 提为 public —— 新模块需要它，不该 reach into 私有名；同步更新两处 monkeypatch。

GitHub Action 每周一至周五北京时间 **16:05** 运行（收盘后、早于其它盘后任务），并附带报告近 30 天的净值空洞。

## Validation / 验证

实测 `--check` 精确报出三个缺口，与手工核对一致：

```
[nav] USER_LIVE:... 2026-07-30~2026-08-17 缺失 3 个交易日
  - 2026-08-07
  - 2026-08-10
  - 2026-08-17
```

dry-run 算出 08-17 净值 **102,838.45**（现金 6,724.21 + 持仓 96,114.24）。

- `pytest tests/` — **3068 passed, 22 skipped**（新增 11 个用例：按市价估值、空仓仍记录、行情缺失拒绝部分估值、缺 trade_date/组合/API Key 各自报错、0 股行等价空仓、写入失败不致命、失败快照不触发写入、空洞只报缺失日）
- `ruff check .` / `ruff format --check .`
- `python scripts/quality_gate.py --check-functions`
- `python scripts/check_workflow_hygiene.py`
- `python scripts/daily_job.py --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)