### PR TITLE
feat: 威科夫纯度检验——量化本仓与原版的偏离及其收益归因

### DIFF
--- a/.github/workflows/wyckoff_purity_eval.yml
+++ b/.github/workflows/wyckoff_purity_eval.yml
@@ -1,0 +1,66 @@
+name: Wyckoff Purity Eval
+
+# 威科夫纯度检验：原版事件覆盖率 + 原生事件 vs 均线叠加，跨 T+5/10/20/40。
+# 起因是一个理论质疑：威科夫原版没有均线概念，而本仓 core/ 里 bias_200 出现 81 次、
+# ma_long 92 次，同时原版吸筹阶段前四步（PS/SC/AR/ST）一次都没实现。
+#
+# 首轮（2026-08-20，498 个交易日 / 269 万行 / 5602 只）结论：偏离原版的方向是对的。
+#   SOS+MA200  T+5 +0.43(57%)  T+40 -0.68   ← 唯一正贡献，且只存在于 T+5
+#   Spring     T+5 -0.49(33%)  T+20 -1.06
+#   SC抛售高潮  T+5 -0.71       T+40 -3.83   ← 原版缺失事件，最差
+# 即「补全威科夫原版不会带来正收益」，42.9% 覆盖率不是缺陷。
+#
+# 每月重跑的意义在于盯住那个唯一的正 alpha 会不会衰减，而不是重复验证已知结论。
+on:
+  schedule:
+    # UTC 每月 1 日 03:10 = 北京时间当日 11:10。跨 2 年行情，跑一次约 25 分钟，故按月而非按周。
+    - cron: "10 3 1 * *"
+  workflow_dispatch:
+    inputs:
+      start:
+        description: "行情起始日（需留足 210 日预热）"
+        default: "2024-08-01"
+
+concurrency:
+  group: wyckoff-purity-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      PYTHONUNBUFFERED: "1"
+      # 只读行情，不写库；故不设 WYCKOFF_WRITE_CONTEXT。
+      TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      TZ: Asia/Shanghai
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Evaluate Wyckoff purity
+        run: |
+          python scripts/evaluate_wyckoff_purity.py --start "${{ github.event.inputs.start || '2024-08-01' }}"
+
+      - name: Upload evidence
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: wyckoff-purity-evidence
+          path: docs/evidence/wyckoff_purity.json
+          if-no-files-found: warn

