### PR TITLE
feat(core): 分市场交易成本，补上港美两处漏计的手续费

### DIFF
--- a/core/market_trade_cost.py
+++ b/core/market_trade_cost.py
@@ -1,0 +1,141 @@
+"""分市场交易成本：A 股 / 港股 / 美股的费率结构不同，不能共用一套。
+
+两处已知缺口（2026-08-17 复盘）：
+
+1. ``core/trade_fill.py`` 对非人民币成交直接把手续费置零（``fee = ... if rate == 1.0
+   else 0.0``）。原意是避免 A 股「最低佣金 5 元」被当成 5 美元摊进本币成本——这个顾虑
+   是对的，但结果是港美成交**完全不计费**，已实现盈亏因此偏乐观。
+2. ``core/trade_friction.py`` 的 ``round_trip_cost_pct`` 只有 A 股口径，信号层净收益
+   对港美标的会低估成本。
+
+费率结构的关键差异（这也是不能共用一套配置的原因）：
+
+- **A 股**：佣金有**最低 5 元**门槛（小额交易的百分比成本被显著推高）；印花税 0.05%
+  仅卖出单边；过户费 0.001% 双边。
+- **港股**：印花税 0.1%（2023-11 起，**买卖双边**都征，与 A 股只收卖出侧不同）；
+  交易征费 0.0027%、财汇局征费 0.00015%、交易所交易费 0.00565%，均双边；
+  券商佣金常有最低收费（港币计）。
+- **美股**：无印花税；卖出侧有 SEC 规费与 FINRA TAF；零佣金券商很常见，
+  但 TAF 按**股数**计（每股 0.000166 美元、单笔上限 8.30 美元），与金额无关。
+
+各档默认值取自公开费率表的常见档位，**不是从你的对账单实测出来的**。真实费率取决于
+券商与账户等级，可用 env 覆盖。把它们显式化的意义在于让成本可见可调，而不是置零假装不存在。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+BUY = "buy"
+SELL = "sell"
+
+CN = "CN"
+HK = "HK"
+US = "US"
+
+
+@dataclass(frozen=True)
+class MarketFeeConfig:
+    """单一市场的单边费率。比例项均按成交金额计，除 ``per_share_fee``。"""
+
+    commission_rate: float
+    min_commission: float
+    # 印花税。``stamp_duty_both_sides`` 为 True 时买卖双边都征（港股），否则只在卖出侧（A 股）。
+    stamp_duty_rate: float = 0.0
+    stamp_duty_both_sides: bool = False
+    # 其它按金额计的双边杂费合计（过户费、交易征费、交易所交易费等）。
+    misc_rate_both_sides: float = 0.0
+    # 只在卖出侧征收的按金额计规费（美股 SEC 规费）。
+    sell_only_rate: float = 0.0
+    # 按股数计的费用与其单笔上限（美股 FINRA TAF）。
+    per_share_fee: float = 0.0
+    per_share_fee_cap: float = 0.0
+
+
+# A 股：与 core.cash_portfolio.CashPortfolioConfig 的默认值保持一致，避免两处漂移。
+CN_FEES = MarketFeeConfig(
+    commission_rate=0.0002,
+    min_commission=5.0,
+    stamp_duty_rate=0.0005,
+    stamp_duty_both_sides=False,
+    misc_rate_both_sides=0.00001,
+)
+
+# 港股：印花税双边 0.1% 是主要成本项，远高于 A 股的单边 0.05%。
+HK_FEES = MarketFeeConfig(
+    commission_rate=0.0003,
+    min_commission=15.0,  # 港币
+    stamp_duty_rate=0.001,
+    stamp_duty_both_sides=True,
+    misc_rate_both_sides=0.0000885,  # 交易征费 + 财汇局征费 + 交易所交易费
+)
+
+# 美股：默认零佣金，成本主要在卖出侧规费与按股数的 TAF。
+US_FEES = MarketFeeConfig(
+    commission_rate=0.0,
+    min_commission=0.0,
+    sell_only_rate=0.0000278,  # SEC 规费（费率逐年调整）
+    per_share_fee=0.000166,  # FINRA TAF
+    per_share_fee_cap=8.30,
+)
+
+_MARKET_FEES = {CN: CN_FEES, HK: HK_FEES, US: US_FEES}
+
+
+def market_of(code: str) -> str:
+    """从持仓代码判断市场。与 core.portfolio_valuation.portfolio_currency 同源。"""
+    normalized = str(code or "").strip().upper()
+    if normalized.endswith(".HK"):
+        return HK
+    if normalized.endswith(".US"):
+        return US
+    return CN
+
+
+def fees_for_market(market: str) -> MarketFeeConfig:
+    return _MARKET_FEES.get(str(market or "").strip().upper(), CN_FEES)
+
+
+def single_side_cost(
+    amount: float,
+    *,
+    side: str,
+    market: str = CN,
+    shares: float = 0.0,
+    config: MarketFeeConfig | None = None,
+) -> float:
+    """单边交易成本，以**成交货币**计（港股得港币、美股得美元）。
+
+    调用方负责换汇：把本币成本乘汇率再改人民币现金，不要先换汇再算费
+    （最低佣金门槛是本币概念，换汇后判断会失真）。
+    """
+    gross = max(float(amount), 0.0)
+    if gross <= 0:
+        return 0.0
+    fees = config or fees_for_market(market)
+    cost = max(gross * fees.commission_rate, fees.min_commission)
+    cost += gross * fees.misc_rate_both_sides
+    if fees.stamp_duty_both_sides or side == SELL:
+        cost += gross * fees.stamp_duty_rate
+    if side == SELL:
+        cost += gross * fees.sell_only_rate
+        if fees.per_share_fee > 0:
+            taf = max(float(shares), 0.0) * fees.per_share_fee
+            cost += min(taf, fees.per_share_fee_cap) if fees.per_share_fee_cap > 0 else taf
+    return cost
+
+
+def round_trip_cost_pct(
+    notional: float,
+    *,
+    market: str = CN,
+    shares: float = 0.0,
+    slippage_bps_per_side: float = 0.0,
+) -> float:
+    """一次完整买卖的成本占名义金额的百分比（含双边滑点）。"""
+    gross = max(float(notional), 1.0)
+    fees = single_side_cost(gross, side=BUY, market=market, shares=shares) + single_side_cost(
+        gross, side=SELL, market=market, shares=shares
+    )
+    slippage = gross * (max(float(slippage_bps_per_side), 0.0) / 10_000.0) * 2.0
+    return (fees + slippage) / gross * 100.0

--- a/core/trade_fill.py
+++ b/core/trade_fill.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 
 from core.buy_dt import parse_buy_dt
 from core.cash_portfolio import CashPortfolioConfig, calc_trade_cost
+from core.market_trade_cost import CN, market_of, single_side_cost
 
 BUY = "buy"
 SELL = "sell"
@@ -73,14 +74,27 @@ def apply_fill(
     rate = float(fx_to_cny)
     if rate <= 0:
         raise ValueError("缺少有效汇率，无法把成交金额折成人民币现金")
-    cfg = config or CashPortfolioConfig()
     gross = fill.shares * fill.price
-    # A 股费用模型（最低佣金/印花税/过户费）只适用于人民币成交；港美暂不计费，
-    # 避免把「最低 5 元」误当成 5 美元从本币成本里摊进去。
-    fee = calc_trade_cost(gross, cfg, side=fill.side) if rate == 1.0 else 0.0
+    fee = _fill_fee(fill, gross, config)
     if fill.side == BUY:
         return _apply_buy(holding, cash, fill, gross, fee, rate)
     return _apply_sell(holding, cash, fill, gross, fee, rate)
+
+
+def _fill_fee(fill: Fill, gross: float, config: CashPortfolioConfig | None) -> float:
+    """单边费用，以**成交货币**计（港股得港币、美股得美元），由调用方乘汇率折人民币。
+
+    此前非人民币成交直接把费用置零，港美因此完全不计费、已实现盈亏偏乐观。现按标的
+    所属市场计费——分市场是必须的：港股印花税 0.1% 买卖**双边**（A 股 0.05% 只收卖出侧），
+    美股无印花税但卖出侧有 SEC 规费与按**股数**计的 FINRA TAF。
+
+    显式传入的 ``config`` 仍然优先且只作用于 A 股：它是调用方（含测试）指定的人民币
+    费率覆盖，把它套到港美会重现「最低 5 元当成 5 美元」那类单位错误。
+    """
+    market = market_of(fill.code)
+    if market == CN and config is not None:
+        return calc_trade_cost(gross, config, side=fill.side)
+    return single_side_cost(gross, side=fill.side, market=market, shares=fill.shares)
 
 
 def _apply_buy(

--- a/core/trade_friction.py
+++ b/core/trade_friction.py
@@ -20,6 +20,7 @@ T+20 −16.23% 都是**未扣成本**的数字，真实更差。
 from __future__ import annotations
 
 from core.cash_portfolio import CashPortfolioConfig, calc_trade_cost
+from core.market_trade_cost import CN, market_of, single_side_cost
 
 DEFAULT_SLIPPAGE_BPS_PER_SIDE = 5.0
 # 每笔按此名义金额估算佣金最低收费的影响。A 股佣金常有 5 元门槛，
@@ -49,14 +50,21 @@ def slippage_bps_per_side() -> float:
 def round_trip_cost_pct(
     notional: float = DEFAULT_NOTIONAL_YUAN,
     config: CashPortfolioConfig | None = None,
+    *,
+    code: str = "",
 ) -> float:
     """一次完整买卖的成本占名义金额的百分比。
 
