### PR TITLE
refactor(layer2): 暗中护盘量能阈值提取为可配置字段，行为不变

### DIFF
--- a/core/layer2_strength.py
+++ b/core/layer2_strength.py
@@ -670,7 +670,10 @@ def _rs_divergence_volume_ok(df_sorted: pd.DataFrame, bench_sorted: pd.DataFrame
     stock_ref_vol = stock_vol.tail(cfg.rs_div_bench_ref_window).iloc[: -cfg.rs_div_stock_window].mean()
     if bench_ref_vol <= 0 or stock_ref_vol <= 0:
         return True
-    return bench_recent_vol > bench_ref_vol * 1.2 and stock_recent_vol < stock_ref_vol * 0.8
+    expand = float(getattr(cfg, "rs_div_bench_vol_expand_ratio", 1.2))
+    shrink = float(getattr(cfg, "rs_div_stock_vol_shrink_ratio", 0.8))
+    # 显式转 bool：pandas 聚合返回 numpy.bool_，会让调用方的 `is True` 判断意外失败。
+    return bool(bench_recent_vol > bench_ref_vol * expand and stock_recent_vol < stock_ref_vol * shrink)
 
 
 def _breakout_volume_ok(df_sorted: pd.DataFrame, cfg: Any) -> bool:

--- a/core/wyckoff_engine.py
+++ b/core/wyckoff_engine.py
@@ -195,6 +195,18 @@ class FunnelConfig:
     rs_div_stock_window: int = 20  # 个股同期窗口
     rs_div_bench_ref_window: int = 60  # 大盘新低对比的参考窗口（近 60 日）
     rs_div_price_from_low_max: float = 0.50  # 位阶保护：现价 <= 年内低点 +50%
+    # 量能分歧判据：大盘放量而个股缩量。此前这两个系数硬编码在
+    # core/layer2_strength.py 的 _rs_divergence_volume_ok 里，既不能调也不能关。
+    #
+    # 实测（两年 / 100 个大盘创 60 日新低的交易日）：大盘近 20 日均量 > 前 40 日均量 ×1.2
+    # 的满足天数为 **0 天（0.0%）**，导致「暗中护盘」通道在生产回测 66 个交易日里命中恒为 0。
+    # 原因是指数成交量是 5000+ 只股票的加总，20 日尺度上被平滑，不会像个股那样放量 20%；
+    # 该阈值对个股合理、对指数不合理。
+    #
+    # 本次仅提取为可配置字段，默认值保持 1.2 / 0.8 不变（即通道仍失效），
+    # 以便后续单独扫描合理档位——先让它可调，再依证据定值。
+    rs_div_bench_vol_expand_ratio: float = 1.2  # 大盘放量倍数下限
+    rs_div_stock_vol_shrink_ratio: float = 0.8  # 个股缩量倍数上限
 
     # Layer 2 趋势延续通道（Trend Continuation Channel）
     # 已确认多头且 RPS 极强的趋势股，不受 bias_200 上限约束。

--- a/tests/core/test_rs_divergence_volume_thresholds.py
+++ b/tests/core/test_rs_divergence_volume_thresholds.py
@@ -1,0 +1,106 @@
+"""Tests for the RS-divergence volume thresholds extracted from hardcoded literals.
+
+背景：`_rs_divergence_volume_ok` 原先把 1.2 / 0.8 硬编码在函数体里，既不能调也不能关。
+实测（两年 / 100 个大盘创 60 日新低的交易日）大盘近 20 日均量 > 前 40 日均量 ×1.2 的
+满足天数为 **0 天**，导致「暗中护盘」通道在生产回测 66 个交易日里命中恒为 0——指数成交量
+是 5000+ 只股票的加总，20 日尺度被平滑，不会像个股那样放量 20%。
+
+本次仅提取为可配置字段，**默认值保持不变**（通道仍失效），故这些用例的第一职责是
+守住「重构不改行为」，第二职责是证明新字段真的能调。
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pandas as pd
+import pytest
+
+from core.layer2_strength import _rs_divergence_volume_ok
+from core.wyckoff_engine import FunnelConfig
+
+
+def _frames(bench_change: float, stock_change: float, ref_len: int = 40, recent_len: int = 20):
+    """构造前 ref_len 日基准量 100、近 recent_len 日按给定比例变化的量能序列。"""
+    bench = pd.DataFrame({"volume": [100.0] * ref_len + [100.0 * bench_change] * recent_len})
+    stock = pd.DataFrame({"volume": [100.0] * ref_len + [100.0 * stock_change] * recent_len})
+    return stock, bench
+
+
+class TestDefaultsUnchanged:
+    def test_field_defaults_match_previous_literals(self):
+        cfg = FunnelConfig()
+        assert cfg.rs_div_bench_vol_expand_ratio == pytest.approx(1.2)
+        assert cfg.rs_div_stock_vol_shrink_ratio == pytest.approx(0.8)
+
+    def test_bench_expand_and_stock_shrink_passes(self):
+        stock, bench = _frames(1.3, 0.7)
+        assert _rs_divergence_volume_ok(stock, bench, FunnelConfig()) is True
+
+    def test_bench_expand_below_threshold_fails(self):
+        """大盘只放量 10% —— 这正是实盘 100% 的触发日所处的区间。"""
+        stock, bench = _frames(1.1, 0.7)
+        assert _rs_divergence_volume_ok(stock, bench, FunnelConfig()) is False
+
+    def test_stock_not_shrinking_enough_fails(self):
+        stock, bench = _frames(1.3, 0.9)
+        assert _rs_divergence_volume_ok(stock, bench, FunnelConfig()) is False
+
+    def test_boundary_is_strict_on_bench(self):
+        """恰好等于 1.2 倍应判否（原实现用 > 而非 >=），重构不得放宽。"""
+        stock, bench = _frames(1.2, 0.7)
+        assert _rs_divergence_volume_ok(stock, bench, FunnelConfig()) is False
+
+    def test_boundary_is_strict_on_stock(self):
+        """恰好等于 0.8 倍应判否（原实现用 < 而非 <=）。"""
+        stock, bench = _frames(1.3, 0.8)
+        assert _rs_divergence_volume_ok(stock, bench, FunnelConfig()) is False
+
+
+class TestNowConfigurable:
+    def test_lowering_bench_ratio_admits_realistic_index_volume(self):
+        """把大盘阈值降到 1.05 后，+10% 的现实指数放量即可通过——证明字段生效。"""
+        stock, bench = _frames(1.1, 0.7)
+        cfg = replace(FunnelConfig(), rs_div_bench_vol_expand_ratio=1.05)
+        assert _rs_divergence_volume_ok(stock, bench, cfg) is True
+
+    def test_raising_stock_ratio_admits_milder_shrink(self):
+        stock, bench = _frames(1.3, 0.9)
+        cfg = replace(FunnelConfig(), rs_div_stock_vol_shrink_ratio=0.95)
+        assert _rs_divergence_volume_ok(stock, bench, cfg) is True
+
+    def test_both_ratios_independent(self):
+        stock, bench = _frames(1.1, 0.9)
+        loosened = replace(FunnelConfig(), rs_div_bench_vol_expand_ratio=1.05, rs_div_stock_vol_shrink_ratio=0.95)
+        assert _rs_divergence_volume_ok(stock, bench, loosened) is True
+        # 只放宽一侧仍应被另一侧拦住。
+        assert (
+            _rs_divergence_volume_ok(stock, bench, replace(FunnelConfig(), rs_div_bench_vol_expand_ratio=1.05)) is False
+        )
+
+    def test_missing_attrs_fall_back_to_previous_literals(self):
+        """getattr 回退：传入不带新字段的配置对象时仍按 1.2/0.8 行为。"""
+
+        class Legacy:
+            rs_div_bench_window = 20
+            rs_div_bench_ref_window = 60
+            rs_div_stock_window = 20
+
+        stock, bench = _frames(1.3, 0.7)
+        assert _rs_divergence_volume_ok(stock, bench, Legacy()) is True
+        stock2, bench2 = _frames(1.1, 0.7)
+        assert _rs_divergence_volume_ok(stock2, bench2, Legacy()) is False
+
+
+class TestDegenerateInputs:
+    def test_empty_volume_passes_through(self):
+        """量能缺失时不应因此否决——保持原实现的宽松回退。"""
+        empty = pd.DataFrame({"volume": []})
+        stock, _ = _frames(1.3, 0.7)
+        assert _rs_divergence_volume_ok(stock, empty, FunnelConfig()) is True
+        assert _rs_divergence_volume_ok(empty, stock, FunnelConfig()) is True
+
+    def test_zero_reference_volume_passes_through(self):
+        bench = pd.DataFrame({"volume": [0.0] * 40 + [130.0] * 20})
+        stock = pd.DataFrame({"volume": [0.0] * 40 + [70.0] * 20})
+        assert _rs_divergence_volume_ok(stock, bench, FunnelConfig()) is True


### PR DESCRIPTION
## Summary / 变更摘要

定位到「暗中护盘」通道在生产回测 **66 个交易日里命中恒为 0** 的根因。

`core/layer2_strength.py` 的 `_rs_divergence_volume_ok` 末行硬编码：

```python
return bench_recent_vol > bench_ref_vol * 1.2 and stock_recent_vol < stock_ref_vol * 0.8
```

即要求**大盘近 20 日均量 > 前 40 日均量 ×1.2**（放量 20%+）。

**实测两年、100 个大盘创 60 日新低的交易日，满足该条件的是 0 天（0.0%）。**

原因是指数成交量为 5000+ 只股票的加总，在 20 日尺度上被平滑，不会像个股那样放量 20% —— **该阈值对个股合理、对指数不合理**。

而这两个系数**不在 `FunnelConfig` 里**（原先只有 4 个 `rs_div_*` 字段：`bench_window` / `bench_ref_window` / `stock_window` / `price_from_low_max`），所以这条门槛既不能调也不能关。

## 本次只做提取，不改行为

新增两个字段，**默认值与原字面量一致，通道行为不变**（仍失效）：

| 字段 | 默认值 |
| --- | ---: |
| `rs_div_bench_vol_expand_ratio` | 1.2 |
| `rs_div_stock_vol_shrink_ratio` | 0.8 |

先让它可调，再依证据定值 —— 合理档位需单独扫描，且按 `AGENTS.md` 规则 7 需与流动性门槛改动一起做**组合验证**，故不在本 PR 改默认值。

顺带修一处隐患：该函数原先返回 `numpy.bool_`（pandas 聚合结果），会让调用方的 `is True` 判断意外失败；现显式转 `bool`。

## 排查过程中的两次自我更正（记录以免重犯）

先用**末日单点**算 `_bench_made_lower_low` 得 `False`，据此判定「非 bug，只是行情不符」—— 但**回测是逐日滚动的**，滚动口径下区间内有 25 天满足，2026-08-13 即触发日。在该日复测才定位到卡点在**量能条件**而非大盘新低条件。

## Validation / 验证

- `pytest tests/` — **3225 passed, 22 skipped**（新增 12 个用例：四个默认值与原字面量一致、大盘放量不足/个股缩量不足分别判否、两侧边界均为严格不等、降低大盘阈值后现实指数放量可通过、两系数互相独立、缺字段时 `getattr` 回退到旧字面量、空量能与零基准量的宽松回退）
- `ruff check .` / `ruff format --check .`、`quality_gate --check-functions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)