### PR TITLE
fix(backtest): 回测下单闸门改读实盘禁买名单，此前方向恰好相反

### DIFF
--- a/.github/workflows/backtest_grid.yml
+++ b/.github/workflows/backtest_grid.yml
@@ -253,6 +253,22 @@ jobs:
       FUNNEL_AI_NEUTRAL_TREND: "5"
       FUNNEL_AI_NEUTRAL_ACCUM: "1"
 
+      # 与实盘漏斗对齐的判定类配置。回测 live 闸门现直接读 STEP4_BUY_BLOCK_REGIMES /
+      # STEP4_BUY_ALLOW_REGIMES（见 core/backtest_config._live_buy_block_regimes），
+      # 此前用硬编码集合，方向与实盘恰好相反：回测禁 BEAR_REBOUND/RISK_ON 而放行 NEUTRAL，
+      # 实盘正相反，导致两者成交的交易日几乎不重叠。
+      # 允许用 repository variable 覆盖，便于运维调参而不必改代码。
+      STEP4_BUY_BLOCK_REGIMES: ${{ vars.STEP4_BUY_BLOCK_REGIMES || 'UNKNOWN,NEUTRAL,PANIC_REPAIR,RISK_OFF,CRASH,BLACK_SWAN' }}
+      STEP4_BUY_ALLOW_REGIMES: ${{ vars.STEP4_BUY_ALLOW_REGIMES || 'BEAR_REBOUND,RISK_ON' }}
+      STEP4_BLOCK_BUY_SIGNAL_TYPES: ${{ vars.STEP4_BLOCK_BUY_SIGNAL_TYPES || '' }}
+      FUNNEL_DYNAMIC_POLICY: ${{ vars.FUNNEL_DYNAMIC_POLICY || 'shadow' }}
+      FUNNEL_DYNAMIC_POLICY_HORIZON: "5"
+      FUNNEL_DEFENSIVE_FORCE_QUOTA: "1"
+      FUNNEL_MAX_STRUCTURE_STOP_PCT: "12.0"
+      FUNNEL_THEME_RADAR_PROMOTE_CAP: "2"
+      FUNNEL_L2_BYPASS_AI_ENABLED: "0"
+      FUNNEL_STRATEGIC_L2_BYPASS_AI_CAP: "2"
+
     steps:
       - name: Resolve period dates
         id: period

--- a/core/backtest_config.py
+++ b/core/backtest_config.py
@@ -16,6 +16,7 @@ from core.backtest_replay import BacktestReplayConfig, MarketBreadthCalculator, 
 from core.candidate_policy import CandidatePolicyConfig
 from core.cash_portfolio import CashPortfolioConfig, expand_portfolio_styles
 from core.mainline_engine import MainlineEngineConfig
+from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES
 
 
 @dataclass(frozen=True)