-    含买入佣金+过户费、卖出佣金+过户费+印花税，以及双边滑点。
+    ``code`` 决定市场：给出港美代码时按对应费率算，缺省按 A 股。此前只有 A 股口径，
+    港美标的的净收益会低估成本——港股双边印花税 0.1% 使其往返成本约为 A 股的 3.6 倍。
+    显式传入的 ``config`` 仍优先，且只适用于 A 股（它是人民币费率覆盖）。
     """
-    cfg = config or CashPortfolioConfig()
     gross = max(float(notional), 1.0)
-    fees = calc_trade_cost(gross, cfg, side="buy") + calc_trade_cost(gross, cfg, side="sell")
+    market = market_of(code) if code else CN
+    if market == CN and config is not None:
+        fees = calc_trade_cost(gross, config, side="buy") + calc_trade_cost(gross, config, side="sell")
+    else:
+        fees = single_side_cost(gross, side="buy", market=market) + single_side_cost(gross, side="sell", market=market)
     slippage = gross * (slippage_bps_per_side() / 10_000.0) * 2.0
     return (fees + slippage) / gross * 100.0
 
@@ -66,11 +74,12 @@ def net_return_pct(
     *,
     notional: float = DEFAULT_NOTIONAL_YUAN,
     config: CashPortfolioConfig | None = None,
+    code: str = "",
 ) -> float | None:
-    """毛收益 -> 扣除双边成本后的净收益（百分数）。"""
+    """毛收益 -> 扣除双边成本后的净收益（百分数）。``code`` 用于选市场费率。"""
     if gross_return_pct is None:
         return None
-    return round(float(gross_return_pct) - round_trip_cost_pct(notional, config), 6)
+    return round(float(gross_return_pct) - round_trip_cost_pct(notional, config, code=code), 6)
 
 
 def friction_breakdown(

--- a/tests/core/test_market_trade_cost.py
+++ b/tests/core/test_market_trade_cost.py
@@ -1,0 +1,100 @@
+"""Tests for per-market trade cost.
+
+A 股 / 港股 / 美股的费率结构不同，共用一套会算错：
+- A 股佣金有最低 5 元门槛；印花税 0.05% **只收卖出侧**；过户费双边。
+- 港股印花税 0.1% **买卖双边都征**，是其主要成本项。
+- 美股无印花税；卖出侧有 SEC 规费与按**股数**计的 FINRA TAF（单笔有上限）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.market_trade_cost import (
+    CN,
+    HK,
+    US,
+    US_FEES,
+    market_of,
+    round_trip_cost_pct,
+    single_side_cost,
+)
+
+
+class TestMarketOf:
+    def test_detects_each_market(self):
+        assert market_of("600519") == CN
+        assert market_of("06881.HK") == HK
+        assert market_of("AAPL.US") == US
+
+    def test_case_and_whitespace_tolerant(self):
+        assert market_of(" aapl.us ") == US
+        assert market_of("06881.hk") == HK
+
+    def test_unknown_defaults_to_cn(self):
+        assert market_of("") == CN
+        assert market_of(None) == CN
+
+
+class TestStampDutySides:
+    def test_a_share_stamp_duty_is_sell_only(self):
+        buy = single_side_cost(20_000.0, side="buy", market=CN)
+        sell = single_side_cost(20_000.0, side="sell", market=CN)
+        # 差额即卖出侧印花税 0.05%。
+        assert sell - buy == pytest.approx(20_000.0 * 0.0005)
+
+    def test_hk_stamp_duty_is_both_sides(self):
+        buy = single_side_cost(20_000.0, side="buy", market=HK)
+        sell = single_side_cost(20_000.0, side="sell", market=HK)
+        assert buy == pytest.approx(sell)
+        # 双边各含 0.1% 印花税，故买入侧成本远高于 A 股买入侧。
+        assert buy > single_side_cost(20_000.0, side="buy", market=CN) * 3
+
+    def test_us_has_no_stamp_duty_on_buy(self):
+        buy = single_side_cost(3_000.0, side="buy", market=US, shares=15)
+        assert buy == pytest.approx(0.0)
+
+
+class TestMinCommission:
+    def test_a_share_min_commission_dominates_small_orders(self):
+        assert round_trip_cost_pct(2_000.0, market=CN) > round_trip_cost_pct(200_000.0, market=CN)
+
+    def test_small_order_hits_the_floor(self):
+        # 2000 * 0.0002 = 0.4 元 < 5 元门槛。
+        assert single_side_cost(2_000.0, side="buy", market=CN) >= 5.0
+
+
+class TestUsPerShareFee:
+    def test_taf_scales_with_shares(self):
+        few = single_side_cost(10_000.0, side="sell", market=US, shares=10)
+        many = single_side_cost(10_000.0, side="sell", market=US, shares=1_000)
+        assert many > few
+
+    def test_taf_is_capped(self):
+        """TAF 按股数计但单笔有上限，百万股不能线性膨胀。"""
+        huge = single_side_cost(1_000.0, side="sell", market=US, shares=1_000_000)
+        sec_part = 1_000.0 * US_FEES.sell_only_rate
+        assert huge - sec_part == pytest.approx(US_FEES.per_share_fee_cap)
+
+    def test_buy_side_has_no_taf(self):
+        assert single_side_cost(10_000.0, side="buy", market=US, shares=1_000) == pytest.approx(0.0)
+
+
+class TestRoundTrip:
+    def test_hk_costs_more_than_a_share(self):
+        """回归：港股往返成本约为 A 股 3 倍以上，不能再被当成零。"""
+        assert round_trip_cost_pct(100_000.0, market=HK) > round_trip_cost_pct(100_000.0, market=CN) * 3
+
+    def test_slippage_is_two_sided(self):
+        without = round_trip_cost_pct(20_000.0, market=CN)
+        with_slip = round_trip_cost_pct(20_000.0, market=CN, slippage_bps_per_side=5.0)
+        assert with_slip - without == pytest.approx(0.1)
+
+    def test_zero_and_negative_amounts_are_safe(self):
+        assert single_side_cost(0.0, side="buy", market=CN) == 0.0
+        assert single_side_cost(-100.0, side="sell", market=HK) == 0.0
+
+    def test_negative_slippage_clamped(self):
+        assert round_trip_cost_pct(20_000.0, market=CN, slippage_bps_per_side=-5.0) == pytest.approx(
+            round_trip_cost_pct(20_000.0, market=CN)
+        )

