### PR TITLE
fix(backtest): 补齐回测闸门 fallback，并披露分层表的统计口径

### DIFF
--- a/.github/workflows/backtest_grid.yml
+++ b/.github/workflows/backtest_grid.yml
@@ -270,7 +270,10 @@ jobs:
       # 实盘正相反，导致两者成交的交易日几乎不重叠。
       # 允许用 repository variable 覆盖，便于运维调参而不必改代码。
       STEP4_BUY_BLOCK_REGIMES: ${{ vars.STEP4_BUY_BLOCK_REGIMES || 'UNKNOWN,NEUTRAL,PANIC_REPAIR,RISK_OFF,CRASH,BLACK_SWAN' }}
-      STEP4_BUY_ALLOW_REGIMES: ${{ vars.STEP4_BUY_ALLOW_REGIMES || 'BEAR_REBOUND,RISK_ON' }}
+      # fallback 必须与生产两个 workflow 保持一致（当前 BEAR_REBOUND）。
+      # PR #305 把 RISK_ON 移出豁免时漏改此处，导致 run 32537955220 的回测仍放行 RISK_ON
+      # 并产生 6 笔成交（胜率 16.7%、均收 -5.03%），与实盘口径不符。
+      STEP4_BUY_ALLOW_REGIMES: ${{ vars.STEP4_BUY_ALLOW_REGIMES || 'BEAR_REBOUND' }}
       STEP4_BLOCK_BUY_SIGNAL_TYPES: ${{ vars.STEP4_BLOCK_BUY_SIGNAL_TYPES || '' }}
       FUNNEL_DYNAMIC_POLICY: ${{ vars.FUNNEL_DYNAMIC_POLICY || 'shadow' }}
       FUNNEL_DYNAMIC_POLICY_HORIZON: "5"

--- a/tests/workflows/test_report_layer_scope.py
+++ b/tests/workflows/test_report_layer_scope.py
@@ -1,0 +1,89 @@
+"""Tests for regime/trigger layer tables disclosing their scope.
+
+「市场周期分层」与「信号类型分层」的数据来自 `read_trades(best.trades_path)`，
+即**单个最优参数单元**的成交，而非全部单元汇总。此前标题未说明，导致误读：
+
+报告曾显示 NEUTRAL 14 笔 +3.80%，而 recent_6m 全部 9 个 trades 文件里 NEUTRAL 实为
+0 笔（该档在禁买名单内）——那 14 笔来自 best 所指的另一个周期。我据此一度怀疑
+NEUTRAL 禁买的正确性，属被报告口径误导。
+
+不改成聚合全部单元，是因为各周期表现差异极大（recent_6m +24% vs
+sideways_2023 -10.78%），混合平均反而更误导。
+"""
+
+from __future__ import annotations
+
+from workflows.backtest_market_report_builder import (
+    _build_regime_stats_table,
+    _build_trigger_stats_table,
+)
+
+_REGIME_STATS = [
+    {
+        "key": "CAUTION",
+        "count": 14,
+        "first_date": "2026-02-25",
+        "last_date": "2026-07-01",
+        "win_rate": 50.0,
+        "avg": 3.80,
+        "median": 0.0,
+    }
+]
+_TRIGGER_STATS = [{"key": "spring(确认)", "count": 8, "win_rate": 50.0, "avg": 5.50, "median": 2.20}]
+
+
+class TestRegimeTableScope:
+    def test_discloses_scope_when_given(self):
+        scope = "（recent_6m / 集中换股 / 10天 / SL-8% / 无TP / Trail-8% / 24 笔）"
+        text = "\n".join(_build_regime_stats_table(_REGIME_STATS, scope))
+        assert "仅统计最优单元" in text
+        assert "非全部参数单元汇总" in text
+        assert "recent_6m" in text
+        assert "24 笔" in text
+
+    def test_still_renders_without_scope(self):
+        """scope 缺省时不得崩溃，仍要保留口径提示。"""
+        text = "\n".join(_build_regime_stats_table(_REGIME_STATS))
+        assert "仅统计最优单元" in text
+        assert "| CAUTION |" in text
+
+    def test_data_rows_intact(self):
+        text = "\n".join(_build_regime_stats_table(_REGIME_STATS, "（x）"))
+        assert "14" in text
+        assert "+3.80%" in text
+
+
+class TestTriggerTableScope:
+    def test_discloses_scope(self):
+        text = "\n".join(_build_trigger_stats_table(_TRIGGER_STATS, "（bear_2022 / 42 笔）"))
+        assert "仅统计最优单元" in text
+        assert "bear_2022" in text
+
+    def test_data_rows_intact(self):
+        text = "\n".join(_build_trigger_stats_table(_TRIGGER_STATS, "（x）"))
+        assert "spring(确认)" in text
+        assert "+5.50%" in text
+
+
+class TestBacktestGateFallbackMatchesLive:
+    def test_all_three_workflows_agree(self):
+        """回测与两个生产 workflow 的 ALLOW fallback 必须一致。
+
+        PR #305 把 RISK_ON 移出豁免时漏改 backtest_grid.yml，使 run 32537955220
+        的回测仍放行 RISK_ON 并产生 6 笔成交（胜率 16.7%、均收 -5.03%）。
+        """
+        import re
+        from pathlib import Path
+
+        values = {}
+        for name in ("backtest_grid.yml", "wyckoff_funnel.yml", "step4_from_supabase.yml"):
+            text = Path(".github/workflows").joinpath(name).read_text(encoding="utf-8")
+            hit = re.search(r"STEP4_BUY_ALLOW_REGIMES:\s*(.+)", text)
+            assert hit, name
+            raw = hit.group(1)
+            # 取 fallback（`|| '...'`）或直接值，去掉引号
+            fb = re.search(r"\|\|\s*'([^']*)'", raw)
+            values[name] = (fb.group(1) if fb else raw.strip().strip('"').strip("'")).strip()
+
+        assert len(set(values.values())) == 1, values
+        assert "RISK_ON" not in next(iter(values.values()))

