### PR TITLE
style(feishu): 候选类表格拍平成「标题行 + 指标尾」

### DIFF
--- a/tests/integrations/test_feishu_text.py
+++ b/tests/integrations/test_feishu_text.py
@@ -37,8 +37,11 @@ def test_normalize_lark_md_handles_multiple_tables_and_plain_text():
         ]
     )
     result = normalize_lark_md(content)
-    assert "- #: 1，代码: 01336.HK，分数: 0.71" in result
+    # 带序号/代码列的表改成「标题行 + 指标尾」，不再逐格重复表头（见 test_feishu_table_flatten）。
+    assert "- **1. 01336.HK**" in result
+    assert "分数: 0.71" in result
     assert "普通说明文字保持不变" in result
+    # 无序号无标识列的表（触发分布）保持原单行格式。
     assert "- 触发: LPS（缩量回踩），数量: 11" in result
 
 

--- a/tests/utils/test_feishu_table_flatten.py
+++ b/tests/utils/test_feishu_table_flatten.py
@@ -1,0 +1,103 @@
+"""飞书卡片不支持表格，必须拍平；拍平后要可读，且不能破坏其他报告的表形。"""
+
+from __future__ import annotations
+
+from utils.feishu_text import normalize_lark_md
+
+CANDIDATE_TABLE = """| # | 代码 | 名称 | 分数 | 最新收盘 | 触发 |
+| ---: | --- | --- | ---: | ---: | --- |
+| 1 | RDAC.US | Rising Dragon | 1737.67 | 8.780 | SOS（量价点火） |
+| 2 | AZI.US | Autozi | 7.89 | 1.660 | SOS（量价点火） |
+"""
+
+
+def test_index_and_name_become_bold_title() -> None:
+    """回归：原先每行都重复表头，读起来是 `#: 1，代码: X，名称: Y，分数: Z` 一大坨。"""
+    out = normalize_lark_md(CANDIDATE_TABLE)
+
+    assert "- **1. RDAC.US · Rising Dragon**" in out
+    assert "#: 1" not in out
+    assert "代码: RDAC.US" not in out
+
+
+def test_metrics_move_to_indented_second_line() -> None:
+    out = normalize_lark_md(CANDIDATE_TABLE)
+
+    assert "  分数: 1737.67 | 最新收盘: 8.780 | 触发: SOS（量价点火）" in out
+
+
+def test_placeholder_row_collapses_to_single_note() -> None:
+    """空表占位行 `| - | - | - | 本次无候选 |` 不该渲染成一串 '-'。"""
+    md = """| # | 代码 | 名称 | 分数 | 最新收盘 | 触发 |
+| ---: | --- | --- | ---: | ---: | --- |
+| - | - | - | - | - | 本次无买点确认候选 |
+"""
+
+    out = normalize_lark_md(md)
+
+    assert "- 本次无买点确认候选" in out
+    assert "- - -" not in out
+
+
+def test_wide_table_keeps_all_columns() -> None:
+    """funnel_delivery 有 11 列，拍平不能丢字段。"""
+    md = """| Rank | Code | Name | Action | AI | Funnel | Quality | Shadow | Entry | Label | Risks |
+| ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | 002648 | 卫星化学 | PROBE | yes | 88 | A | pass | 25.3 | 主线 | 无 |
+"""
+
+    out = normalize_lark_md(md)
+
+    assert "**1. 002648 · 卫星化学**" in out
+    for field in ("Action: PROBE", "AI: yes", "Funnel: 88", "Quality: A", "Entry: 25.3", "Risks: 无"):
+        assert field in out, field
+
+
+def test_table_without_index_or_identity_keeps_legacy_single_line() -> None:
+    """无序号无标识列的表保持旧格式不动。
+
+    这类表（signal_feedback 的 Grade 表、筛选概览的环节/数量、市场闸门表）通常 2~4 列、
+    本来一行就读完，改它没有收益；硬造空标题行还会多出 "- -" 噪音。
+    """
+    md = """| Grade | Ready | Hit rate | Payoff |
+| --- | ---: | ---: | ---: |
+| A | 120 | 34.2% | 0.85 |
+"""
+
+    out = normalize_lark_md(md)
+
+    assert "- Grade: A，Ready: 120，Hit rate: 34.2%，Payoff: 0.85" in out
+    assert "**" not in out
+
+
+def test_trend_watch_table_has_no_name_column() -> None:
+    """只有代码没有名称时，标题就是代码本身。"""
+    md = """| # | 代码 | 分数 | 20日 | 60日 | 120日 | 风险 |
+| ---: | --- | ---: | ---: | ---: | ---: | --- |
+| 1 | TEM.US | 3.78 | 12.50% | 30.10% | 55.20% | 高波动 |
+"""
+
+    out = normalize_lark_md(md)
+
+    assert "- **1. TEM.US**" in out
+    assert "风险: 高波动" in out
+
+
+def test_missing_trailing_cells_do_not_crash() -> None:
+    md = """| # | 代码 | 名称 | 分数 |
+| ---: | --- | --- | ---: |
+| 1 | AAA.US |
+"""
+
+    out = normalize_lark_md(md)
+
+    assert "AAA.US" in out
+
+
+def test_non_table_content_is_untouched() -> None:
+    md = "## 概览\n- 命中: 87\n\n正文一行。\n"
+
+    out = normalize_lark_md(md)
+
+    assert "命中: 87" in out
+    assert "正文一行。" in out