--- a/tests/core/test_trade_fill.py
+++ b/tests/core/test_trade_fill.py
@@ -131,13 +131,46 @@ def test_us_buy_converts_cash_to_cny_but_keeps_native_cost():
 
 
 def test_us_sell_credits_cny_cash_and_reports_cny_pnl():
+    """美股卖出：现金按汇率入账，费用按美股费率以美元计后折人民币。
+
+    此前非人民币成交一律不计费，故本用例原先断言零费用。现按市场计费——美股无印花税，
+    卖出侧有 SEC 规费与按股数计的 FINRA TAF，金额很小但不应为零。
+    """
     holding = Holding(code="AAPL.US", name="Apple", shares=10, cost_price=180.0, buy_dt="20260101")
     result = apply_fill(holding, 1_000.0, Fill("AAPL.US", "sell", 5, 200.0, "20260815"), FREE, fx_to_cny=7.0)
 
     assert result.holding is not None
     assert result.holding.shares == 5
-    assert result.cash == pytest.approx(1_000.0 + 7_000.0)
-    assert result.realized_pnl == pytest.approx((200.0 - 180.0) * 5 * 7.0)
+    # 毛收入 1000 美元 -> 7000 人民币，减去折算后的费用。
+    assert result.cash == pytest.approx(1_000.0 + 7_000.0 - result.fee, rel=1e-9)
+    assert 0.0 < result.fee < 1.0
+    # 已实现盈亏为净额：毛利 700 元减去费用，这才是到手的钱。
+    assert result.realized_pnl == pytest.approx((200.0 - 180.0) * 5 * 7.0 - result.fee, rel=1e-9)
+
+
+def test_hk_stamp_duty_applies_to_both_sides():
+    """港股印花税 0.1% 买卖双边都征，与 A 股只收卖出侧不同。"""
+    buy = apply_fill(None, 100_000.0, Fill("06881.HK", "buy", 1000, 7.0, "20260815"), FREE, fx_to_cny=0.92)
+    sell = apply_fill(
+        Holding(code="06881.HK", name="中国银河", shares=1000, cost_price=7.0, buy_dt="20260101"),
+        0.0,
+        Fill("06881.HK", "sell", 1000, 7.0, "20260815"),
+        FREE,
+        fx_to_cny=0.92,
+    )
+
+    assert buy.fee > 0.0
+    assert sell.fee > 0.0
+    # 同等金额下双边费用应接近（卖出侧无额外单边税项）。
+    assert buy.fee == pytest.approx(sell.fee, rel=0.01)
+
+
+def test_hk_fee_is_materially_higher_than_a_share():
+    """回归：港股成本显著高于 A 股，不能再被当成零。"""
+    hk = apply_fill(None, 100_000.0, Fill("06881.HK", "buy", 1000, 20.0, "20260815"), FREE, fx_to_cny=1.0)
+    cn = apply_fill(None, 100_000.0, Fill("600519", "buy", 1000, 20.0, "20260815"), FREE)
+
+    assert hk.fee > cn.fee * 2
 
 
 def test_missing_fx_rate_is_rejected():

