### PR TITLE
feat(scripts): 漏斗吞吐诊断，逐层定位瓶颈而非靠猜调参

### DIFF
--- a/scripts/diagnose_funnel_throughput.py
+++ b/scripts/diagnose_funnel_throughput.py
@@ -1,0 +1,223 @@
+"""漏斗吞吐诊断：逐层报告收缩比，直接指出卡在哪一层。
+
+与 ``diagnose_funnel_recall.py`` 的区别：那个按**代码**回放（「这几只为什么没进池」），
+本脚本按**层**统计（「今天池子里的票在哪一层被截断」）。前者查个案，后者定位瓶颈参数。
+
+动机：2026-08 复盘发现 8/17 有 71 只 formal_l4 却 0 只进 AI、8/12 有 60 只进 0 只。
+当时误以为是 ``FUNNEL_AI_TOTAL_CAP=8`` 太小，实测才发现 ``tradeable_l4`` 模式下该 cap
+不参与晋级限制（workflows/funnel_ai_selection.py 把 promotion_total_cap 传 None），
+真瓶颈是水温闸门（``allow_ai_review=False`` 直接提前返回）与该档 AI 配额为 0。
+
+所以这个脚本存在的意义是：**别再靠猜调参数**。它把每层的输入/输出/收缩比摊开，
+并标出当日实际生效的限制值（水温、配额、cap、每板块上限），让「卡在哪」一眼可见。
+
+用法::
+
+    python scripts/diagnose_funnel_throughput.py                    # 最近交易日
+    python scripts/diagnose_funnel_throughput.py --date 2026-08-17
+    python scripts/diagnose_funnel_throughput.py --days 10          # 近 10 个交易日趋势
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import _bootstrap  # noqa: F401
+import pandas as pd
+
+# 只读脚本：不写库、不发通知、不改配置。
+FORMAL_STATUS = "formal_l4"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="漏斗逐层吞吐与瓶颈定位")
+    parser.add_argument("--date", default="", help="交易日 YYYY-MM-DD，默认最近有数据的一天")
+    parser.add_argument("--days", type=int, default=1, help="回看交易日数，>1 时输出趋势表")
+    parser.add_argument("--json-out", default="", help="结构化结果输出路径")
+    return parser.parse_args()
+
+
+def _load_observations() -> pd.DataFrame:
+    from integrations.supabase_base import create_admin_client, is_admin_configured
+
+    if not is_admin_configured():
+        raise SystemExit("需要 SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY")
+    client = create_admin_client()
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while offset < 40_000:
+        page = (
+            client.table("signal_observations")
+            .select("trade_date,code,candidate_status,selected_for_ai,selection_mode,industry,signal_type")
+            .range(offset, offset + 999)
+            .execute()
+        )
+        if not page.data:
+            break
+        rows += page.data
+        offset += 1000
+    return pd.DataFrame(rows)
+
+
+def _load_regimes() -> dict[str, str]:
+    from integrations.supabase_base import create_admin_client
+    from workflows.step4_market import resolve_effective_market_regime
+
+    client = create_admin_client()
+    rows = (
+        client.table("market_signal_daily")
+        .select("trade_date,benchmark_regime,premarket_regime")
+        .order("trade_date")
+        .execute()
+        .data
+        or []
+    )
+    return {
+        str(row["trade_date"]): resolve_effective_market_regime(
+            row.get("benchmark_regime"), row.get("premarket_regime")
+        )
+        for row in rows
+        if row.get("trade_date")
+    }
+
+
+def _limits_for(regime: str) -> dict[str, Any]:
+    """当日实际生效的限制值。这些才是「卡在哪」的候选答案。"""
+    from core.ai_candidate_allocation import resolve_ai_candidate_policy
+    from core.market_trade_mode import resolve_market_trade_mode
+    from workflows.ai_candidate_allocation_config import ai_candidate_allocation_config_from_env
+    from workflows.step4_order_config import step4_order_config_from_env
+
+    config = ai_candidate_allocation_config_from_env()
+    policy = resolve_ai_candidate_policy(regime, config=config)
+    mode = resolve_market_trade_mode(regime)
+    selection_mode = os.getenv("FUNNEL_AI_SELECTION_MODE", "tradeable_l4")
+    return {
+        "regime": regime,
+        "allow_ai_review": bool(mode.allow_ai_review),
+        "trade_mode": mode.mode,
+        "trend_quota": int(policy.get("trend_quota") or 0),
+        "accum_quota": int(policy.get("accum_quota") or 0),
+        "total_cap": int(policy.get("total_cap") or 0),
+        "max_per_sector": int(config.max_per_sector),
+        "selection_mode": selection_mode,
+        # tradeable_l4 下 total_cap 不参与晋级限制，标注出来避免再次误判。
+        "total_cap_binds_promotion": selection_mode != "tradeable_l4",
+        "buy_blocked": regime in set(step4_order_config_from_env().buy_block_regimes),
+    }
+
+
+def _bottleneck(stages: dict[str, int], limits: dict[str, Any]) -> str:
+    """按最先归零/最紧的一层给出结论，措辞必须指向可改的具体参数。"""
+    if stages["observations"] == 0:
+        return "无 observation：上游漏斗未产出，检查取数与 L1/L2"
+    if not limits["allow_ai_review"]:
+        return f"水温闸门（{limits['regime']} / {limits['trade_mode']}）：allow_ai_review=False，AI 复核被整体跳过"
+    if stages["formal_l4"] == 0:
+        return "无 formal_l4：候选未通过买点确认或跨日 confirmed，非配额问题"
+    if stages["selected_for_ai"] == 0:
+        quota = limits["trend_quota"] + limits["accum_quota"]
+        if quota == 0:
+            return f"该档 AI 配额为 0（FUNNEL_AI_{limits['regime']}_TREND/ACCUM）"
+        return "配额非零但未选出：检查板块上限与评分门槛"
+    quota = limits["trend_quota"] + limits["accum_quota"]
+    if stages["selected_for_ai"] >= quota > 0:
+        return f"AI 配额打满（{quota}）：如需更多，提高 FUNNEL_AI_{limits['regime']}_TREND/ACCUM"
+    if limits["total_cap_binds_promotion"] and stages["selected_for_ai"] >= limits["total_cap"]:
+        return f"总量 cap 打满（{limits['total_cap']}）：提高 FUNNEL_AI_TOTAL_CAP"
+    return "未见硬性截断：入选数低于所有上限，瓶颈在候选质量而非配额"
+
+
+def build_day_report(frame: pd.DataFrame, trade_date: str, regime: str) -> dict[str, Any]:
+    day = frame[frame.trade_date == trade_date]
+    formal = day[day.candidate_status == FORMAL_STATUS]
+    picked = day[day.selected_for_ai]
+    stages = {
+        "observations": int(day.code.nunique()),
+        "formal_l4": int(formal.code.nunique()),
+        "selected_for_ai": int(picked.code.nunique()),
+    }
+    limits = _limits_for(regime)
+    sector_top = {}
+    if not formal.empty and "industry" in formal.columns:
+        counts = formal.dropna(subset=["industry"]).groupby("industry").code.nunique().sort_values(ascending=False)
+        sector_top = {str(k): int(v) for k, v in counts.head(5).items()}
+    return {
+        "trade_date": trade_date,
+        "stages": stages,
+        "shrink": {
+            "observations_to_formal": _ratio(stages["formal_l4"], stages["observations"]),
+            "formal_to_ai": _ratio(stages["selected_for_ai"], stages["formal_l4"]),
+        },
+        "limits": limits,
+        "formal_by_sector_top5": sector_top,
+        "bottleneck": _bottleneck(stages, limits),
+    }
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    return None if denominator <= 0 else round(100.0 * numerator / denominator, 1)
+
+
+def _pct(value: float | None) -> str:
+    return "—" if value is None else f"{value}%"
+
+
+def render(reports: list[dict[str, Any]]) -> str:
+    lines = [
+        "| 日期 | 水温 | obs | formal_l4 | 进AI | obs→formal | formal→AI | 瓶颈 |",
+        "| --- | --- | --: | --: | --: | --: | --: | --- |",
+    ]
+    for report in reports:
+        stage = report["stages"]
+        shrink = report["shrink"]
+        lines.append(
+            f"| {report['trade_date']} | {report['limits']['regime']} | {stage['observations']} | "
+            f"{stage['formal_l4']} | {stage['selected_for_ai']} | "
+            f"{_pct(shrink['observations_to_formal'])} | {_pct(shrink['formal_to_ai'])} | {report['bottleneck']} |"
+        )
+    latest = reports[-1]
+    limits = latest["limits"]
+    lines += [
+        "",
+        f"**{latest['trade_date']} 当日生效限制**",
+        f"- 水温 `{limits['regime']}`／模式 `{limits['trade_mode']}`　allow_ai_review={limits['allow_ai_review']}",
+        f"- AI 配额 trend={limits['trend_quota']} accum={limits['accum_quota']}　总量 cap={limits['total_cap']}"
+        f"（{'参与' if limits['total_cap_binds_promotion'] else '**不参与**'}晋级限制，selection_mode={limits['selection_mode']}）",
+        f"- 每板块上限 {limits['max_per_sector']}　买入闸门：{'禁买' if limits['buy_blocked'] else '可买'}",
+    ]
+    if latest["formal_by_sector_top5"]:
+        top = "、".join(f"{k} {v}" for k, v in latest["formal_by_sector_top5"].items())
+        lines.append(f"- formal_l4 板块分布 Top5：{top}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    frame = _load_observations()
+    if frame.empty:
+        print("[throughput] 无 observation 数据")
+        return 1
+    frame["selected_for_ai"] = frame.selected_for_ai.fillna(False).astype(bool)
+    regimes = _load_regimes()
+    dates = sorted(frame.trade_date.unique())
+    if args.date:
+        dates = [d for d in dates if d == args.date] or [args.date]
+    else:
+        dates = dates[-max(int(args.days), 1) :]
+    reports = [build_day_report(frame, d, regimes.get(d, "UNKNOWN")) for d in dates]
+    text = render(reports)
+    print(text)
+    if args.json_out:
+        Path(args.json_out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.json_out).write_text(json.dumps(reports, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"\n[throughput] written -> {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_diagnose_funnel_throughput.py
+++ b/tests/scripts/test_diagnose_funnel_throughput.py
@@ -1,0 +1,147 @@
+"""Tests for funnel throughput bottleneck attribution.
+
+这个脚本存在的意义是别再靠猜调参数：2026-08 复盘时我曾误判
+``FUNNEL_AI_TOTAL_CAP=8`` 是瓶颈，实测 12 天里它一次都没卡住，真瓶颈是水温闸门
+（``allow_ai_review=False``）与该档 AI 配额为 0。所以这些用例重点守 ``_bottleneck``
+的归因优先级，别让结论再次指错参数。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts import diagnose_funnel_throughput as mod
+
+
+def _limits(**overrides):
+    base = {
+        "regime": "BEAR_REBOUND",
+        "allow_ai_review": True,
+        "trade_mode": "repair_review",
+        "trend_quota": 5,
+        "accum_quota": 1,
+        "total_cap": 8,
+        "max_per_sector": 2,
+        "selection_mode": "tradeable_l4",
+        "total_cap_binds_promotion": False,
+        "buy_blocked": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestBottleneckPriority:
+    def test_no_observations_reported_first(self):
+        stages = {"observations": 0, "formal_l4": 0, "selected_for_ai": 0}
+        assert "无 observation" in mod._bottleneck(stages, _limits())
+
+    def test_gate_outranks_quota(self):
+        """闸门关闭时不该归因到配额——8/17 有 71 只 formal_l4 却因闸门丢光。"""
+        stages = {"observations": 168, "formal_l4": 71, "selected_for_ai": 0}
+        verdict = mod._bottleneck(stages, _limits(allow_ai_review=False, trade_mode="observe_only", regime="UNKNOWN"))
+        assert "水温闸门" in verdict
+        assert "配额" not in verdict
+
+    def test_zero_formal_is_not_a_quota_problem(self):
+        stages = {"observations": 120, "formal_l4": 0, "selected_for_ai": 0}
+        verdict = mod._bottleneck(stages, _limits())
+        assert "无 formal_l4" in verdict
+        assert "非配额问题" in verdict
+
+    def test_zero_quota_named_explicitly(self):
+        """配额为 0 时要点名具体 env 变量，否则运维无从下手。"""
+        stages = {"observations": 134, "formal_l4": 60, "selected_for_ai": 0}
+        verdict = mod._bottleneck(stages, _limits(trend_quota=0, accum_quota=0))
+        assert "FUNNEL_AI_BEAR_REBOUND_TREND/ACCUM" in verdict
+
+    def test_quota_saturated(self):
+        stages = {"observations": 140, "formal_l4": 30, "selected_for_ai": 6}
+        assert "配额打满" in mod._bottleneck(stages, _limits())
+
+    def test_total_cap_only_blamed_when_it_binds(self):
+        """tradeable_l4 下 total_cap 不参与晋级，不能归因到它。"""
+        stages = {"observations": 200, "formal_l4": 50, "selected_for_ai": 8}
+        # 配额 5+1=6，selected 8 已超配额 -> 先归因配额
+        assert "配额打满" in mod._bottleneck(stages, _limits())
+        # 配额放大后，binds=False 时不应提 total_cap
+        verdict = mod._bottleneck(stages, _limits(trend_quota=20, accum_quota=5))
+        assert "FUNNEL_AI_TOTAL_CAP" not in verdict
+
+    def test_total_cap_blamed_when_binding(self):
+        stages = {"observations": 200, "formal_l4": 50, "selected_for_ai": 8}
+        verdict = mod._bottleneck(
+            stages, _limits(trend_quota=20, accum_quota=5, total_cap_binds_promotion=True, total_cap=8)
+        )
+        assert "FUNNEL_AI_TOTAL_CAP" in verdict
+
+    def test_no_hard_cut_when_below_all_limits(self):
+        stages = {"observations": 112, "formal_l4": 5, "selected_for_ai": 2}
+        verdict = mod._bottleneck(stages, _limits())
+        assert "未见硬性截断" in verdict
+        assert "候选质量" in verdict
+
+
+class TestRatioAndRender:
+    def test_ratio_guards_zero_denominator(self):
+        assert mod._ratio(3, 0) is None
+        assert mod._ratio(3, 6) == 50.0
+
+    def test_pct_formats_none(self):
+        assert mod._pct(None) == "—"
+        assert mod._pct(42.3) == "42.3%"
+
+    def test_render_includes_bottleneck_and_limits(self):
+        report = {
+            "trade_date": "2026-08-17",
+            "stages": {"observations": 168, "formal_l4": 71, "selected_for_ai": 0},
+            "shrink": {"observations_to_formal": 42.3, "formal_to_ai": 0.0},
+            "limits": _limits(allow_ai_review=False, regime="UNKNOWN", trade_mode="observe_only", buy_blocked=True),
+            "formal_by_sector_top5": {"种植业": 3},
+            "bottleneck": "水温闸门（UNKNOWN / observe_only）",
+        }
+        text = mod.render([report])
+        assert "2026-08-17" in text
+        assert "水温闸门" in text
+        assert "**不参与**" in text  # tradeable_l4 下须标明 cap 不限制晋级
+        assert "禁买" in text
+
+
+class TestBuildDayReport:
+    def test_counts_distinct_codes_per_stage(self, monkeypatch):
+        monkeypatch.setattr(mod, "_limits_for", lambda regime: _limits(regime=regime))
+        frame = pd.DataFrame(
+            [
+                {"trade_date": "2026-08-17", "code": "A", "candidate_status": "formal_l4", "selected_for_ai": True},
+                {"trade_date": "2026-08-17", "code": "A", "candidate_status": "formal_l4", "selected_for_ai": True},
+                {"trade_date": "2026-08-17", "code": "B", "candidate_status": "Lane", "selected_for_ai": False},
+                {"trade_date": "2026-08-14", "code": "C", "candidate_status": "formal_l4", "selected_for_ai": False},
+            ]
+        )
+        report = mod.build_day_report(frame, "2026-08-17", "BEAR_REBOUND")
+        # 同一 code 多行只算一次；另一天不计入。
+        assert report["stages"] == {"observations": 2, "formal_l4": 1, "selected_for_ai": 1}
+        assert report["shrink"]["formal_to_ai"] == 100.0
+
+    def test_missing_industry_column_is_safe(self, monkeypatch):
+        monkeypatch.setattr(mod, "_limits_for", lambda regime: _limits())
+        frame = pd.DataFrame(
+            [{"trade_date": "2026-08-17", "code": "A", "candidate_status": "formal_l4", "selected_for_ai": False}]
+        )
+        report = mod.build_day_report(frame, "2026-08-17", "BEAR_REBOUND")
+        assert report["formal_by_sector_top5"] == {}
+
+
+def test_module_is_read_only():
+    """诊断脚本不得写库或发通知。"""
+    source = (Path(__file__).resolve().parents[2] / "scripts" / "diagnose_funnel_throughput.py").read_text(
+        encoding="utf-8"
+    )
+    for forbidden in ("upsert", "insert(", "send_feishu", "require_server_write_context"):
+        assert forbidden not in source, f"诊断脚本不应包含写入/通知调用: {forbidden}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary / 变更摘要

**先更正我此前的一个错判**：我曾提醒 `FUNNEL_AI_TOTAL_CAP=8` 会成为候选变多后的新瓶颈，并建议改它。实测 8 月 12 个交易日，它**一次都没卡住**。

| 日期 | 水温 | obs | formal_l4 | 进AI | 真实瓶颈 |
| --- | --- | --: | --: | --: | --- |
| 08-12 | BEAR_REBOUND | 134 | **60** | 0 | 该档配额为 0 |
| **08-17** | UNKNOWN | 168 | **71** | 0 | **水温闸门 observe_only** |
| 08-18 | RISK_OFF | 137 | 8 | 0 | 水温闸门 observe_only |

真瓶颈是两类：**水温闸门 7/12 天**（`allow_ai_review=False` 直接跳过整个 AI 复核）与**该档 AI 配额为 0**（2 天）。而且 `tradeable_l4` 模式下 `total_cap` 压根不参与晋级限制 —— `workflows/funnel_ai_selection.py` 把 `promotion_total_cap` 传 `None`。

这两处已分别由 #281（取数失败误判为 `UNKNOWN`）与 #285（`BEAR_REBOUND` 配额 0→5/1）修掉。

## 实现

新增 `scripts/diagnose_funnel_throughput.py`：按**层**统计收缩比并给出瓶颈归因，与既有 `diagnose_funnel_recall.py`（按**代码**回放个案）互补。

归因有明确优先级，措辞直接点名可改的 env 变量：

```
无 observation > 闸门关闭 > 无 formal_l4 > 配额为 0
  > 配额打满 > total_cap 打满 > 未见硬性截断
```

报告同时打印当日生效的全部限制值，并**显式标注 `total_cap` 是否参与晋级** —— 就是为了不再重犯上面那个误判。

只读脚本：不写库、不发通知、不改配置，有用例守这条边界。

## Validation / 验证

- `pytest tests/` — **3139 passed, 22 skipped**（新增 14 个用例：归因优先级 8 条，含「闸门关闭时不得归因到配额」与「`tradeable_l4` 下不得归因 `total_cap`」；零分母保护；渲染须标明 cap 不参与晋级；按 code 去重计数；缺 `industry` 列不崩；只读边界）
- `ruff check .` / `ruff format --check .`
- `python scripts/quality_gate.py --check-functions`
- 脚本已在真实生产数据上跑通 12 个交易日

## 附带发现：本地 `.env` 与生产漂移

排查中发现本地 `.env` 有 11 项与 workflow 不一致，其中两项会让本地测试给出**误导性结论**：

- `STEP4_BUY_BLOCK_REGIMES` 本地少禁 `NEUTRAL` 且无 `ALLOW` 豁免 —— 与生产**恰好相反**（本地放行 −4.35pct 那档、却禁 +4.08pct 那档）
- `FUNNEL_AI_SELECTION_MODE=modern` 让 `total_cap` 参与晋级限制，与生产 `tradeable_l4` 行为不同 —— 我差点因此再次误判瓶颈

已同步这两项及 AI 配额四项、`STEP4_BUY_HARD_STOP_PCT`；性能四项（`BATCH_SIZE`/`BATCH_SLEEP`/`EXECUTOR_MODE`/`MAX_WORKERS`）刻意保留本地值。`.env` 不入版本库，此处仅作记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)