--- a/workflows/backtest_market_report_builder.py
+++ b/workflows/backtest_market_report_builder.py
@@ -806,10 +806,22 @@ def _build_trade_structure_lines(diagnostics: dict[str, object]) -> list[str]:
     ]
 
 
-def _build_regime_stats_table(regime_stats: list[dict[str, object]]) -> list[str]:
+def _build_regime_stats_table(regime_stats: list[dict[str, object]], scope: str = "") -> list[str]:
+    """按水温分层。
+
+    统计口径是**单个最优参数单元**的成交，不是全部单元的汇总——这里的 regime_stats
+    来自 `read_trades(best.trades_path)`。此前标题未说明，读者会误以为是全局分层：
+    例如报告曾显示 NEUTRAL 14 笔 +3.80%，而 recent_6m 全部 9 个 trades 文件里
+    NEUTRAL 实为 0 笔（该档在禁买名单内），那 14 笔来自 best 所指的另一个周期。
+
+    不改成聚合全部单元，是因为各周期表现差异极大（recent_6m +24% vs
+    sideways_2023 -10.78%），混合平均反而更误导。
+    """
     lines = [
         "",
         "## 市场周期分层",
+        "",
+        f"> 口径：仅统计最优单元{scope} 的成交，非全部参数单元汇总。",
         "",
         "| 周期 | 含义 | 笔数 | 信号期 | 胜率 | 均收 | 中位数 |",
         "|---|---|---:|---|---:|---:|---:|",
@@ -835,8 +847,17 @@ def _build_regime_stats_table(regime_stats: list[dict[str, object]]) -> list[str
     return lines
 
 
-def _build_trigger_stats_table(trigger_stats: list[dict[str, object]]) -> list[str]:
-    lines = ["", "## 信号类型分层", "", "| 信号 | 笔数 | 胜率 | 均收 | 中位数 |", "|---|---:|---:|---:|---:|"]
+def _build_trigger_stats_table(trigger_stats: list[dict[str, object]], scope: str = "") -> list[str]:
+    """按买点类型分层。口径同 _build_regime_stats_table——仅最优单元，非全局。"""
+    lines = [
+        "",
+        "## 信号类型分层",
+        "",
+        f"> 口径：仅统计最优单元{scope} 的成交，非全部参数单元汇总。",
+        "",
+        "| 信号 | 笔数 | 胜率 | 均收 | 中位数 |",
+        "|---|---:|---:|---:|---:|",
+    ]
     for stat in trigger_stats:
         lines.append(
             "| "
@@ -914,8 +935,9 @@ def build_report(cells: list[GridCell], run_url: str = "", generated_at: str = "
 
     lines.extend(["", "## 最优夏普矩阵", "", *_build_matrix(cells, best_sharpe_cell)])
     lines.extend(_build_trade_structure_lines(diagnostics))
-    lines.extend(_build_regime_stats_table(regime_stats))
-    lines.extend(_build_trigger_stats_table(trigger_stats))
+    best_scope = f"（{best.period_key} / {_fmt_param(best)} / {len(best_rows)} 笔）"
+    lines.extend(_build_regime_stats_table(regime_stats, best_scope))
+    lines.extend(_build_trigger_stats_table(trigger_stats, best_scope))
     lines.extend(_build_followup_lines(regime_stats, trigger_stats))
     lines.extend(_build_methodology_notes())
     return "\n".join(lines)


### PR DESCRIPTION
## Summary / 变更摘要

两个问题，一个是我漏改的真 bug，一个是报告表述误导。

### 一、`backtest_grid.yml` 的 ALLOW fallback 漏改（真 bug）

PR #305 把 RISK_ON 移出豁免时只改了 `wyckoff_funnel.yml` 与 `step4_from_supabase.yml`，**漏了 `backtest_grid.yml`** —— 其 fallback 仍是 `'BEAR_REBOUND,RISK_ON'`。且仓库 variables 里并未设置该键（只有 `PYPI_PUBLISH_ENABLED` 一个），故回测走 fallback 用了旧值。

**后果**：run 32537955220 的回测仍放行 RISK_ON，产生 6 笔成交（胜率 16.7%、均收 −5.03%、中位 −6.81%）—— 而这恰是本次要验证 #305 是否生效的那一档。

现改为 `'BEAR_REBOUND'`，三个 workflow 一致。**新增用例直接扫三个 yml 的 fallback 值并断言相等且不含 RISK_ON**，防止再漏改。

### 二、分层表未披露口径，导致误读（表述问题，非数据错）

「市场周期分层」与「信号类型分层」的数据来自 `read_trades(best.trades_path)`，即**单个最优参数单元**的成交，而非全部单元汇总。标题此前未说明。

**我被它误导过一次**：报告显示 NEUTRAL 14 笔 +3.80%，据此一度怀疑 NEUTRAL 禁买的正确性；实际 `recent_6m` 全部 9 个 trades 文件里 NEUTRAL 为 **0 笔**（该档在禁买名单内，闸门正确拦截），那 14 笔来自 `best` 所指的另一个周期。

查清后三份数据其实一致：市场层 −1.52%（p=0.006）、候选超额 −4.35pct、回测 0 笔成交。

现在两表都渲染口径行并带出 best 单元信息：

```
> 口径：仅统计最优单元（recent_6m / 集中换股 / 10天 / SL-8% / 无TP / Trail-8% / 24 笔）
> 的成交，非全部参数单元汇总。
```

不改成聚合全部单元，是因为各周期表现差异极大（recent_6m +24% vs sideways_2023 −10.78%），混合平均反而更误导。

## 顺带记录 run 32537955220 的结论：止损档位不改

新增 −5% 档后最优夏普矩阵 10 天持有为 **−5% 1.912** > −8% 1.612 > −7% 1.247 > 无SL 1.179，看似生产现值最优。

**但跨周期稳健性相反**：−5% 仅 **1/6** 个周期为正，−7%/−8% 均为 2/6；且 15 天持有下 −5% 夏普 0.458 为三档最低。即 −5% 的高夏普只出现在 `recent_6m` 单周期。

更关键的是 **Walk-forward 仍为 1/16**，与上一轮持平 —— 无论 5%/7%/8% 都在样本外失效。故结论是「止损档位不是关键变量」，而非「选一个最优档位」，**不做改动**。

## Validation / 验证

- `pytest tests/` — **3266 passed, 22 skipped**（新增 6 个用例）
- 用真实 artifact 跑 `update_backtest_market_report.py` 验证渲染正确
- `ruff check .` / `ruff format --check .`、`quality_gate --check-functions`、`check_workflow_hygiene`

🤖 Generated with [Claude Code](https://claude.com/claude-code)