### PR TITLE
docs: 增加策略结论的证据要求，防止手写近似口径误导参数改动

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,43 @@ pnpm --filter @wyckoff/api test
 
 6. **No debug artifacts** — Don't commit `console.log`, `breakpoint()`, `TODO/FIXME`, temporary dumps, or `print("debug")`-style traces. In `core/`, `integrations/`, `tools/`, and `agents/`, use logging instead of print-style diagnostics. In `scripts/` and `cli/`, user-facing progress/output via `print()` is allowed.
 
+## Strategy Evidence Rules (策略结论的证据要求)
+
+These exist because ad-hoc reimplementations of production signal logic produced three
+wrong conclusions in a single day (2026-08-20): the dry-volume channel was nearly deleted
+based on a hand-rolled "20-day min volume / 60-day mean" proxy when production uses a
+250-day quantile; Spring was judged MA-damaged from an 11-symbol/day sample; and SOS was
+reported at +0.43pct excess when a consistent-universe rerun showed −0.80pct. Each time
+the error direction favored acting. So:
+
+1. **Never hand-roll a proxy for production signal logic** — To evaluate a gate or signal,
+   drive it through the production path (`scripts/backtest_runner.py`, `core/backtest_replay.py`,
+   `scripts/diagnose_funnel_recall.py`) so the tested definition is the shipped definition.
+   If a proxy is unavoidable, state it as a proxy in the output and never let it justify a
+   parameter change on its own.
+
+2. **Report net of cost, and state the universe** — Gross excess is not a result. Subtract
+   `core.trade_friction.round_trip_cost_pct()` (currently ~0.202% A-share round trip) and
+   print the per-day candidate count. A conclusion whose gain is smaller than the cost is
+   not actionable no matter how clean the sign.
+
+3. **Watch for survivorship from `dropna`** — Joining many indicator columns silently drops
+   symbols that lack any one of them, and the dropped set is usually not random. Log the
+   surviving universe size per day; if two runs of the "same" rule differ several-fold in
+   hit count, treat both as void until reconciled.
+
+4. **Beta is not alpha** — Absolute return rising with holding period while excess stays
+   negative means the signal is only capturing market drift. Say so explicitly rather than
+   quoting the absolute number.
+
+5. **One segment is not evidence** — A single market phase (e.g. a rally) cannot establish
+   a directional claim. Require the sign to hold across regimes, or label the finding as
+   segment-specific. `45%–55%` of days positive is noise, not direction.
+
+6. **Prefer "no change" when the evidence is self-contradictory** — Reversing an earlier
+   measurement is normal; acting on the reversal within the same session is not. Record the
+   correction, keep production as-is, and let the scheduled evaluators accumulate samples.
+
 ## Gate Levels
 
 - **Fast gate (local/default)**: `.venv/bin/ruff check .`, `.venv/bin/ruff format --check .`, `.venv/bin/python scripts/quality_gate.py --check-functions`, and focused tests for touched code.


### PR DESCRIPTION
## Summary / 变更摘要

2026-08-20 一天内因「**不读生产实现就自造近似口径**」得出三个错误结论，而且三次的错误方向都偏向「应该动手改」：

| # | 错误结论 | 真实情况 |
| --- | --- | --- |
| 1 | 地量蓄势通道该删（自造口径测出全负） | 生产真实定义是 **250 日分位数**，按真实口径四档全为正超额，放宽反而更优 |
| 2 | Spring 被均线严重伤害（−1.57pct） | 该组合只有 **11 只/天**；两年数据六档全在 −0.36~−0.47、几乎无差别 |
| 3 | SOS 是唯一正 alpha（+0.43pct） | 一致口径重跑是 **−0.80pct**，日均命中从 34 变 195 —— `dropna` 造成幸存者偏差 |

**第 3 条最危险**：差点据此建议把候选从 1,997 只/天收窄到 **23 只**，把仓位集中押在一个实际为负的形态上。

## 新增六条约束

核心是**用生产路径测生产逻辑**：

1. **禁止为生产信号逻辑手写近似实现** —— 改用 `backtest_runner.py` / `backtest_replay.py` / `diagnose_funnel_recall.py` 驱动，让被测定义就是上线定义。不得已用近似时必须在产出里标注，且不能单独作为改参依据。
2. **结论必须扣成本并给出日均候选数** —— 扣 `core.trade_friction.round_trip_cost_pct()`（现约 0.202%）。增益小于成本即不可行动，符号再干净也一样。
3. **警惕 `dropna` 造成的幸存者偏差** —— 多列 join 会静默丢弃缺任一指标的标的，且被丢弃的通常不随机。逐日记录存活标的数；同一规则两次跑数命中量差数倍则双方作废。
4. **区分 beta 与 alpha** —— 绝对收益随持有期上升而超额为负，只是吃到市场漂移，必须明说而非引用绝对值。
5. **单一行情段不构成证据** —— 要求符号跨行情段稳定，否则标注为段内结论。为正日占比 45%~55% 属噪声而非方向。
6. **证据自相矛盾时优先「不改」** —— 修正测量是正常的，当场按修正结果行动不是。记录修正、保持生产现状，交由定时评估器积累样本。

`CLAUDE.md` 已指向 `AGENTS.md`，故该约束对后续会话生效。

## 为什么放进 AGENTS.md 而不是某个脚本注释

这三次错误不是某个脚本的 bug，是**方法论问题**——同一个模式会在任何新分析里重现。放进项目规范才能约束到后续所有会话。

🤖 Generated with [Claude Code](https://claude.com/claude-code)