### PR TITLE
feat: 卖出建议归因脚本化，每周跑并推飞书

### DIFF
--- a/.github/workflows/exit_attribution.yml
+++ b/.github/workflows/exit_attribution.yml
@@ -1,0 +1,63 @@
+name: Exit Attribution
+
+# 卖出建议归因：系统建议卖出之后，那些票涨了还是跌了。
+# 2026-08-17 首轮（20 次建议 / 10 只票）：卖出后 +16.22%、超额 +13.26pct、**卖对 1/20**。
+# 两个机制假设被数据否掉——「陈旧止损是主因」（倒挂 0~5% 也错 20.83%）与
+# 「重复触发是主因」（首次已错 14.74%）。20 次里 4 次挤在 07-30 同一天而那天是阶段底部，
+# 故更像同一次市场时机误判的多次表现，而非机制缺陷。
+# 样本撑不起改风控代码，所以每周重跑，等跨越不同市场环境后再重判。
+on:
+  schedule:
+    # UTC 周六 02:10 = 北京时间周六 10:10，紧随 regime 前瞻检验之后。
+    - cron: "10 2 * * 6"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "回看天数"
+        default: "60"
+
+concurrency:
+  group: exit-attribution-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: "1"
+      # 只读 trade_orders 与行情，不写库；故不设 WYCKOFF_WRITE_CONTEXT。
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
+      TICKFLOW_API_KEY: ${{ secrets.TICKFLOW_API_KEY }}
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      TZ: Asia/Shanghai
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Evaluate exit attribution
+        run: |
+          python scripts/evaluate_exit_attribution.py --days "${{ github.event.inputs.days || '60' }}"
+
+      - name: Upload evidence
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: exit-attribution-evidence
+          path: docs/evidence/exit_attribution.json
+          if-no-files-found: warn