--- a/utils/feishu_text.py
+++ b/utils/feishu_text.py
@@ -59,12 +59,62 @@ def _split_table_row(stripped: str) -> list[str]:
     return [cell.strip() for cell in stripped.strip("|").split("|")]
 
 
+# 序号类列名：它们的值直接做行首标号，不重复打印列名（"#: 1" 这种噪音占了整行开头）。
+_INDEX_HEADERS = frozenset({"#", "序号", "Rank", "rank", "No", "no", "No.", "排名"})
+# 标识类列名：值本身自解释（代码/名称），做行首标题，不加"代码: "前缀。
+_IDENTITY_HEADERS = frozenset(
+    {"代码", "名称", "Code", "code", "Name", "name", "symbol", "Symbol", "标的", "概念", "Strategy", "策略"}
+)
+
+
 def _table_block_to_lines(header: list[str], rows: list[list[str]]) -> list[str]:
+    """把 markdown 表格拍平成飞书卡片可读的行。
+
+    飞书 lark_md 不支持表格，必须拍平。原实现把每格都写成 `列名: 值` 再用「，」连起来，
+    于是 30 行候选每行都重复一遍表头，读起来是一大坨 `#: 1，代码: X，名称: Y，分数: Z`，
+    在手机上会折成三四行。
+
+    这里改成「标题行 + 指标尾」：序号与标识列（代码/名称）直接做行首并加粗，其余列才带列名。
+    列宽差异很大（4~11 列，横跨 7 份报告），所以规则必须是通用的，不能对某张表硬编码。
+    """
     out: list[str] = []
+    index_cols = [i for i, name in enumerate(header) if name in _INDEX_HEADERS]
+    identity_cols = [i for i, name in enumerate(header) if name in _IDENTITY_HEADERS]
     for row in rows:
-        cells = [f"{name}: {row[idx]}" if idx < len(row) else f"{name}: -" for idx, name in enumerate(header)]
-        out.append("- " + "，".join(cells))
+        if _is_placeholder_row(row):
+            out.append(f"- {_placeholder_text(row)}")
+            continue
+        lead = [row[i] for i in index_cols if i < len(row) and row[i] not in ("", "-")]
+        names = [row[i] for i in identity_cols if i < len(row) and row[i] not in ("", "-")]
+        rest = [
+            f"{name}: {row[i]}"
+            for i, name in enumerate(header)
+            if i not in index_cols and i not in identity_cols and i < len(row) and row[i] != ""
+        ]
+        prefix = f"{lead[0]}. " if lead else ""
+        title = " · ".join(names)
+        if not title and not prefix:
+            # 没有序号也没有标识列（如筛选概览的「环节/数量」、signal_feedback 的 Grade 表、
+            # 市场闸门表）：保持原来的 `列名: 值，列名: 值` 单行格式不动。
+            # 这类表通常只有 2~4 列、本来就一行读完，改它没有收益，只会让 diff 变大。
+            # 硬造一个空标题行还会多出一条 "- -" 噪音。
+            cells = [f"{name}: {row[idx]}" if idx < len(row) else f"{name}: -" for idx, name in enumerate(header)]
+            out.append("- " + "，".join(cells))
+            continue
+        head = f"**{prefix}{title}**" if title else f"**{prefix.rstrip('. ')}**"
+        out.append(f"- {head}" + (f"\n  {' | '.join(rest)}" if rest else ""))
     return out