--- a/tests/integrations/test_record_fill_symbol_normalize.py
+++ b/tests/integrations/test_record_fill_symbol_normalize.py
@@ -55,7 +55,10 @@ def test_record_fill_buy_matches_existing_hk_despite_case_and_padding(monkeypatc
     assert captured["position"]["code"] == "00700.HK"
     assert captured["position"]["shares"] == 1100
     assert captured["position"]["name"] == "腾讯控股"
-    assert captured["cash"] == pytest.approx(100_000.0 - 100 * 300.0 * 0.92)
+    # 港股买入含费用（印花税 0.1% 双边 + 佣金 + 杂费），故现金比毛额少扣一点。
+    gross_cny = 100 * 300.0 * 0.92
+    assert captured["cash"] < 100_000.0 - gross_cny
+    assert captured["cash"] == pytest.approx(100_000.0 - gross_cny, rel=0.002)
 
 
 def test_record_fill_rejects_invalid_code_before_write(monkeypatch):
@@ -92,7 +95,10 @@ def test_record_fill_sell_matches_us_bare_ticker(monkeypatch):
     assert captured["writer"] == "update_position"
     assert captured["position"]["code"] == "AAPL.US"
     assert captured["position"]["shares"] == 5
-    assert captured["cash"] == pytest.approx(1_000.0 + 5 * 200.0 * 7.0)
+    # 美股卖出扣 SEC 规费与 FINRA TAF 后入账，金额很小但不为零。
+    gross_cny = 5 * 200.0 * 7.0
+    assert captured["cash"] < 1_000.0 + gross_cny
+    assert captured["cash"] == pytest.approx(1_000.0 + gross_cny, rel=0.001)
 
 
 def test_record_fill_rejects_foreign_when_fx_missing(monkeypatch):


### PR DESCRIPTION
## Summary / 变更摘要

两处缺口都会让盈亏偏乐观：

1. **`core/trade_fill.py` 对非人民币成交直接把费用置零** —— `fee = calc_trade_cost(...) if rate == 1.0 else 0.0`。原意是避免 A 股「最低佣金 5 元」被当成 5 美元摊进本币成本（顾虑正确），但结果是**港美成交完全不计费**。
2. **`core/trade_friction.py` 的 `round_trip_cost_pct` 只有 A 股口径** —— 信号层净收益对港美标的低估成本。

## 为什么必须分市场

费率**结构**不同，不只是数值不同：

| 市场 | 佣金 | 印花税 | 其它 |
| --- | --- | --- | --- |
| A 股 | 0.02%，**最低 5 元** | 0.05%，**仅卖出侧** | 过户费 0.001% 双边 |
| 港股 | 0.03%，最低 15 港元 | **0.1%，买卖双边都征** | 交易征费+财汇局+交易所费约 0.00885% 双边 |
| 美股 | 默认 0 | **无** | 卖出侧 SEC 规费 + **按股数**计的 FINRA TAF（单笔上限 8.30 美元） |

实测往返成本：

| 市场 | 往返成本 |
| --- | ---: |
| A 股 | 0.202% |
| **港股** | **0.468%**（约 A 股 2.3 倍） |
| 美股 | 0.103% |

港股此前被当成 **0** —— 对持有 06881.HK 的账户影响直接。

## 两处实现要点

**费用以成交货币计**（港股得港币、美股得美元），由调用方乘汇率折人民币。不能先换汇再算费 —— 最低佣金门槛是本币概念，换汇后判断会失真。

**显式传入的 `config` 仍优先，且只作用于 A 股**：它是调用方（含测试）指定的人民币费率覆盖，套到港美会重现「最低 5 元当成 5 美元」那类单位错误。

## 诚实标注

费率默认值取自**公开费率表的常见档位，不是从对账单实测**。真实值取决于券商与账户等级。显式化的意义在于让成本可见可调，而不是置零假装不存在。

## Validation / 验证

- `pytest tests/` — **3122 passed, 22 skipped**
  - 新增 15 个费率用例：印花税单/双边差异、最低佣金对小额的支配、TAF 随股数增长且封顶、买入侧无 TAF、港股往返高于 A 股 3 倍、滑点双边、零/负金额安全、负滑点归零
  - 新增 2 个成交用例：港股双边印花税近似相等、港股费用显著高于 A 股
  - 更新 3 个原先断言港美零费用的用例：美股已实现盈亏改为净额、港美现金入账扣费后校验
- `ruff check .` / `ruff format --check .`
- `python scripts/quality_gate.py --check-functions`
- `python scripts/daily_job.py --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)