### PR TITLE
chore(ci): 移除 TAVILY_API_KEY / SERPAPI_API_KEY 两处死注入

### DIFF
--- a/.github/workflows/wyckoff_funnel.yml
+++ b/.github/workflows/wyckoff_funnel.yml
@@ -73,8 +73,6 @@ jobs:
       SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       SUPABASE_USER_ID: ${{ secrets.SUPABASE_USER_ID }}
-      TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
-      SERPAPI_API_KEY: ${{ secrets.SERPAPI_API_KEY }}
       RAG_SEMANTIC_VETO_ENABLED: ${{ vars.RAG_SEMANTIC_VETO_ENABLED || '1' }}
       RAG_SEMANTIC_PROVIDER: ${{ vars.RAG_SEMANTIC_PROVIDER || secrets.RAG_SEMANTIC_PROVIDER || 'efficiency' }}
       # 实盘风控：ATR/结构止损优先，-12% 仅灾难地板；非主线 5 日时间管理见 holding_time_policy


### PR DESCRIPTION
## Summary / 变更摘要

移除 `wyckoff_funnel.yml` 中两处**死注入**：

| Secret | 依据 |
| --- | --- |
| `TAVILY_API_KEY` | 全仓搜索 `TAVILY`/`tavily`（含 .py/.toml/.txt/.md）**零命中** |
| `SERPAPI_API_KEY` | 同上 |

删除注入行后可在平台侧安全删除这两个 secret。

## 排查中的一处自我更正

`ONEROUTE_API_KEY` / `_MODEL` / `_BASE_URL` 一度被判为死配置 —— 因为 `integrations/llm_client.py:57` 按 `provider.upper()` 动态拼 env 名，provider 叫 `1route` 故读 `1ROUTE_*`。

**但 workflow 已做名称映射**：

```yaml
1ROUTE_API_KEY: ${{ secrets.ONEROUTE_API_KEY }}
```

且 `1route` 在 `SUPPORTED_PROVIDERS` 内、有默认 base_url `https://api.1route.dev/v1` —— **是可用的备用 provider，不可删**。

## 同理保留的

- `deepseek` / `qwen` / `zhipu` / `volcengine` / `minimax` / `openai` 六组凭据：看似「代码零引用」，实为 `llm_client.py:57` 的 `f"{env_prefix}_API_KEY"` 动态读取，属**手动切换的储备链路**，改一个 `vars.STEP3_LLM_PROVIDER` 即可启用
- `SUPABASE_KEY`（anon 读路径）与 `SUPABASE_SERVICE_ROLE_KEY`（写路径）**都在用**，12 个 workflow 同时注入

## Validation / 验证

- `pytest tests/` — 3249 passed, 22 skipped
- `check_workflow_hygiene` 通过
- workflow 内已无 `TAVILY`/`SERPAPI` 残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)