@@ -188,6 +189,26 @@ def _validate_modes(
         raise ValueError("sltp_priority 必须是 stop_first 或 take_first")
 
 
+def _live_buy_block_regimes() -> frozenset[str]:
+    """读实盘的 STEP4_BUY_BLOCK_REGIMES / STEP4_BUY_ALLOW_REGIMES。
+
+    回测 live 模式此前用硬编码集合，与实盘方向相反（详见
+    core/backtest_replay._execution_regime_allows 的说明）。这里改为复用实盘同一份 env，
+    以后运维改闸门，回测自动跟上，无需再动代码。
+
+    直接解析 env 而不复用 workflows.step4_order_config：core 层不得依赖 workflows
+    （tests/test_architecture_boundaries.py 强制这条方向）。
+    """
+    import os
+
+    def _parse(name: str) -> set[str]:
+        raw = os.getenv(name, "").strip()
+        return {item.strip().upper() for item in raw.split(",") if item.strip()}
+
+    blocked = _parse("STEP4_BUY_BLOCK_REGIMES") or set(EXECUTE_BLOCK_NEW_BUY_REGIMES)
+    return frozenset(blocked - _parse("STEP4_BUY_ALLOW_REGIMES"))
+
+
 def _validate_dates_and_trade_params(
     start_dt: date,
     end_dt: date,
@@ -252,6 +273,7 @@ def _replay_config(
         full_formal_l4_max=params.full_formal_l4_max,
         regime_filter=False,
         execution_regime_gate=str(params.execution_regime_gate or "live").strip().lower(),
+        buy_block_regimes=_live_buy_block_regimes(),
         pending_mode=pending_mode,
         pending_merge_order=pending_merge_order,
         abc_filter=bool(params.abc_filter),

--- a/core/backtest_replay.py
+++ b/core/backtest_replay.py
@@ -112,6 +112,9 @@ class BacktestReplayConfig:
     # 小盘基准（默认创业板指）。缺它则 CRASH/PANIC_REPAIR 少一条判据，
     # 防守档会塌成 NEUTRAL——见 _analyze_market_regime 的说明。
     smallcap_bench_df: pd.DataFrame | None = None
+    # live 模式下的禁买水温集合。留空则回退到 EXECUTE_BLOCK_NEW_BUY_REGIMES（旧行为）；
+    # 由调用方注入实盘的 STEP4_BUY_BLOCK_REGIMES 以保证回测与实盘闸门一致。
+    buy_block_regimes: frozenset[str] = frozenset()
     a_share_entry_research: AShareEntryResearchPolicy = field(default_factory=AShareEntryResearchPolicy)
 
 
@@ -310,7 +313,8 @@ def _apply_execution_gates(
     selected: _RankedSelection | None,
     config: BacktestReplayConfig,
 ) -> tuple[_ExecutionGateResult, int]:
-    if selected is not None and not _execution_regime_allows(ctx.regime, config.execution_regime_gate):
+    blocked = config.buy_block_regimes or None
+    if selected is not None and not _execution_regime_allows(ctx.regime, config.execution_regime_gate, blocked):
         return _ExecutionGateResult(None, True), len(selected.codes)
     if selected is None:
         return _ExecutionGateResult(None, False), 0
@@ -372,13 +376,24 @@ def _trade_context(ctx: _DayContext) -> _TradeContext:
     return _TradeContext(ctx.idx, ctx.signal_date, ctx.entry_target_date, ctx.regime)
 
 
-def _execution_regime_allows(regime: str, mode: str) -> bool:
+def _execution_regime_allows(regime: str, mode: str, blocked: frozenset[str] | None = None) -> bool:
+    """回测的下单闸门。
+
+    `live` 模式此前用硬编码的 EXECUTE_BLOCK_NEW_BUY_REGIMES，与实盘的
+    STEP4_BUY_BLOCK_REGIMES 不一致，且方向恰好相反：
+
+        回测禁买  BEAR_REBOUND / RISK_ON（实测超额 +4.08 / +6.07pct，实盘已放开）
+        回测放行  NEUTRAL（实测超额 -4.35pct，实盘已禁买）
+
+    后果是回测只在 NEUTRAL 下单、实盘恰好不在 NEUTRAL 下单，两者成交的交易日几乎不重叠，
+    任何按水温分档的回测结论都无法映射到实盘。现改为接受实盘同一份禁买集合。
+    """
     normalized = normalize_regime(regime)
     if mode == "off":
         return True
     if mode == "neutral_only":
         return normalized == "NEUTRAL"
-    return normalized not in EXECUTE_BLOCK_NEW_BUY_REGIMES
+    return normalized not in (blocked if blocked is not None else EXECUTE_BLOCK_NEW_BUY_REGIMES)
 
 
 def _limit_probe_only_selection(

--- a/tests/core/test_backtest_gate_alignment.py
+++ b/tests/core/test_backtest_gate_alignment.py
@@ -1,0 +1,76 @@
+"""Tests for backtest execution gate aligning with the live buy-block list.
+
+回测 live 模式此前用硬编码的 EXECUTE_BLOCK_NEW_BUY_REGIMES，与实盘
+STEP4_BUY_BLOCK_REGIMES 方向恰好相反：
+
+    回测禁买  BEAR_REBOUND / RISK_ON（实测超额 +4.08 / +6.07pct，实盘已放开）
+    回测放行  NEUTRAL（实测超额 -4.35pct，实盘已禁买）
+
+后果是回测只在 NEUTRAL 下单、实盘恰好不在 NEUTRAL 下单，两者成交的交易日几乎不重叠，
+任何按水温分档的回测结论都无法映射到实盘。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.backtest_replay import _execution_regime_allows
+from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES
+
+LIVE_BLOCKED = frozenset({"UNKNOWN", "NEUTRAL", "PANIC_REPAIR", "RISK_OFF", "CRASH", "BLACK_SWAN"})
+
+
+class TestLiveGateUsesInjectedList:
+    def test_neutral_blocked_when_live_blocks_it(self):
+        """最关键的一条：实盘禁 NEUTRAL，回测必须跟随。"""
+        assert _execution_regime_allows("NEUTRAL", "live", LIVE_BLOCKED) is False
+
+    @pytest.mark.parametrize("regime", ["BEAR_REBOUND", "RISK_ON"])
+    def test_positive_regimes_allowed(self, regime):
+        """实测为正的两档必须放行——旧硬编码集合把它们禁掉了。"""
+        assert _execution_regime_allows(regime, "live", LIVE_BLOCKED) is True
+
+    @pytest.mark.parametrize("regime", ["CRASH", "RISK_OFF", "PANIC_REPAIR", "BLACK_SWAN", "UNKNOWN"])
+    def test_defensive_regimes_still_blocked(self, regime):
+        assert _execution_regime_allows(regime, "live", LIVE_BLOCKED) is False
+
+
+class TestFallbackPreservesOldBehaviour:
+    def test_none_falls_back_to_hardcoded(self):
+        """不注入时保持旧行为，避免遗漏调用方静默改变语义。"""
+        for regime in EXECUTE_BLOCK_NEW_BUY_REGIMES:
+            assert _execution_regime_allows(regime, "live", None) is False
+
+    def test_neutral_allowed_under_fallback(self):
+        assert _execution_regime_allows("NEUTRAL", "live", None) is True
+
+
+class TestOtherModesUnaffected:
+    @pytest.mark.parametrize("regime", ["NEUTRAL", "CRASH", "BEAR_REBOUND"])
+    def test_off_allows_everything(self, regime):
+        assert _execution_regime_allows(regime, "off", LIVE_BLOCKED) is True
+
+    def test_neutral_only_ignores_block_list(self):
+        assert _execution_regime_allows("NEUTRAL", "neutral_only", LIVE_BLOCKED) is True
+        assert _execution_regime_allows("BEAR_REBOUND", "neutral_only", LIVE_BLOCKED) is False
+
+
+class TestConfigWiring:
+    def test_reads_live_config(self, monkeypatch):
+        from core.backtest_config import _live_buy_block_regimes
+
+        monkeypatch.setenv("STEP4_BUY_BLOCK_REGIMES", "NEUTRAL,CRASH")
+        monkeypatch.setenv("STEP4_BUY_ALLOW_REGIMES", "")
+        blocked = _live_buy_block_regimes()
+        assert "NEUTRAL" in blocked
+        assert "CRASH" in blocked
+
+    def test_allow_list_takes_precedence(self, monkeypatch):
+        """ALLOW 豁免必须生效，否则放开的档位在回测里仍被禁。"""
+        from core.backtest_config import _live_buy_block_regimes
+
+        monkeypatch.setenv("STEP4_BUY_BLOCK_REGIMES", "NEUTRAL,BEAR_REBOUND")
+        monkeypatch.setenv("STEP4_BUY_ALLOW_REGIMES", "BEAR_REBOUND")
+        blocked = _live_buy_block_regimes()
+        assert "BEAR_REBOUND" not in blocked
+        assert "NEUTRAL" in blocked


### PR DESCRIPTION
## Summary / 变更摘要

`core/backtest_replay._execution_regime_allows` 的 `live` 模式用**硬编码**的 `EXECUTE_BLOCK_NEW_BUY_REGIMES`，与实盘 `STEP4_BUY_BLOCK_REGIMES` 不一致，且**方向恰好相反**：

| 水温 | 回测 `live`（旧） | 实盘 |
| --- | --- | --- |
| **NEUTRAL** | **可买** | **禁买**（实测超额 −4.35pct，CI 不跨 0） |
| **BEAR_REBOUND** | **禁买** | **可买**（+4.08pct，4/4 为正） |
| **RISK_ON** | **禁买** | **可买**（+6.07pct，3/3 为正） |

**后果**：回测只在 NEUTRAL 下单，实盘恰好不在 NEUTRAL 下单，两者成交的交易日几乎不重叠。

这解释了今天所有回测里成交**全部落在 NEUTRAL（94~114 笔）**的现象 —— 不是只有 NEUTRAL 出现，而是回测只在该档买入。任何按水温分档的回测结论都无法映射到实盘；止损档位的**方向**（四档单调）大概率仍成立，但**幅度需在对齐后重测**。

## 改动

- `_execution_regime_allows` 增 `blocked` 参数；留空则回退硬编码集合，**旧行为可复现**
- `BacktestReplayConfig` 增 `buy_block_regimes` 字段（默认空集）
- `core/backtest_config._live_buy_block_regimes` 直接解析 `STEP4_BUY_BLOCK_REGIMES` 与 `STEP4_BUY_ALLOW_REGIMES` —— 不复用 `workflows.step4_order_config`，因为 `tests/test_architecture_boundaries.py` 禁止 `core` 依赖 `workflows`
- `backtest_grid.yml` 补齐与实盘对齐的判定类 env，**支持 repository variable 覆盖**，运维可在 Actions 侧调参而不必改代码；同时补 `FUNNEL_DEFENSIVE_FORCE_QUOTA` / `MAX_STRUCTURE_STOP_PCT` / `THEME_RADAR_PROMOTE_CAP` / `L2_BYPASS` 等此前缺失、会影响判定的项；`FUNNEL_DYNAMIC_POLICY` 从 `off` 对齐为 `shadow`

## Validation / 验证

- `pytest tests/` — **3249 passed, 22 skipped**（新增 16 个用例：NEUTRAL 须随实盘被禁、BEAR_REBOUND/RISK_ON 须放行、防守档仍禁、不注入时回退旧行为可复现、`off` 与 `neutral_only` 模式不受影响、配置读取 env、ALLOW 豁免优先于 BLOCK）
- `ruff check .` / `ruff format --check .`、`quality_gate --check-functions`、`check_workflow_hygiene`

🤖 Generated with [Claude Code](https://claude.com/claude-code)