+
+
+def _is_placeholder_row(row: list[str]) -> bool:
+    """空表占位行形如 `| - | - | - | 本次无候选 |`：全是 '-' 只剩一句说明。"""
+    meaningful = [cell for cell in row if cell not in ("", "-")]
+    return len(meaningful) <= 1 and len(row) > 1
+
+
+def _placeholder_text(row: list[str]) -> str:
+    meaningful = [cell for cell in row if cell not in ("", "-")]
+    return meaningful[0] if meaningful else "-"
 
 
 def _consume_table(lines: list[str], start: int) -> tuple[list[str], int]:


### PR DESCRIPTION
## Summary

飞书 `lark_md` 不支持表格,报告里的 markdown 表必须拍平。原实现把**每一格**都写成 `列名: 值` 再用「，」连起来,于是 Top 候选 30 行里每行都重复一遍表头:

**修复前**(手机上会折成三四行):
```
- #: 1，代码: RDAC.US，名称: Rising Dragon Acquisition，分数: 1737.67，最新收盘: 8.780，触发: SOS（量价点火）
- #: 2，代码: AZI.US，名称: Autozi Internet Tech Global，分数: 7.89，最新收盘: 1.660，触发: SOS（量价点火）
```

**修复后**:
```
- **1. RDAC.US · Rising Dragon Acquisition**
  分数: 1737.67 | 最新收盘: 8.780 | 触发: SOS（量价点火）
- **2. AZI.US · Autozi Internet Tech Global**
  分数: 7.89 | 最新收盘: 1.660 | 触发: SOS（量价点火）
```

序号列(`#`/序号/Rank/排名)与标识列(代码/名称/Code/Name/symbol/Strategy 等)提到行首加粗做标题,其余列缩进到第二行用 ` | ` 分隔。空表占位行(`| - | - | - | 本次无候选 |`)收成一句说明,不再渲染成一串 `-`。

## 只改需要改的表

**无序号无标识列的表保持旧格式不动** —— 筛选概览的「环节/数量」、触发分布、`signal_feedback` 的 Grade 表、市场闸门表。它们通常 2~4 列、本来一行就读完,改它没有收益,只会放大 diff 并冒回归风险。

拍平逻辑被 **7 份生产报告共用**(`market_funnel` / `funnel_delivery` / `daily_job` / `review_list` / `sector_continuity` / `premarket_risk` / `single_symbol`),表宽从 2 列到 11 列。所以规则按列名通用匹配,**不对某张表硬编码**;我逐一预览了这些表形,11 列的 `funnel_delivery` 字段无丢失。

## 已在本分支实跑验证

触发美股漏斗(run `32329688138`,success):

```
[market-funnel] done ok=True market=us quotes=4989 selected=3500 fetched=3424 hits=87
[feishu] sent part 1/3, len=376, attempt=1
[feishu] sent part 2/3, len=2527, attempt=1
[feishu] sent part 3/3, len=1071, attempt=1
```

候选表那段(2527 字)已按新格式推送到飞书。

## 顺带修正既有测试

`test_normalize_lark_md_handles_multiple_tables_and_plain_text` 断言的正是被改掉的候选表旧格式,已更新为新期望。**保留了同一用例里触发分布表的旧断言**,当作「未改动路径」的守卫。

## 关于那个 1737.67

截图里 `RDAC.US` 分数 1737.67 比第二名 7.89 高两个数量级,看着像 bug。查过 `_sos_volume_ratio` 后确认:**score 是当日成交量与 60 日均量的比值**,1737 意味着量能是均量的 1737 倍,属于极端低流动性标的的真实读数,不是计算错误。本次不改,仅在 commit 里记录。

## Validation

- 新增 `tests/utils/test_feishu_table_flatten.py`(8 项:序号+名称成加粗标题、指标移到缩进第二行、占位行收成单句、11 列宽表字段不丢、无序号表保持旧格式、只有代码没有名称、缺尾列不崩、非表格内容不受影响)
- `pytest tests -q` → **3158 passed / 22 skipped**
- `ruff check .` / `ruff format --check .` → 通过
- `quality_gate.py --ci` → 无新增违规
- 已用真实美股 result 结构渲染完整卡片预览确认观感

🤖 Generated with [Claude Code](https://claude.com/claude-code)
