### PR TITLE
feat(backtest): 新增 bull_2025 回测时期，并把 sideways/volatile 补进可选项

### DIFF
--- a/.github/workflows/backtest_grid.yml
+++ b/.github/workflows/backtest_grid.yml
@@ -13,6 +13,9 @@ on:
           - "recent_6m"
           - "bull_2020"
           - "bear_2022"
+          - "sideways_2023"
+          - "volatile_2024"
+          - "bull_2025"
           - "custom"
         default: "all_defined"
       start:
@@ -102,7 +105,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        period_key: [recent_2m, recent_6m, bull_2020, bear_2022, sideways_2023, volatile_2024]
+        period_key: [recent_2m, recent_6m, bull_2020, bear_2022, sideways_2023, volatile_2024, bull_2025]
     env:
       PYTHONUNBUFFERED: "1"
       TICKFLOW_API_KEY: ${{ secrets.TICKFLOW_API_KEY }}
@@ -152,6 +155,9 @@ jobs:
           elif [ "$PERIOD" = "volatile_2024" ]; then
             echo "BT_START=2024-01-02" >> "$GITHUB_ENV"
             echo "BT_END=2024-12-31" >> "$GITHUB_ENV"
+          elif [ "$PERIOD" = "bull_2025" ]; then
+            echo "BT_START=2025-01-02" >> "$GITHUB_ENV"
+            echo "BT_END=2025-12-31" >> "$GITHUB_ENV"
           elif [ "$PERIOD" = "custom" ]; then
             if [ -z "$BT_END" ]; then
               echo "BT_END=$(TZ=Asia/Shanghai date -d '-1 day' +%Y-%m-%d)" >> "$GITHUB_ENV"
@@ -232,6 +238,11 @@ jobs:
             grid_cells: "5:0:0:0,10:0:0:0,10:-7:0:0,10:-8:0:0,15:-7:0:0,15:-8:0:0,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
           - period_key: volatile_2024
             grid_cells: "5:0:0:0,10:0:0:0,10:-7:0:0,10:-8:0:0,15:-7:0:0,15:-8:0:0,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
+          # 2026-08-21 补齐 bull_2025：此前 5 个时期覆盖 61% 交易日，2025 全年（243 日、
+          # 上证 +21.6%、创业板 +55.5%、振幅 30.1%）完全落在空档里，而它是最近的完整年度、
+          # 市场结构最接近当前。
+          - period_key: bull_2025
+            grid_cells: "5:0:0:0,10:0:0:0,10:-7:0:0,10:-8:0:0,15:-7:0:0,15:-8:0:0,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
     env:
       PYTHONUNBUFFERED: "1"
       TZ: Asia/Shanghai
@@ -311,6 +322,9 @@ jobs:
           elif [ "$PERIOD" = "volatile_2024" ]; then
             echo "BT_START=2024-01-02" >> "$GITHUB_ENV"
             echo "BT_END=2024-12-31" >> "$GITHUB_ENV"
+          elif [ "$PERIOD" = "bull_2025" ]; then
+            echo "BT_START=2025-01-02" >> "$GITHUB_ENV"
+            echo "BT_END=2025-12-31" >> "$GITHUB_ENV"
           elif [ "$PERIOD" = "custom" ]; then
             if [ -z "$BT_END" ]; then
               echo "BT_END=$(TZ=Asia/Shanghai date -d '-1 day' +%Y-%m-%d)" >> "$GITHUB_ENV"
@@ -421,7 +435,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        period_key: [recent_2m, recent_6m, bull_2020, bear_2022, sideways_2023, volatile_2024]
+        period_key: [recent_2m, recent_6m, bull_2020, bear_2022, sideways_2023, volatile_2024, bull_2025]
         # amp  = A,M,P 共享一次信号台账（三者只改入场仓位权重，故可复用）
         # calib = 仅变体 I（calibrate_confirmed_score），必须独立算台账
         variant_set: [amp, calib]
@@ -463,6 +477,9 @@ jobs:
           elif [ "$PERIOD" = "volatile_2024" ]; then
             echo "BT_START=2024-01-02" >> "$GITHUB_ENV"
             echo "BT_END=2024-12-31" >> "$GITHUB_ENV"
+          elif [ "$PERIOD" = "bull_2025" ]; then
+            echo "BT_START=2025-01-02" >> "$GITHUB_ENV"
+            echo "BT_END=2025-12-31" >> "$GITHUB_ENV"
           elif [ "$PERIOD" = "custom" ]; then
             if [ -z "$BT_END" ]; then
               echo "BT_END=$(TZ=Asia/Shanghai date -d '-1 day' +%Y-%m-%d)" >> "$GITHUB_ENV"