--- a/core/wyckoff_purity_eval.py
+++ b/core/wyckoff_purity_eval.py
@@ -1,0 +1,163 @@
+"""威科夫纯度检验：原生事件 vs 均线叠加，跨多个持有期。
+
+起因是一个理论层面的质疑：威科夫原版方法里**没有均线概念**，而本仓 ``core/`` 里
+``bias_200`` 出现 81 次、``ma_long`` 92 次、``ma_short`` 71 次、``above_ma50`` 33 次，
+同时原版吸筹阶段的前四步——PS 初步支撑、SC 抛售高潮、AR 自动反弹、ST 二次测试——
+一次都没实现。所以问题是：偏离原版的这部分，是正收益还是负收益。
+
+2026-08-20 首轮跑数（498 个交易日 / 269 万行 / 5602 只，2024-08~2026-08）给出的答案是
+**偏离方向是对的，补全原版会更亏**：
+
+    事件                T+5      T+10     T+20     T+40
+    SOS              +0.36    -0.10    -0.57    -0.89
+    SOS+MA200        +0.43    -0.00    -0.41    -0.68   ← 唯一正贡献
+    LPS              +0.01    -0.05    -0.07    -0.31
+    Spring           -0.49    -0.66    -1.06    -0.81
+    SC 抛售高潮       -0.71    -1.43    -2.12    -3.83   ← 原版缺失的事件，最差
+
+三条结论：
+
+1. **唯一正 alpha 是 SOS + MA200 + T+5**（+0.43、57% 的交易日为正）——这恰是最不威科夫、
+   最趋势跟随、最短线的组合。且该 alpha 只存在于 T+5，T+10 即归零。
+2. **补全原版是负收益**：实测 SC 抛售高潮 T+40 超额 -3.83pct、绝对收益 -6.27%。
+   「抄底抛售高潮」在这两年 A 股明确亏钱。
+3. **拉长持有期不能救 Spring**：T+5 -0.49 → T+20 -1.06，越拉越差。曾假设「威科夫是
+   中长线方法所以 T+5 太短」，该假设被否。
+
+另需区分 beta 与 alpha：LPS 与 Spring 的**绝对收益**随持有期上升（LPS T+40 +1.14%），
+但超额为负——赚的是市场整体的钱，不是选股的钱。若目标是跑赢基准，它们无效。
+
+一处此前的误判也记在这里：用 107 天数据曾测出「纯 Spring -0.10、加 MA20 变 -1.57」，
+据此以为均线严重伤害 Spring。两年数据显示六档（纯/+MA20/+MA50/+MA200/+MA20&50/MA20下方）
+全在 -0.36~-0.47 之间、几乎无差别——那个 -1.57 是日均命中仅 11 只造成的噪声。
+**Spring 本身是负的，不是均线毁了它。**
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import mean
+from typing import Any
+
+HORIZONS: tuple[int, ...] = (5, 10, 20, 40)
+MIN_DAYS = 20
+MIN_GROUP = 5
+# 单次往返成本，用于判断增益是否值得落到参数改动。见 core/trade_friction.py。
+ROUND_TRIP_COST_PCT = 0.202
+# 为正日占比落在该区间内视为无方向性，避免把噪声当信号。
+RANDOM_BAND = (45.0, 55.0)
+
+# 原版吸筹阶段 A~E 的事件序列；标注哪些本仓已实现。
+WYCKOFF_CANON: tuple[tuple[str, str, bool], ...] = (
+    ("PS", "初步支撑", False),
+    ("SC", "抛售高潮", False),
+    ("AR", "自动反弹", False),
+    ("ST", "二次测试", False),
+    ("Spring", "弹簧/假跌破", True),
+    ("LPS", "最后支撑点", True),
+    ("SOS", "强势信号", True),
+)
+
+
+@dataclass
+class HorizonStat:
+    horizon: int
+    days: int
+    avg_hits: float
+    event_ret: float | None
+    market_ret: float | None
+    excess: float | None
+    positive_day_pct: float | None
+
+    @property
+    def verdict(self) -> str:
+        if self.days < MIN_DAYS or self.excess is None:
+            return "样本不足"
+        if self.positive_day_pct is not None and RANDOM_BAND[0] <= self.positive_day_pct <= RANDOM_BAND[1]:
+            return "无方向性"
+        return "正贡献" if self.excess > 0 else "负贡献"
+
+    @property
+    def beats_cost(self) -> bool:
+        """超额是否大于单次往返成本。不过门槛的正贡献不足以支撑参数改动。"""
+        return self.excess is not None and self.excess > ROUND_TRIP_COST_PCT
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "horizon": self.horizon,
+            "days": self.days,
+            "avg_hits": round(self.avg_hits, 1),
+            "event_ret": _round(self.event_ret),
+            "market_ret": _round(self.market_ret),
+            "excess": _round(self.excess),
+            "positive_day_pct": _round(self.positive_day_pct, 1),
+            "verdict": self.verdict,
+            "beats_cost": self.beats_cost,
+        }
+
+
+def _round(value: float | None, digits: int = 4) -> float | None:
+    return None if value is None else round(float(value), digits)
+
+
+@dataclass
+class EventCurve:
+    """一个事件在各持有期上的表现曲线。"""
+
+    name: str
+    is_canon: bool
+    stats: list[HorizonStat] = field(default_factory=list)
+
+    def at(self, horizon: int) -> HorizonStat | None:
+        return next((stat for stat in self.stats if stat.horizon == horizon), None)
+
+    @property
+    def best(self) -> HorizonStat | None:
+        usable = [stat for stat in self.stats if stat.excess is not None]
+        return max(usable, key=lambda stat: stat.excess) if usable else None
+
+    @property
+    def decays(self) -> bool:
+        """短周期为正、长周期转负——说明 alpha 是短期效应，不能靠拉长持有期放大。"""
+        short = self.at(HORIZONS[0])
+        long_ = self.at(HORIZONS[-1])
+        if short is None or long_ is None or short.excess is None or long_.excess is None:
+            return False
+        return short.excess > 0 > long_.excess
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "is_canon": self.is_canon,
+            "decays_with_horizon": self.decays,
+            "stats": [stat.as_dict() for stat in self.stats],
+        }
+
+
+def summarize_horizon(horizon: int, daily: list[dict[str, float]]) -> HorizonStat:
+    """按交易日等权汇总。个股多的日子不该主导均值。"""
+    usable = [row for row in daily if row.get("event") is not None and row.get("market") is not None]
+    if len(usable) < MIN_DAYS:
+        return HorizonStat(horizon, len(usable), 0.0, None, None, None, None)
+    diffs = [float(row["event"]) - float(row["market"]) for row in usable]
+    return HorizonStat(
+        horizon=horizon,
+        days=len(usable),
+        avg_hits=mean(float(row.get("hits") or 0) for row in usable),
+        event_ret=mean(float(row["event"]) for row in usable),
+        market_ret=mean(float(row["market"]) for row in usable),
+        excess=mean(diffs),
+        positive_day_pct=100.0 * sum(1 for value in diffs if value > 0) / len(diffs),
+    )
+
+
+def canon_coverage() -> dict[str, Any]:
+    """原版事件的实现覆盖率。回答「差了多少」这一半问题。"""
+    implemented = [code for code, _, done in WYCKOFF_CANON if done]
+    missing = [f"{code}({name})" for code, name, done in WYCKOFF_CANON if not done]
+    return {
+        "total": len(WYCKOFF_CANON),
+        "implemented": implemented,
+        "missing": missing,
+        "coverage_pct": round(100.0 * len(implemented) / len(WYCKOFF_CANON), 1),
+    }

--- a/scripts/evaluate_wyckoff_purity.py
+++ b/scripts/evaluate_wyckoff_purity.py
@@ -1,0 +1,237 @@
+"""威科夫纯度检验：跑数、落盘、推飞书。
+
+回答两个问题：
+1. 本仓与威科夫原版差了多少（原版事件覆盖率）。
+2. 差的那部分是正收益还是负收益（原生事件 vs 均线叠加，跨 T+5/10/20/40）。
+
+首轮（2026-08-20，498 个交易日 / 269 万行）：**偏离原版的方向是对的，补全会更亏**。
+唯一正 alpha 是 SOS+MA200+T+5（+0.43、57% 日为正），而原版缺失的 SC 抛售高潮
+T+40 超额 -3.83pct。详见 core/wyckoff_purity_eval.py 的模块文档。
+
+事件定义刻意用**朴素价量口径**而非复用生产代码：生产的 spring/sos 判定本身已内嵌均线与
+评分，用它测「均线的影响」会循环论证。这里的定义只依赖高低点、收盘位置与量比。
+
+用法::
+
+    python scripts/evaluate_wyckoff_purity.py --start 2024-08-01
+    python scripts/evaluate_wyckoff_purity.py --start 2025-06-01 --no-notify
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+import pandas as pd
+
+from core.wyckoff_purity_eval import (
+    HORIZONS,
+    MIN_GROUP,
+    ROUND_TRIP_COST_PCT,
+    EventCurve,
+    canon_coverage,
+    summarize_horizon,
+)
+
+WARMUP = 210
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="威科夫纯度检验")
+    parser.add_argument("--start", default="2024-08-01", help="行情起始（需留足 210 日预热）")
+    parser.add_argument("--out", default="docs/evidence", help="产物目录")
+    parser.add_argument("--no-notify", action="store_true", help="不推飞书")
+    return parser.parse_args()
+
+
+def load_market(start: str) -> pd.DataFrame:
+    from integrations.fetch_a_share_csv import cached_trade_dates
+    from integrations.tushare_client import get_pro
+
+    pro = get_pro()
+    if pro is None:
+        raise SystemExit("需要 TUSHARE_TOKEN")
+    end = pd.Timestamp.now().strftime("%Y-%m-%d")
+    days = [str(day) for day in cached_trade_dates() if start <= str(day) <= end]
+    frames = []
+    for day in days:
+        try:
+            frame = pro.daily(trade_date=day.replace("-", ""), fields="ts_code,trade_date,high,low,close,vol")
+            if frame is not None and not frame.empty:
+                frames.append(frame)
+        except Exception as exc:  # noqa: BLE001 - 单日失败不中断整体检验
+            print(f"[purity] {day} 取数失败: {str(exc)[:60]}")
+    if not frames:
+        raise SystemExit("未取到行情")
+    market = pd.concat(frames)
+    market["d"] = pd.to_datetime(market.trade_date, format="%Y%m%d")
+    return market.sort_values(["ts_code", "d"])
+
+
+def _event_masks(frame: pd.DataFrame) -> dict[str, pd.Series]:
+    """朴素价量口径的威科夫事件。不引用生产判定，避免循环论证。"""
+    vol_ratio = frame.v / frame.v20
+    above200 = frame.c > frame.ma200
+    spring = (frame.lowday <= frame.lo20 * 1.002) & (frame.c > frame.lo20) & (frame.cpos >= 50)
+    sos = (frame.c >= frame.hi20 * 0.999) & (vol_ratio >= 1.5)
+    lps = (frame.c > frame.lo20 * 1.02) & (frame.c < frame.hi20 * 0.97) & (vol_ratio <= 0.8)
+    # 原版缺失的两个事件，补测其是否值得实现。
+    selling_climax = (frame.lowday <= frame.lo60 * 1.002) & (vol_ratio >= 2.0) & (frame.cpos >= 40)
+    secondary_test = (frame.lowday <= frame.lo60 * 1.05) & (frame.lowday > frame.lo60) & (vol_ratio <= 0.7)
+    return {
+        "Spring": spring,
+        "SOS": sos,
+        "LPS": lps,
+        "SC抛售高潮(原版缺失)": selling_climax,
+        "ST二次测试(原版缺失)": secondary_test,
+        "SOS+MA200": sos & above200,
+        "Spring+MA200下方": spring & ~above200,
+    }
+
+
+def build_curves(market: pd.DataFrame) -> list[EventCurve]:
+    close = market.pivot_table(index="d", columns="ts_code", values="close")
+    high = market.pivot_table(index="d", columns="ts_code", values="high")
+    low = market.pivot_table(index="d", columns="ts_code", values="low")
+    volume = market.pivot_table(index="d", columns="ts_code", values="vol")
+    dates = list(close.index)
+    sink: dict[str, dict[int, list[dict[str, float]]]] = {}
+
+    for i in range(WARMUP, len(dates) - max(HORIZONS)):
+        spot = close.iloc[i]
+        day_range = high.iloc[i] - low.iloc[i]
+        frame = pd.DataFrame(
+            {
+                "c": spot,
+                "ma200": close.iloc[i - 199 : i + 1].mean(),
+                "lo20": low.iloc[i - 19 : i + 1].min(),
+                "hi20": high.iloc[i - 19 : i + 1].max(),
+                "lo60": low.iloc[i - 59 : i + 1].min(),
+                "lowday": low.iloc[i],
+                "v": volume.iloc[i],
+                "v20": volume.iloc[i - 19 : i + 1].mean(),
+                "cpos": (spot - low.iloc[i]) / day_range.where(day_range > 0) * 100.0,
+            }
+        ).dropna()
+        frame = frame[(frame.c > 0) & (frame.ma200 > 0) & (frame.lo20 > 0) & (frame.lo60 > 0) & (frame.v20 > 0)]
+        if len(frame) < 100:
+            continue
+        masks = _event_masks(frame)
+        for horizon in HORIZONS:
+            forward = (close.iloc[i + horizon] / frame.c - 1.0) * 100.0
+            scoped = frame.assign(fwd=forward).dropna(subset=["fwd"])
+            if len(scoped) < 100:
+                continue
+            market_ret = float(scoped.fwd.mean())
+            for name, mask in masks.items():
+                hit = scoped[mask.reindex(scoped.index, fill_value=False)]
+                if len(hit) < MIN_GROUP:
+                    continue
+                sink.setdefault(name, {}).setdefault(horizon, []).append(
+                    {"event": float(hit.fwd.mean()), "market": market_ret, "hits": float(len(hit))}
+                )
+
+    curves = []
+    for name, per_horizon in sink.items():
+        curve = EventCurve(name=name, is_canon="原版缺失" not in name and "+" not in name)
+        curve.stats = [summarize_horizon(h, per_horizon.get(h, [])) for h in HORIZONS]
+        curves.append(curve)
+    return curves
+
+
+def render(curves: list[EventCurve], coverage: dict) -> str:
+    lines = [
+        "**威科夫纯度检验**",
+        "",
+        f"**原版事件覆盖** {coverage['coverage_pct']}%（{len(coverage['implemented'])}/{coverage['total']}）　"
+        f"已实现：{'、'.join(coverage['implemented'])}",
+        f"**未实现**：{'、'.join(coverage['missing'])}",
+        "",
+        "| 事件 | " + " | ".join(f"T+{h}" for h in HORIZONS) + " | 衰减 |",
+        "| --- | " + " | ".join("--:" for _ in HORIZONS) + " | --- |",
+    ]
+    for curve in sorted(curves, key=lambda c: -(c.best.excess if c.best and c.best.excess else -9)):
+        cells = []
+        for horizon in HORIZONS:
+            stat = curve.at(horizon)
+            if stat is None or stat.excess is None:
+                cells.append("—")
+            else:
+                cells.append(f"{stat.excess:+.2f}({stat.positive_day_pct:.0f}%)")
+        lines.append(f"| {curve.name} | " + " | ".join(cells) + f" | {'是' if curve.decays else '否'} |")
+    lines += [
+        "",
+        "**读法**　单元格为「超额pct(为正交易日占比)」。超额已扣同日全市场均值。",
+        "",
+        "**接下来做什么**",
+        *_actions(curves, coverage),
+    ]
+    return "\n".join(lines)
+
+
+def _actions(curves: list[EventCurve], coverage: dict) -> list[str]:
+    out = []
+    winners = [c for c in curves if c.best and c.best.excess and c.best.excess > 0]
+    if winners:
+        top = max(winners, key=lambda c: c.best.excess)
+        stat = top.best
+        cost_note = "已过成本门槛" if stat.beats_cost else f"**未过成本门槛 {ROUND_TRIP_COST_PCT}%**"
+        out.append(
+            f"- ① 最佳组合 `{top.name}` 在 T+{stat.horizon} 超额 {stat.excess:+.2f}pct"
+            f"（{stat.positive_day_pct:.0f}% 日为正），{cost_note}。"
+        )
+        decaying = [c.name for c in winners if c.decays]
+        if decaying:
+            out.append(f"- ② 以下事件的 alpha 随持有期衰减，**不要靠拉长持有期放大**：{'、'.join(decaying)}。")
+    canon_missing = [c for c in curves if "原版缺失" in c.name and c.best and c.best.excess is not None]
+    negatives = [c.name for c in canon_missing if c.best.excess < 0]
+    if negatives:
+        out.append(
+            f"- ③ 原版缺失事件实测为负贡献：{'、'.join(negatives)}——"
+            f"**补全威科夫原版不会带来正收益**，当前 {coverage['coverage_pct']}% 覆盖率不是缺陷。"
+        )
+    out.append(
+        "- ④ 任何据此改动都需增益大于往返成本 0.202%，且跨越多个行情段后方向稳定；"
+        "注意区分 beta 与 alpha——绝对收益为正而超额为负意味着只赚了市场的钱。"
+    )
+    return out
+
+
+def main() -> int:
+    args = parse_args()
+    market = load_market(args.start)
+    print(f"[purity] 行情 {len(market):,} 行 / {market.ts_code.nunique()} 只")
+    curves = build_curves(market)
+    coverage = canon_coverage()
+    payload = {
+        "canon_coverage": coverage,
+        "horizons": list(HORIZONS),
+        "curves": [curve.as_dict() for curve in curves],
+        "round_trip_cost_pct": ROUND_TRIP_COST_PCT,
+    }
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "wyckoff_purity.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    text = render(curves, coverage)
+    print(text)
+    if not args.no_notify:
+        _notify(text)
+    return 0
+
+
+def _notify(markdown: str) -> None:
+    webhook = os.getenv("FEISHU_WEBHOOK_URL", "").strip()
+    if not webhook:
+        print("[purity] 未配置 FEISHU_WEBHOOK_URL，跳过推送")
+        return
+    from utils.feishu import send_feishu_notification
+
+    title = f"威科夫纯度检验｜{pd.Timestamp.now().strftime('%Y-%m-%d')}"
+    print("[purity] feishu sent" if send_feishu_notification(webhook, title, markdown) else "[purity] feishu failed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_wyckoff_purity_eval.py
+++ b/tests/core/test_wyckoff_purity_eval.py
@@ -1,0 +1,120 @@
+"""Tests for Wyckoff purity evaluation.
+
+守两类结论，防止以后被误读：
+- 原版覆盖率只是事实陈述，不是缺陷指标（实测补全为负收益）。
+- alpha 随持有期衰减必须被识别出来，否则会有人试图靠拉长持有期放大它。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.wyckoff_purity_eval import (
+    HORIZONS,
+    MIN_DAYS,
+    ROUND_TRIP_COST_PCT,
+    WYCKOFF_CANON,
+    EventCurve,
+    HorizonStat,
+    canon_coverage,
+    summarize_horizon,
+)
+
+
+def _daily(pairs: list[tuple[float, float]], hits: float = 20.0) -> list[dict[str, float]]:
+    return [{"event": a, "market": b, "hits": hits} for a, b in pairs]
+
+
+def _stat(horizon: int, excess: float, positive: float = 60.0, days: int = 200) -> HorizonStat:
+    return HorizonStat(horizon, days, 30.0, excess, 0.0, excess, positive)
+
+
+class TestSummarizeHorizon:
+    def test_requires_minimum_days(self):
+        stat = summarize_horizon(5, _daily([(1.0, 0.0)] * (MIN_DAYS - 1)))
+        assert stat.verdict == "样本不足"
+        assert stat.excess is None
+
+    def test_equal_weights_days_not_symbols(self):
+        """按交易日等权：命中个股多的日子不该主导均值。"""
+        rows = [{"event": 10.0, "market": 0.0, "hits": 5000.0}, *_daily([(0.0, 0.0)] * (MIN_DAYS - 1))]
+        assert summarize_horizon(5, rows).excess == pytest.approx(10.0 / MIN_DAYS)
+
+    def test_near_random_has_no_direction(self):
+        pairs = [(1.0, 0.0), (-1.0, 0.0)] * (MIN_DAYS // 2)
+        stat = summarize_horizon(5, _daily(pairs))
+        assert stat.positive_day_pct == pytest.approx(50.0)
+        assert stat.verdict == "无方向性"
+
+    def test_negative_verdict(self):
+        stat = summarize_horizon(5, _daily([(-1.0, 0.0)] * MIN_DAYS))
+        assert stat.verdict == "负贡献"
+
+    def test_skips_rows_missing_a_side(self):
+        rows = _daily([(1.0, 0.0)] * MIN_DAYS) + [{"event": None, "market": 0.0, "hits": 1.0}]
+        assert summarize_horizon(5, rows).days == MIN_DAYS
+
+
+class TestCostThreshold:
+    def test_small_positive_does_not_beat_cost(self):
+        """+0.1pct 的超额撑不过 0.202% 往返成本，不该被当成可落地的改动依据。"""
+        assert _stat(5, 0.1).beats_cost is False
+
+    def test_large_positive_beats_cost(self):
+        assert _stat(5, 0.43).beats_cost is True
+
+    def test_none_excess_does_not_beat_cost(self):
+        assert HorizonStat(5, 0, 0.0, None, None, None, None).beats_cost is False
+
+
+class TestEventCurve:
+    def test_detects_decay(self):
+        """短周期为正、长周期转负 → 判定为衰减。SOS 实测就是这个形态。"""
+        curve = EventCurve("SOS", True, [_stat(5, 0.36), _stat(10, -0.10), _stat(20, -0.57), _stat(40, -0.89)])
+        assert curve.decays is True
+
+    def test_persistent_negative_is_not_decay(self):
+        """Spring 各周期全负，属持续为负而非衰减，两者含义不同。"""
+        curve = EventCurve("Spring", True, [_stat(h, -0.5) for h in HORIZONS])
+        assert curve.decays is False
+
+    def test_best_picks_highest_excess(self):
+        curve = EventCurve("x", True, [_stat(5, 0.1), _stat(10, 0.43), _stat(20, -0.2), _stat(40, -0.5)])
+        assert curve.best.horizon == 10
+
+    def test_best_is_none_without_usable_stats(self):
+        curve = EventCurve("x", True, [HorizonStat(h, 0, 0.0, None, None, None, None) for h in HORIZONS])
+        assert curve.best is None
+        assert curve.decays is False
+
+    def test_serializable(self):
+        import json
+
+        curve = EventCurve("SOS", True, [_stat(5, 0.36), _stat(40, -0.89)])
+        payload = json.loads(json.dumps(curve.as_dict(), ensure_ascii=False))
+        assert payload["decays_with_horizon"] is True
+        assert payload["stats"][0]["beats_cost"] is True
+
+
+class TestCanonCoverage:
+    def test_reports_missing_phase_a_events(self):
+        """原版吸筹阶段 A 的四个事件（PS/SC/AR/ST）本仓均未实现。"""
+        coverage = canon_coverage()
+        missing = " ".join(coverage["missing"])
+        for code in ("PS", "SC", "AR", "ST"):
+            assert code in missing
+
+    def test_implemented_are_the_late_stage_events(self):
+        coverage = canon_coverage()
+        assert set(coverage["implemented"]) == {"Spring", "LPS", "SOS"}
+
+    def test_coverage_pct_matches_canon(self):
+        coverage = canon_coverage()
+        expected = round(100.0 * sum(1 for _, _, done in WYCKOFF_CANON if done) / len(WYCKOFF_CANON), 1)
+        assert coverage["coverage_pct"] == expected
+
+    def test_cost_constant_is_aligned_with_friction_model(self):
+        """成本门槛须与 core.trade_friction 的实测往返成本一致。"""
+        from core.trade_friction import round_trip_cost_pct
+
+        assert ROUND_TRIP_COST_PCT == pytest.approx(round_trip_cost_pct(), abs=0.01)


### PR DESCRIPTION
## Summary / 变更摘要

起因是一个**理论层面的质疑**：威科夫原版方法**没有均线概念**，而本仓 `core/` 里 `bias_200` 出现 81 次、`ma_long` 92 次、`ma_short` 71 次、`above_ma50` 33 次；同时原版吸筹阶段前四步 **PS/SC/AR/ST 一次都没实现**（覆盖率 3/7 = **42.9%**）。

问题是：偏离原版的这部分，是正收益还是负收益。

## 答案：偏离方向是对的，补全原版会更亏

498 个交易日 / 269 万行 / 5602 只（2024-08~2026-08），超额已扣同日全市场：

| 事件 | T+5 | T+10 | T+20 | T+40 | 衰减 |
| --- | --: | --: | --: | --: | --- |
| **SOS+MA200** | **+0.43(57%)** | −0.00(49%) | −0.41(47%) | −0.68(47%) | 是 |
| SOS | +0.36(56%) | −0.10(47%) | −0.57(47%) | −0.89(45%) | 是 |
| LPS | +0.01(53%) | −0.05(50%) | −0.07(49%) | −0.31(44%) | 是 |
| ST二次测试（原版缺失） | −0.32(36%) | −0.64 | −1.04 | −1.38 | 否 |
| Spring | −0.49(33%) | −0.66 | −1.06 | −0.81 | 否 |
| **SC抛售高潮（原版缺失）** | −0.71(41%) | −1.43 | −2.12 | **−3.83** | 否 |

**三条结论：**

1. **唯一正 alpha 是 SOS+MA200+T+5**（+0.43、57% 日为正，已过 0.202% 成本门槛）—— 这恰是**最不威科夫、最趋势跟随、最短线**的组合，且该 alpha 只存在于 T+5，T+10 即归零。
2. **补全原版是负收益**：SC 抛售高潮 T+40 超额 −3.83pct、绝对收益 −6.27%。「抄底抛售高潮」在这两年 A 股明确亏钱。故 **42.9% 覆盖率不是缺陷**。
3. **拉长持有期不能救 Spring**：T+5 −0.49 → T+20 −1.06，越拉越差。曾假设「威科夫是中长线方法所以 T+5 太短」，该假设被否。

另需区分 **beta 与 alpha**：LPS 与 Spring 的**绝对收益**随持有期上升（LPS T+40 +1.14%）但超额为负 —— 赚的是市场整体的钱。若目标是跑赢基准则无效，渲染层已提示这一点。

## 顺带更正一处此前的误判

曾用 107 天数据测出「纯 Spring −0.10、加 MA20 变 **−1.57**」，据此以为均线严重伤害 Spring。

两年数据显示六档（纯 / +MA20 / +MA50 / +MA200 / +MA20&50 / MA20下方）**全在 −0.36~−0.47、几乎无差别** —— 那个 −1.57 是日均命中仅 11 只造成的噪声。**Spring 本身是负的，不是均线毁了它。**

## 均线在生产代码中的真实角色（盘点后不改任何参数）

| 位置 | 均线用法 | 是否符合威科夫 |
| --- | --- | --- |
| `layer2_strength.py:260` ambush 潜伏通道 | `\|bias_200\| <= 8%`（贴近年线） | ✅ 潜伏期就该在年线附近 |
| `layer2_strength.py:277` accum 吸筹通道 | 短长均线间距 `<= 8%`（收敛） | ✅ 均线纠缠是横盘特征 |
| `wyckoff_engine.py:2110、2140` alpha/breakout | `above_ma50` **硬门槛** | 这类恰是唯一正贡献的 |

底部结构通道要求的是「贴近/收敛」而非「站上」，**均线没有污染底部判定**。硬门槛只守突破类信号。故本次**不改任何生产参数**。

## 实现要点

事件定义刻意用**朴素价量口径**（高低点/收盘位置/量比）而非复用生产判定 —— 生产的 `spring`/`sos` 已内嵌均线与评分，用它测「均线的影响」会**循环论证**。

GitHub Action 每月 1 日北京时间 **11:10** 运行（跨 2 年行情单次约 25 分钟，故按月而非按周），只读行情不写库。重跑目的是**盯住那个唯一正 alpha 会不会衰减**。

## Validation / 验证

- `pytest tests/` — **3184 passed, 22 skipped**（新增 17 个用例：按交易日等权而非按个股数加权、无方向性判定、+0.1pct 不过成本门槛、衰减识别须区分「短正长负」与「持续为负」、原版缺失事件必须被点名、成本常量须与 `core.trade_friction` 实测值一致）
- `ruff check .` / `ruff format --check .`、`quality_gate --check-functions`、`check_workflow_hygiene`
- 脚本已在真实行情上跑通并产出 `docs/evidence/wyckoff_purity.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)