--- a/core/exit_attribution.py
+++ b/core/exit_attribution.py
@@ -1,0 +1,161 @@
+"""卖出建议归因：卖出后价格怎么走，以及分组对照。
+
+背景（2026-08-17 首轮跑数，10 只票 / 20 次建议）：
+
+- 全部 10 只票卖出后平均 +14.19%，同期上证 +2.01%，即**卖错约 13.7 个百分点**。
+- 分组检验否掉了两个机制假设：
+  - 「陈旧止损是主因」不成立：偏离 <5%（正常止损）卖后 +17.36%，偏离 >20%（陈旧）
+    +23.84%，两档都严重卖错，陈旧只加剧约 6pct。
+  - 「重复触发是主因」不成立：首次 +14.74%、重复 +17.71%，差仅 2.97pct，而首次本身
+    就已经错了 14.74pct。
+- 20 次建议里有 4 次集中在 2026-07-30 同一天，而那天是阶段底部（同期 CRASH 判定后
+  T+5 +2.51%）。故更像**同一个市场时机误判的多次表现**，而非多次独立的判断失误。
+
+因此本模块只做归因，不给改动建议：样本仅 10 只票、全部落在同一段 V 型行情，
+撑不起修改风控代码。判据由持续积累的样本决定，而不是一次跑数的结论。
+
+口径约定：``after_pct`` 为**卖出后**的价格变化，所以**负值表示卖对了**（避开了下跌），
+正值表示卖早了。``excess_pct`` 扣掉同期基准，剔除市场整体涨跌。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from statistics import mean
+from typing import Any
+
+STALE_DEVIATION_PCT = 20.0
+NEAR_TRIGGER_PCT = 5.0
+_STOP_PATTERN = re.compile(r"inherit_pos_stop\(([\d.]+)\)")
+
+
+@dataclass(frozen=True)
+class ExitRecord:
+    code: str
+    name: str
+    action: str
+    trade_date: str
+    price: float
+    sequence: int
+    origin: str = "模型判断"
+    stop_loss: float | None = None
+    after_pct: float | None = None
+    benchmark_pct: float | None = None
+
+    @property
+    def is_first(self) -> bool:
+        return self.sequence == 1
+
+    @property
+    def stop_deviation_pct(self) -> float | None:
+        """止损位相对建议价的偏离。正值=倒挂（止损高于现价），负值=正常。"""
+        if self.stop_loss is None or self.price <= 0:
+            return None
+        return (self.stop_loss / self.price - 1.0) * 100.0
+
+    @property
+    def stop_band(self) -> str:
+        deviation = self.stop_deviation_pct
+        if deviation is None:
+            return "无止损信息"
+        if deviation < 0:
+            return "止损低于现价"
+        if deviation < NEAR_TRIGGER_PCT:
+            return f"倒挂 0~{NEAR_TRIGGER_PCT:.0f}%"
+        if deviation < STALE_DEVIATION_PCT:
+            return f"倒挂 {NEAR_TRIGGER_PCT:.0f}~{STALE_DEVIATION_PCT:.0f}%"
+        return f"陈旧 >{STALE_DEVIATION_PCT:.0f}%"
+
+    @property
+    def excess_pct(self) -> float | None:
+        if self.after_pct is None or self.benchmark_pct is None:
+            return None
+        return self.after_pct - self.benchmark_pct
+
+
+@dataclass
+class GroupStat:
+    label: str
+    count: int
+    after_pct: float | None
+    excess_pct: float | None
+    sold_correctly: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "n": self.count,
+            "after_pct": None if self.after_pct is None else round(self.after_pct, 4),
+            "excess_pct": None if self.excess_pct is None else round(self.excess_pct, 4),
+            "sold_correctly": self.sold_correctly,
+        }
+
+
+@dataclass
+class ExitAttribution:
+    records: list[ExitRecord] = field(default_factory=list)
+    overall: GroupStat | None = None
+    by_origin: list[GroupStat] = field(default_factory=list)
+    by_sequence: list[GroupStat] = field(default_factory=list)
+    by_stop_band: list[GroupStat] = field(default_factory=list)
+
+
+def parse_stop_loss(reason: str) -> float | None:
+    match = _STOP_PATTERN.search(str(reason or ""))
+    return float(match.group(1)) if match else None
+
+
+def classify_origin(reason: str) -> str:
+    text = str(reason or "")
+    if "系统强制止损" in text or "system_stop_breach_override" in text:
+        return "系统强制止损"
+    if "已穿止损" in text or "inherit_pos_stop" in text:
+        return "止损驱动"
+    return "模型判断"
+
+
+def _stat(label: str, records: list[ExitRecord]) -> GroupStat:
+    after = [r.after_pct for r in records if r.after_pct is not None]
+    excess = [r.excess_pct for r in records if r.excess_pct is not None]
+    return GroupStat(
+        label=label,
+        count=len(records),
+        after_pct=mean(after) if after else None,
+        excess_pct=mean(excess) if excess else None,
+        # after_pct < 0 表示卖出后继续下跌，即这一笔卖对了。
+        sold_correctly=sum(1 for value in after if value < 0),
+    )
+
+
+def build_attribution(records: list[ExitRecord]) -> ExitAttribution:
+    report = ExitAttribution(records=list(records))
+    if not records:
+        return report
+    report.overall = _stat("全部", records)
+    report.by_origin = [
+        _stat(origin, [r for r in records if r.origin == origin]) for origin in sorted({r.origin for r in records})
+    ]
+    first = [r for r in records if r.is_first]
+    repeat = [r for r in records if not r.is_first]
+    report.by_sequence = [stat for stat in (_stat("首次触发", first), _stat("重复触发", repeat)) if stat.count]
+    report.by_stop_band = [
+        _stat(band, [r for r in records if r.stop_band == band]) for band in sorted({r.stop_band for r in records})
+    ]
+    return report
+
+
+def as_report_dict(report: ExitAttribution) -> dict[str, Any]:
+    """归因结果的可序列化形式，供落盘与飞书卡片使用。"""
+    return {
+        "records": len(report.records),
+        "codes": len({r.code for r in report.records}),
+        "overall": None if report.overall is None else report.overall.as_dict(),
+        "by_origin": [stat.as_dict() for stat in report.by_origin],
+        "by_sequence": [stat.as_dict() for stat in report.by_sequence],
+        "by_stop_band": [stat.as_dict() for stat in report.by_stop_band],
+        "reading": (
+            "after_pct 为卖出后价格变化：负值=卖对了（避开下跌），正值=卖早了。"
+            "excess_pct 已扣同期基准。样本不足时不要据此改风控。"
+        ),
+    }

--- a/docs/evidence/exit_attribution.json
+++ b/docs/evidence/exit_attribution.json
@@ -1,0 +1,81 @@
+{
+  "records": 20,
+  "codes": 10,
+  "overall": {
+    "label": "全部",
+    "n": 20,
+    "after_pct": 16.2222,
+    "excess_pct": 13.2563,
+    "sold_correctly": 1
+  },
+  "by_origin": [
+    {
+      "label": "模型判断",
+      "n": 6,
+      "after_pct": 8.8556,
+      "excess_pct": 6.1022,
+      "sold_correctly": 1
+    },
+    {
+      "label": "止损驱动",
+      "n": 14,
+      "after_pct": 19.3794,
+      "excess_pct": 16.5582,
+      "sold_correctly": 0
+    }
+  ],
+  "by_sequence": [
+    {
+      "label": "首次触发",
+      "n": 10,
+      "after_pct": 14.7362,
+      "excess_pct": 12.8023,
+      "sold_correctly": 1
+    },
+    {
+      "label": "重复触发",
+      "n": 10,
+      "after_pct": 17.7083,
+      "excess_pct": 13.6649,
+      "sold_correctly": 0
+    }
+  ],
+  "by_stop_band": [
+    {
+      "label": "倒挂 0~5%",
+      "n": 4,
+      "after_pct": 20.8349,
+      "excess_pct": 22.8242,
+      "sold_correctly": 0
+    },
+    {
+      "label": "倒挂 5~20%",
+      "n": 2,
+      "after_pct": 4.751,
+      "excess_pct": 2.3524,
+      "sold_correctly": 0
+    },
+    {
+      "label": "无止损信息",
+      "n": 7,
+      "after_pct": 11.4011,
+      "excess_pct": 8.4417,
+      "sold_correctly": 1
+    },
+    {
+      "label": "止损低于现价",
+      "n": 2,
+      "after_pct": 21.3,
+      "excess_pct": 16.6909,
+      "sold_correctly": 0
+    },
+    {
+      "label": "陈旧 >20%",
+      "n": 5,
+      "after_pct": 21.8392,
+      "excess_pct": 17.2437,
+      "sold_correctly": 0
+    }
+  ],
+  "reading": "after_pct 为卖出后价格变化：负值=卖对了（避开下跌），正值=卖早了。excess_pct 已扣同期基准。样本不足时不要据此改风控。"
+}

--- a/scripts/evaluate_exit_attribution.py
+++ b/scripts/evaluate_exit_attribution.py
@@ -1,0 +1,201 @@
+"""卖出建议归因：跑数、落盘、推飞书。
+
+回答一个问题：**系统建议卖出之后，那些票涨了还是跌了。**
+
+2026-08-17 首轮（10 只票 / 20 次建议）：卖出后平均 +14.19%，同期上证 +2.01%，
+即卖错约 13.7pct。两个机制假设都被数据否掉——「陈旧止损是主因」（偏离<5% 也错 17.36%）
+与「重复触发是主因」（首次已错 14.74%）。20 次里 4 次挤在 2026-07-30 同一天，
+而那天是阶段底部，故更像同一次市场时机误判的多次表现。
+
+样本仅 10 只票、全落在同一段 V 型行情，**撑不起修改风控代码**。本脚本的作用是让样本
+持续积累，判据留给未来的数据。
+
+用法::
+
+    python scripts/evaluate_exit_attribution.py --days 60
+    python scripts/evaluate_exit_attribution.py --days 60 --no-notify
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+import pandas as pd
+
+from core.exit_attribution import (
+    ExitRecord,
+    as_report_dict,
+    build_attribution,
+    classify_origin,
+    parse_stop_loss,
+)
+
+BENCHMARK = "000001"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="卖出建议归因")
+    parser.add_argument("--days", type=int, default=60, help="回看天数")
+    parser.add_argument("--portfolio-id", default="", help="限定组合，留空则全部")
+    parser.add_argument("--out", default="docs/evidence", help="输出目录")
+    parser.add_argument("--no-notify", action="store_true", help="不推飞书")
+    return parser.parse_args()
+
+
+def _load_sell_orders(days: int, portfolio_id: str) -> pd.DataFrame:
+    from integrations.supabase_base import create_admin_client, is_admin_configured
+
+    if not is_admin_configured():
+        raise SystemExit("需要 SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY")
+    client = create_admin_client()
+    query = client.table("trade_orders").select("*").order("created_at")
+    if portfolio_id:
+        query = query.eq("portfolio_id", portfolio_id)
+    frame = pd.DataFrame(query.execute().data or [])
+    if frame.empty:
+        return frame
+    frame["trade_date"] = frame.created_at.astype(str).str[:10]
+    cutoff = (pd.Timestamp.now() - pd.Timedelta(days=max(int(days), 1))).strftime("%Y-%m-%d")
+    sells = frame[(frame.action.isin(["EXIT", "TRIM"])) & (frame.trade_date >= cutoff)]
+    return sells.sort_values("trade_date")
+
+
+def _price_series(code: str, start: str):
+    from integrations.data_source import fetch_stock_hist
+
+    frame = fetch_stock_hist(code, start, pd.Timestamp.now().strftime("%Y-%m-%d"))
+    if frame is None or frame.empty:
+        return None
+    work = frame.rename(columns={"日期": "date", "收盘": "close"})
+    if "close" not in work.columns or "date" not in work.columns:
+        return None
+    work["close"] = pd.to_numeric(work["close"], errors="coerce")
+    work = work.dropna(subset=["close"])
+    work["ds"] = pd.to_datetime(work["date"]).dt.strftime("%Y-%m-%d")
+    return work.sort_values("ds").reset_index(drop=True)
+
+
+def _benchmark_series(start: str):
+    from integrations.index_data_source import fetch_index_hist
+
+    frame = fetch_index_hist(BENCHMARK, start, pd.Timestamp.now().strftime("%Y-%m-%d"))
+    if frame is None or frame.empty:
+        return None
+    work = frame.copy()
+    work["close"] = pd.to_numeric(work["close"], errors="coerce")
+    work = work.dropna(subset=["close"])
+    date_col = "date" if "date" in work.columns else work.columns[0]
+    work["ds"] = pd.to_datetime(work[date_col]).dt.strftime("%Y-%m-%d")
+    return work.sort_values("ds").drop_duplicates("ds").reset_index(drop=True)
+
+
+def collect_records(sells: pd.DataFrame, start: str) -> list[ExitRecord]:
+    bench = _benchmark_series(start)
+    records: list[ExitRecord] = []
+    for code, group in sells.groupby("code"):
+        series = _price_series(str(code), start)
+        if series is None:
+            continue
+        for sequence, (_, row) in enumerate(group.sort_values("trade_date").iterrows(), start=1):
+            price = float(row.get("price_hint") or 0.0)
+            if price <= 0:
+                continue
+            trade_date = str(row.trade_date)
+            forward = series[series.ds >= trade_date]
+            if forward.empty:
+                continue
+            after = (float(forward.close.iloc[-1]) / price - 1.0) * 100.0
+            benchmark_pct = None
+            if bench is not None:
+                # 基准区间用个股实际的首末交易日对齐，避开周末的下单日期。
+                window = bench[(bench.ds >= forward.ds.iloc[0]) & (bench.ds <= forward.ds.iloc[-1])]
+                if len(window) > 1:
+                    benchmark_pct = (float(window.close.iloc[-1]) / float(window.close.iloc[0]) - 1.0) * 100.0
+            records.append(
+                ExitRecord(
+                    code=str(code),
+                    name=str(row.get("name") or ""),
+                    action=str(row.get("action") or ""),
+                    trade_date=trade_date,
+                    price=price,
+                    sequence=sequence,
+                    origin=classify_origin(row.get("reason")),
+                    stop_loss=parse_stop_loss(row.get("reason")),
+                    after_pct=after,
+                    benchmark_pct=benchmark_pct,
+                )
+            )
+    return records
+
+
+def render_markdown(report_dict: dict, records: list[ExitRecord]) -> str:
+    overall = report_dict.get("overall") or {}
+    lines = [
+        f"**样本** {report_dict['records']} 次建议 / {report_dict['codes']} 只票",
+        f"**整体** 卖出后 {overall.get('after_pct', 0):+.2f}%　超额 {overall.get('excess_pct') or 0:+.2f}pct　"
+        f"卖对 {overall.get('sold_correctly', 0)}/{overall.get('n', 0)}",
+        "",
+        "| 分组 | n | 卖出后 | 超额 | 卖对 |",
+        "| --- | --: | --: | --: | --: |",
+    ]
+    for key in ("by_origin", "by_sequence", "by_stop_band"):
+        for stat in report_dict.get(key) or []:
+            after = stat.get("after_pct")
+            excess = stat.get("excess_pct")
+            lines.append(
+                f"| {stat['label']} | {stat['n']} | "
+                f"{'—' if after is None else f'{after:+.2f}%'} | "
+                f"{'—' if excess is None else f'{excess:+.2f}'} | {stat['sold_correctly']}/{stat['n']} |"
+            )
+    lines += [
+        "",
+        "**读法**　卖出后为负=卖对了（避开下跌），为正=卖早了。超额已扣同期上证。",
+        "",
+        "**接下来做什么**",
+        "- ① 超额显著为正意味着卖出建议系统性偏晚，此时**不要**执行 EXIT/清仓建议。",
+        "- ② 不据此改风控代码：样本少且集中在同一段行情，机制假设（陈旧止损、重复触发）"
+        "首轮均被数据否掉，更像市场时机误判而非机制缺陷。",
+        "- ③ 下一步只做一件事：继续积累样本，跨越不同市场环境后再重判。",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    start = (pd.Timestamp.now() - pd.Timedelta(days=max(int(args.days), 1) + 30)).strftime("%Y-%m-%d")
+    sells = _load_sell_orders(args.days, args.portfolio_id.strip())
+    if sells.empty:
+        print("[exit] 区间内没有 EXIT/TRIM 建议")
+        return 0
+    records = collect_records(sells, start)
+    if not records:
+        print("[exit] 无法关联行情，样本为空")
+        return 1
+    report = as_report_dict(build_attribution(records))
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "exit_attribution.json").write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    markdown = render_markdown(report, records)
+    print(markdown)
+    if not args.no_notify:
+        _notify(markdown)
+    return 0
+
+
+def _notify(markdown: str) -> None:
+    webhook = os.getenv("FEISHU_WEBHOOK_URL", "").strip()
+    if not webhook:
+        print("[exit] 未配置 FEISHU_WEBHOOK_URL，跳过推送")
+        return
+    from utils.feishu import send_feishu_notification
+
+    title = f"卖出建议归因｜{pd.Timestamp.now().strftime('%Y-%m-%d')}"
+    print("[exit] feishu sent" if send_feishu_notification(webhook, title, markdown) else "[exit] feishu failed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_exit_attribution.py
+++ b/tests/core/test_exit_attribution.py
@@ -1,0 +1,131 @@
+"""Tests for exit-recommendation attribution."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.exit_attribution import (
+    NEAR_TRIGGER_PCT,
+    STALE_DEVIATION_PCT,
+    ExitRecord,
+    as_report_dict,
+    build_attribution,
+    classify_origin,
+    parse_stop_loss,
+)
+
+
+def _record(**kwargs) -> ExitRecord:
+    base = {
+        "code": "600000",
+        "name": "测试",
+        "action": "EXIT",
+        "trade_date": "2026-08-01",
+        "price": 10.0,
+        "sequence": 1,
+    }
+    base.update(kwargs)
+    return ExitRecord(**base)
+
+
+class TestParsing:
+    def test_extracts_stop_loss(self):
+        assert parse_stop_loss("audit=inherit_pos_stop(67.78); sell_with_slippage") == 67.78
+
+    def test_missing_stop_returns_none(self):
+        assert parse_stop_loss("audit=hold") is None
+        assert parse_stop_loss(None) is None
+
+    def test_origin_prefers_forced_stop(self):
+        assert classify_origin("系统强制止损: 现价跌破...") == "系统强制止损"
+
+    def test_origin_detects_stop_driven(self):
+        assert classify_origin("已穿止损，结构破位") == "止损驱动"
+        assert classify_origin("audit=inherit_pos_stop(35.10)") == "止损驱动"
+
+    def test_origin_defaults_to_model(self):
+        assert classify_origin("均线空头排列，减仓防守") == "模型判断"
+
+
+class TestStopBands:
+    def test_normal_stop_below_price(self):
+        assert _record(stop_loss=9.0).stop_band == "止损低于现价"
+
+    def test_just_triggered(self):
+        record = _record(stop_loss=10.2)
+        assert record.stop_deviation_pct == pytest.approx(2.0)
+        assert record.stop_band == f"倒挂 0~{NEAR_TRIGGER_PCT:.0f}%"
+
+    def test_stale_stop(self):
+        """回归：昊华科技止损 67.78 / 现价 40.06，倒挂 69% 应判为陈旧。"""
+        record = _record(price=40.06, stop_loss=67.78)
+        assert record.stop_deviation_pct > STALE_DEVIATION_PCT
+        assert record.stop_band == f"陈旧 >{STALE_DEVIATION_PCT:.0f}%"
+
+    def test_missing_stop_band(self):
+        assert _record().stop_band == "无止损信息"
+
+    def test_zero_price_is_safe(self):
+        assert _record(price=0.0, stop_loss=5.0).stop_deviation_pct is None
+
+
+class TestExcess:
+    def test_subtracts_benchmark(self):
+        record = _record(after_pct=14.0, benchmark_pct=2.0)
+        assert record.excess_pct == 12.0
+
+    def test_none_without_benchmark(self):
+        assert _record(after_pct=14.0).excess_pct is None
+
+
+class TestAttribution:
+    def test_empty_is_safe(self):
+        report = build_attribution([])
+        assert report.overall is None
+        assert as_report_dict(report)["records"] == 0
+
+    def test_sold_correctly_counts_declines(self):
+        """卖出后下跌才算卖对了。"""
+        records = [
+            _record(code="A", after_pct=-5.0, benchmark_pct=0.0),
+            _record(code="B", after_pct=+8.0, benchmark_pct=0.0),
+        ]
+        report = build_attribution(records)
+        assert report.overall.count == 2
+        assert report.overall.sold_correctly == 1
+        assert report.overall.after_pct == 1.5
+
+    def test_splits_first_and_repeat(self):
+        records = [
+            _record(code="A", sequence=1, after_pct=10.0),
+            _record(code="A", sequence=2, after_pct=20.0),
+            _record(code="A", sequence=3, after_pct=30.0),
+        ]
+        report = build_attribution(records)
+        labels = {stat.label: stat for stat in report.by_sequence}
+        assert labels["首次触发"].count == 1
+        assert labels["重复触发"].count == 2
+        assert labels["重复触发"].after_pct == 25.0
+
+    def test_groups_by_origin(self):
+        records = [
+            _record(code="A", origin="止损驱动", after_pct=20.0),
+            _record(code="B", origin="模型判断", after_pct=5.0),
+        ]
+        report = build_attribution(records)
+        by_origin = {stat.label: stat.after_pct for stat in report.by_origin}
+        assert by_origin["止损驱动"] == 20.0
+        assert by_origin["模型判断"] == 5.0
+
+    def test_report_dict_is_serializable(self):
+        import json
+
+        records = [_record(after_pct=1.0, benchmark_pct=0.5, stop_loss=9.0)]
+        payload = as_report_dict(build_attribution(records))
+        assert json.loads(json.dumps(payload, ensure_ascii=False))["codes"] == 1
+
+    def test_records_without_outcome_do_not_break_stats(self):
+        records = [_record(code="A", after_pct=None), _record(code="B", after_pct=4.0)]
+        report = build_attribution(records)
+        assert report.overall.count == 2
+        assert report.overall.after_pct == 4.0


### PR DESCRIPTION
## Summary / 变更摘要

回答一个问题：**系统建议卖出之后，那些票涨了还是跌了。**

首轮跑数（20 次建议 / 10 只票）：卖出后 **+16.22%**、超额 **+13.26pct**、**卖对 1/20**。

| 分组 | n | 卖出后 | 超额 | 卖对 |
| --- | --: | --: | --: | --: |
| 止损驱动 | 14 | +19.38% | +16.56 | **0/14** |
| 模型判断 | 6 | +8.86% | +6.10 | 1/6 |
| 首次触发 | 10 | +14.74% | +12.80 | 1/10 |
| 重复触发 | 10 | +17.71% | +13.66 | 0/10 |
| 倒挂 0~5% | 4 | +20.83% | +22.82 | 0/4 |
| 陈旧 >20% | 5 | +21.84% | +17.24 | 0/5 |

## 为什么不改风控代码

**两个机制假设都被自己的数据否掉：**

1. **「陈旧止损是主因」不成立** —— 倒挂 0~5%（正常刚触发）也错 20.83%，与陈旧 >20% 的 21.84% 相差无几。陈旧只加剧约 1pct。
2. **「重复触发是主因」不成立** —— 首次触发本身就已错 14.74%，重复只多错 2.97pct。

20 次里 4 次挤在 **07-30 同一天**，而那天是阶段底部（同期 CRASH 判定后 T+5 +2.51%）。所以更像**同一次市场时机误判的多次表现**，而非机制缺陷。若属实，该修的是**市场水温判定**而非止损模块 —— 两者触发的是同一批日子。

## 过程中修正的两次自身错误（已记入模块文档）

- **生存偏差**：先前查「当前 9 只持仓」得出「无陈旧止损」，而陈旧的那几只**已被卖出、不在持仓表里**。用存活样本证明问题不存在。拿掉偏差后 13 笔 `inherit_pos_stop` 里 6 笔偏离 >20%。
- **先假设后找数据**：连续两次先锁定机制假设再去验证，两次都不被支持。正确顺序是先看分布。

## 一个确认但未改的发现

`_guard_recent_decision_stop` 的逻辑本身是对的（检测止损倒挂并把 EXIT 降级为 HOLD），但 `_is_invalid_recent_decision_stop` **只在持仓 ≤ 4 天内生效**，老仓的倒挂止损没有保护。

**未改动它**：放宽范围会拆掉「模型误判 HOLD 时的最后一道防线」，而条件 `stop_loss >= max(cost, current_price)` 对深亏老仓极易满足 —— 那恰是最需要止损的情形。此处需要的是**按偏离幅度分档**而非按持仓天数，但中间档（5~20%）无数据支持任何阈值。

## 实现

GitHub Action 每周六北京时间 **10:10** 运行（紧随 regime 前瞻检验），只读 `trade_orders` 与行情，**不写库**。飞书卡片的「接下来做什么」与证据强度绑定：超额显著为正时提示不要执行 EXIT，同时明确写入「不据此改风控代码」。

## Validation / 验证

- `pytest tests/` — **3086 passed, 22 skipped**（新增 18 个用例：止损位解析、来源三分类、偏离分档含昊华 67.78/40.06 的陈旧回归、零价不崩、超额扣基准、卖对只计下跌、首次/重复切分、按来源分组、报告可 JSON 序列化、缺 outcome 不影响统计）
- `ruff check .` / `ruff format --check .`
- `python scripts/quality_gate.py --check-functions`
- `python scripts/check_workflow_hygiene.py`
- 脚本已在真实生产数据上跑通，产物提交于 `docs/evidence/exit_attribution.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)