@@ -584,7 +601,7 @@ jobs:
           PERIOD: ${{ inputs.period || 'recent_6m' }}
         run: |
           if [ "$PERIOD" = "all_defined" ]; then
-            echo "BT_PERIOD_LABEL=recent_6m,bull_2020,bear_2022,sideways_2023,volatile_2024" >> "$GITHUB_ENV"
+            echo "BT_PERIOD_LABEL=recent_6m,bull_2020,bear_2022,sideways_2023,volatile_2024,bull_2025" >> "$GITHUB_ENV"
             echo "BT_START=multi" >> "$GITHUB_ENV"
             echo "BT_END=multi" >> "$GITHUB_ENV"
           elif [ "$PERIOD" = "recent_2m" ]; then
@@ -607,6 +624,10 @@ jobs:
             echo "BT_PERIOD_LABEL=volatile_2024" >> "$GITHUB_ENV"
             echo "BT_START=2024-01-02" >> "$GITHUB_ENV"
             echo "BT_END=2024-12-31" >> "$GITHUB_ENV"
+          elif [ "$PERIOD" = "bull_2025" ]; then
+            echo "BT_PERIOD_LABEL=bull_2025" >> "$GITHUB_ENV"
+            echo "BT_START=2025-01-02" >> "$GITHUB_ENV"
+            echo "BT_END=2025-12-31" >> "$GITHUB_ENV"
           elif [ "$PERIOD" = "custom" ]; then
             echo "BT_PERIOD_LABEL=custom" >> "$GITHUB_ENV"
             if [ -z "$BT_END" ]; then


### PR DESCRIPTION
## Summary / 变更摘要

先校验既有四个时期与 A 股**实际行情**是否吻合（上证/创业板实测涨跌与振幅）：

| 时期 | 区间 | 上证 | 创业板 | 振幅 | 判定 |
| --- | --- | ---: | ---: | ---: | --- |
| `bull_2020` | 2020-07-01~2021-02-18 | **+21.5%** | +37.2% | 21.5% | ✓ 牛 |
| `bear_2022` | 2021-12-13~2022-10-31 | **−21.4%** | −35.2% | 27.5% | ✓ 熊 |
| `sideways_2023` | 2023-01-03~2023-12-29 | −4.5% | −19.7% | 17.1% | ✓ 横盘 |
| `volatile_2024` | 2024-01-02~2024-12-31 | +13.1% | +15.4% | **29.1%** | ✓ 震荡 |

**四个全部名副其实，边界也准** —— `bull_2020` 起点正在 7 月那波暴涨前、终点是 2021 春节后见顶；`bear_2022` 从 2021/12 高点到 2022/10 低点。**故不改。**

## 但覆盖率只有 61%

已覆盖 975/1608 个交易日。最大空档：

| 空档 | 区间 | 交易日 | 涨跌 | 振幅 |
| --- | --- | ---: | ---: | ---: |
| **2025 全年 + 2026 初** | 2025-01-01~2026-02-19 | **273** | **+25.1%** | **34.5%** |
| 2021 结构市 | 2021-02-19~2021-12-12 | 199 | −0.8% | 10.7% |
| 2022 底部反弹 | 2022-11-01~2022-12-30 | 44 | +4.0% | 8.2% |

故新增 **`bull_2025`（2025-01-02~2025-12-31）**：243 个交易日、上证 +21.6%、创业板 +55.5%、振幅 30.1% —— **最近的完整年度、市场结构最接近当前**。`grid_cells` 与其他时期一致以便横向比较。

## 顺带修一处易用性问题

`workflow_dispatch` 的 `period` 选项此前只列到 `bear_2022`，**`sideways_2023` 与 `volatile_2024` 只能靠 `all_defined` 间接跑到、无法单独复跑**。现补齐全部选项。

## 改动范围

- `fetch` / `grid` / `strategy_compare` 三个 job 的 matrix
- 四处日期解析分支（前三处无 `BT_PERIOD_LABEL` 行、写法与第四处不同，需分别处理）
- `notify` 的 `all_defined` 标签

## Validation / 验证

- PyYAML 解析通过，三个 job 的 matrix 均含 `bull_2025`（fetch/strategy_compare 各 7 期、grid include 7 条）
- 四处日期分支齐全
- `pytest tests/` — 3249 passed, 22 skipped
- `ruff check .`、`check_workflow_hygiene`

🤖 Generated with [Claude Code](https://claude.com/claude-code)