### PR TITLE
feat(tools): 形态前瞻收益检验 + 每周定时任务

### DIFF
--- a/.github/workflows/pattern_forward_eval.yml
+++ b/.github/workflows/pattern_forward_eval.yml
@@ -1,0 +1,104 @@
+name: Pattern Forward Evaluation
+
+# 形态前瞻收益检验：某类票「抓到了」到底赚不赚钱。
+#
+# 起因是一个具体质疑：每天都有「前一日平淡、当日大涨 7%+、次日未高开」的票，
+# 为什么漏斗抓不到。首轮（2026-08-22，498 个交易日 / 2.3 万只次 / 扣 0.202% 成本）
+# 九档阈值组合**全为负超额**且随收紧单调恶化：
+#
+#   开盘缺口<=  当日涨幅>=  日均只数   净超额   为正日
+#       4%         7%         84     -0.71     39%
+#       3%         8%         60     -0.82     41%
+#       2%        10%         28     -0.98     39%
+#
+# 对照同期全市场 T+5 为 +0.44%——买这批票不如随便买。故未据此放宽任何通道门槛。
+#
+# 每周重跑的意义在于：若哪天该形态的超额转正并稳定过 0.202% 成本门槛，才值得
+# 为它开通道；在此之前每次「感觉漏了机会」都能由数据当场否掉，而不必凭直觉改参数。
+#
+# 与 diagnose_funnel_recall.py 互补——那个按代码逐票查「为什么没进候选池」，
+# 这个按形态口径查「这类票值不值得进」。
+on:
+  schedule:
+    # UTC 周六 04:10 = 北京时间周六 12:10。排在 regime_forward_eval(09:40)、
+    # gate_alpha_eval(10:40)、purity_eval(11:10) 之后，避免同时抢 Tushare 配额。
+    - cron: "10 4 * * 6"
+  workflow_dispatch:
+    inputs:
+      start:
+        description: "行情起始（需留 210 日预热）"
+        default: "2024-08-01"
+      sweep_gap:
+        description: "扫开盘缺口上限 %，逗号分隔"
+        default: "2,3,4"
+      sweep_return:
+        description: "扫当日涨幅下限 %，逗号分隔"
+        default: "7,8,10"
+      horizons:
+        description: "持有期（交易日），逗号分隔"
+        default: "5,10"
+      with_intraday:
+        description: "附带日内对照（未来函数，仅参考）"
+        type: boolean
+        default: false
+
+concurrency:
+  group: pattern-forward-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      PYTHONUNBUFFERED: "1"
+      # 只读行情，不写库；故不设 WYCKOFF_WRITE_CONTEXT。
+      TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      TZ: Asia/Shanghai
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Evaluate pattern forward returns
+        env:
+          # inputs 先落 env 再进 shell，避免表达式直接拼进命令行（check_workflow_hygiene 要求）。
+          IN_START: ${{ inputs.start || '2024-08-01' }}
+          IN_SWEEP_GAP: ${{ inputs.sweep_gap || '2,3,4' }}
+          IN_SWEEP_RETURN: ${{ inputs.sweep_return || '7,8,10' }}
+          IN_HORIZONS: ${{ inputs.horizons || '5,10' }}
+          IN_WITH_INTRADAY: ${{ inputs.with_intraday }}
+        run: |
+          EXTRA=()
+          if [ "$IN_WITH_INTRADAY" = "true" ]; then
+            EXTRA+=(--with-intraday)
+          fi
+          python scripts/evaluate_pattern_forward.py \
+            --start "$IN_START" \
+            --sweep-gap "$IN_SWEEP_GAP" \
+            --sweep-return "$IN_SWEEP_RETURN" \
+            --horizons "$IN_HORIZONS" \
+            --json-out docs/evidence/pattern_forward_eval.json \
+            "${EXTRA[@]}"
+
+      - name: Upload evidence
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pattern-forward-eval
+          path: docs/evidence/pattern_forward_eval.json
+          if-no-files-found: warn

--- a/core/pattern_forward_eval.py
+++ b/core/pattern_forward_eval.py
@@ -1,0 +1,149 @@
+"""按自定义形态口径检验前瞻收益：某类票「抓到了」到底赚不赚钱。
+
+与 scripts/diagnose_funnel_recall.py 互补——那个按代码逐票回答「为什么没进候选池」，
+这个按形态口径回答「这类票值不值得进」。先用它确认形态有正 alpha，再去动通道门槛，
+否则放宽召回只会引入更多负 alpha 的标的。
+
+2026-08-22 首轮结论（498 个交易日 / 2.3 万只次 / 扣 0.202% 往返成本）：
+「前一日平淡、当日大涨、次日未高开」这类票，隔夜后是负 alpha，且**收紧阈值更差**：
+
+    开盘缺口<=  当日涨幅>=  日均只数   净收益   净超额   为正日
+        4%         7%         84     -0.27%   -0.71     39%
+        3%         8%         60     -0.38%   -0.82     41%
+        2%        10%         28     -0.55%   -0.98     39%
+
+九档全负且单调恶化——当日涨幅要求越高，次日接力概率越低（动能已在当日释放）。
+对照同期全市场（20 日均额 >= 8000 万）T+5 为 +0.44%，即买这批票不如随便买。
+
+同时发现钱在日内而非隔夜：同一批票 T 日开盘买、T 日收盘卖为 +10.35%、276 天 100% 为正。
+但那是**未来函数**——用「收盘涨幅」筛票再算「开盘到收盘」收益，实盘开盘时并不知道
+哪只会收在高位。要验证「开盘 30 分钟能否预判」需历史分钟数据，而 TickFlow 的
+get_intraday 只返回当日 241 根，取不到历史，故该路径当前无法回测。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import mean
+
+# 与 core.trade_friction 对齐的 A 股单次往返成本。
+ROUND_TRIP_COST_PCT = 0.202
+MIN_DAYS = 20
+MIN_HITS_PER_DAY = 3
+# 为正日占比落在此区间视为无方向性，避免把噪声当信号。
+RANDOM_BAND = (45.0, 55.0)
+
+
+@dataclass(frozen=True)
+class PatternSpec:
+    """形态口径。默认值即 2026-08-22 首轮所用的基线。"""
+
+    prev_day_max_pct: float = 3.0
+    """T-1 日涨幅上限：筛「前一日平淡或水下」。"""
+
+    open_gap_max_pct: float = 4.0
+    """T 日开盘缺口上限：筛「次日未高开、仍可介入」。"""
+
+    day_return_min_pct: float = 7.0
+    """T 日涨幅下限：筛「当日大涨」。"""
+
+    min_avg_amount_wan: float = 8000.0
+    """T-1 及之前 20 日均成交额下限（万元），与生产 RISK_OFF 档门槛对齐。"""
+
+    horizons: tuple[int, ...] = (5, 10)
+    """持有期（交易日）。买点固定为 T+1 开盘——漏斗收盘后才出信号。"""
+
+    def describe(self) -> str:
+        return (
+            f"T-1涨幅<{self.prev_day_max_pct:g}% / T开盘<={self.open_gap_max_pct:g}% / "
+            f"T涨幅>{self.day_return_min_pct:g}% / 20日均额>={self.min_avg_amount_wan:g}万"
+        )
+
+
+@dataclass
+class HorizonResult:
+    horizon: int
+    days: int
+    avg_hits: float
+    net_return_pct: float | None
+    market_return_pct: float | None
+    positive_day_pct: float | None
+
+    @property
+    def net_excess_pct(self) -> float | None:
+        if self.net_return_pct is None or self.market_return_pct is None:
+            return None
+        return self.net_return_pct - self.market_return_pct
+
+    @property
+    def verdict(self) -> str:
+        excess = self.net_excess_pct
+        if self.days < MIN_DAYS or excess is None:
+            return "样本不足"
+        if self.positive_day_pct is not None and RANDOM_BAND[0] <= self.positive_day_pct <= RANDOM_BAND[1]:
+            return "无方向性"
+        return "正贡献" if excess > 0 else "负贡献"
+
+    @property
+    def actionable(self) -> bool:
+        """净超额是否大于往返成本。不过门槛就不该据此放宽通道门槛。"""
+        excess = self.net_excess_pct
+        return excess is not None and excess > ROUND_TRIP_COST_PCT
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "horizon": self.horizon,
+            "days": self.days,
+            "avg_hits": round(self.avg_hits, 1),
+            "net_return_pct": _round(self.net_return_pct),
+            "market_return_pct": _round(self.market_return_pct),
+            "net_excess_pct": _round(self.net_excess_pct),
+            "positive_day_pct": _round(self.positive_day_pct, 1),
+            "verdict": self.verdict,
+            "actionable": self.actionable,
+        }
+
+
+def _round(value: float | None, digits: int = 4) -> float | None:
+    return None if value is None else round(float(value), digits)
+
+
+@dataclass
+class PatternReport:
+    spec: PatternSpec
+    results: list[HorizonResult] = field(default_factory=list)
+
+    def at(self, horizon: int) -> HorizonResult | None:
+        return next((r for r in self.results if r.horizon == horizon), None)
+
+    @property
+    def any_actionable(self) -> bool:
+        return any(r.actionable for r in self.results)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "spec": self.spec.describe(),
+            "round_trip_cost_pct": ROUND_TRIP_COST_PCT,
+            "any_actionable": self.any_actionable,
+            "results": [r.as_dict() for r in self.results],
+        }
+
+
+def summarize_horizon(horizon: int, daily: list[dict[str, float]]) -> HorizonResult:
+    """按交易日等权汇总。命中个股多的日子不该主导均值。"""
+    usable = [
+        row
+        for row in daily
+        if row.get("net") is not None and row.get("market") is not None and (row.get("hits") or 0) >= MIN_HITS_PER_DAY
+    ]
+    if len(usable) < MIN_DAYS:
+        return HorizonResult(horizon, len(usable), 0.0, None, None, None)
+    diffs = [float(r["net"]) - float(r["market"]) for r in usable]
+    return HorizonResult(
+        horizon=horizon,
+        days=len(usable),
+        avg_hits=mean(float(r.get("hits") or 0) for r in usable),
+        net_return_pct=mean(float(r["net"]) for r in usable),
+        market_return_pct=mean(float(r["market"]) for r in usable),
+        positive_day_pct=100.0 * sum(1 for d in diffs if d > 0) / len(diffs),
+    )

--- a/scripts/evaluate_pattern_forward.py
+++ b/scripts/evaluate_pattern_forward.py
@@ -53,6 +53,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--with-intraday", action="store_true", help="附带日内对照（未来函数）")
     parser.add_argument("--cache", default="", help="行情缓存 CSV，跳过在线取数")
     parser.add_argument("--json-out", default="", help="结构化结果输出路径")
+    parser.add_argument("--no-notify", action="store_true", help="不推飞书")
     return parser.parse_args()
 
 
@@ -196,6 +197,7 @@ def main() -> int:
     gaps = [float(x) for x in args.sweep_gap.split(",") if x.strip()] or [args.open_gap_max]
     rets = [float(x) for x in args.sweep_return.split(",") if x.strip()] or [args.day_return_min]
     payload: list[dict] = []
+    sections: list[str] = []
     for gap in gaps:
         for ret in rets:
             spec = PatternSpec(
@@ -206,13 +208,31 @@ def main() -> int:
                 horizons=horizons,
             )
             report, extra = evaluate(market, spec, with_intraday=args.with_intraday)
+            text = render(report, extra)
             print()
-            print(render(report, extra))
+            print(text)
+            sections.append(text)
             payload.append({**report.as_dict(), **extra})
     if args.json_out:
         Path(args.json_out).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
         print(f"\n[pattern] 已写 {args.json_out}")
+    if not args.no_notify:
+        _notify(sections)
     return 0
+
+
+def _notify(sections: list[str]) -> None:
+    import os
+
+    webhook = os.getenv("FEISHU_WEBHOOK_URL", "").strip()
+    if not webhook:
+        print("[pattern] 未配置 FEISHU_WEBHOOK_URL，跳过推送")
+        return
+    from utils.feishu import send_feishu_notification
+
+    title = f"形态前瞻检验｜{pd.Timestamp.now().strftime('%Y-%m-%d')}"
+    ok = send_feishu_notification(webhook, title, "\n\n---\n\n".join(sections))
+    print("[pattern] feishu sent" if ok else "[pattern] feishu failed")
 
 
 if __name__ == "__main__":

--- a/scripts/evaluate_pattern_forward.py
+++ b/scripts/evaluate_pattern_forward.py
@@ -1,0 +1,219 @@
+"""按自定义形态口径检验前瞻收益：这类票「抓到了」到底赚不赚钱。
+
+在为召回缺口放宽通道门槛之前先跑它。与 diagnose_funnel_recall.py 互补——那个按代码
+逐票回答「为什么没进候选池」，这个按形态口径回答「这类票值不值得进」。
+
+买点固定为 T+1 开盘：漏斗在收盘后才出信号，实盘最早只能次日开盘介入。
+基准是同日、同流动性门槛下的全市场等权，故结论是**超额**而非绝对收益。
+
+用法::
+
+    # 默认口径（T-1涨<3%、T开盘<=4%、T涨>7%）
+    python scripts/evaluate_pattern_forward.py
+
+    # 自定义：更严的开盘缺口与更高的当日涨幅
+    python scripts/evaluate_pattern_forward.py --open-gap-max 3 --day-return-min 8
+
+    # 扫一组阈值组合做对比
+    python scripts/evaluate_pattern_forward.py --sweep-gap 2,3,4 --sweep-return 7,8,10
+
+    # 顺带看日内（T 开盘买、T 收盘卖）——注意那是未来函数，仅作参考
+    python scripts/evaluate_pattern_forward.py --with-intraday
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+import pandas as pd
+
+from core.pattern_forward_eval import (
+    ROUND_TRIP_COST_PCT,
+    PatternReport,
+    PatternSpec,
+    summarize_horizon,
+)
+
+WARMUP = 210
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="形态前瞻收益检验")
+    parser.add_argument("--start", default="2024-08-01", help="行情起始（需留 210 日预热）")
+    parser.add_argument("--prev-day-max", type=float, default=3.0, help="T-1 日涨幅上限 %%")
+    parser.add_argument("--open-gap-max", type=float, default=4.0, help="T 日开盘缺口上限 %%")
+    parser.add_argument("--day-return-min", type=float, default=7.0, help="T 日涨幅下限 %%")
+    parser.add_argument("--min-amount-wan", type=float, default=8000.0, help="20 日均额下限（万元）")
+    parser.add_argument("--horizons", default="5,10", help="持有期，逗号分隔")
+    parser.add_argument("--sweep-gap", default="", help="扫开盘缺口，如 2,3,4")
+    parser.add_argument("--sweep-return", default="", help="扫当日涨幅，如 7,8,10")
+    parser.add_argument("--with-intraday", action="store_true", help="附带日内对照（未来函数）")
+    parser.add_argument("--cache", default="", help="行情缓存 CSV，跳过在线取数")
+    parser.add_argument("--json-out", default="", help="结构化结果输出路径")
+    return parser.parse_args()
+
+
+def load_market(start: str, cache: str) -> pd.DataFrame:
+    if cache and Path(cache).exists():
+        print(f"[pattern] 使用缓存 {cache}")
+        frame = pd.read_csv(cache, dtype={"ts_code": str, "trade_date": str})
+    else:
+        from integrations.fetch_a_share_csv import cached_trade_dates
+        from integrations.tushare_client import get_pro
+
+        pro = get_pro()
+        if pro is None:
+            raise SystemExit("需要 TUSHARE_TOKEN，或用 --cache 指定行情 CSV")
+        end = pd.Timestamp.now().strftime("%Y-%m-%d")
+        days = [str(d) for d in cached_trade_dates() if start <= str(d) <= end]
+        frames = []
+        for day in days:
+            try:
+                got = pro.daily(trade_date=day.replace("-", ""), fields="ts_code,trade_date,open,close,amount")
+                if got is not None and not got.empty:
+                    frames.append(got)
+            except Exception as exc:  # noqa: BLE001 - 单日失败不中断
+                print(f"[pattern] {day} 取数失败: {str(exc)[:60]}")
+        if not frames:
+            raise SystemExit("未取到行情")
+        frame = pd.concat(frames)
+    frame["d"] = pd.to_datetime(frame.trade_date, format="%Y%m%d")
+    return frame.sort_values(["ts_code", "d"])
+
+
+def _pivots(market: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    close = market.pivot_table(index="d", columns="ts_code", values="close")
+    open_ = market.pivot_table(index="d", columns="ts_code", values="open")
+    amount = market.pivot_table(index="d", columns="ts_code", values="amount")
+    return close, open_, amount
+
+
+def evaluate(market: pd.DataFrame, spec: PatternSpec, *, with_intraday: bool = False) -> tuple[PatternReport, dict]:
+    close, open_, amount = _pivots(market)
+    dates = list(close.index)
+    sink: dict[int, list[dict[str, float]]] = {h: [] for h in spec.horizons}
+    intraday: list[float] = []
+    max_h = max(spec.horizons)
+
+    for i in range(WARMUP, len(dates) - max_h - 1):
+        frame = pd.DataFrame(
+            {
+                "c": close.iloc[i],
+                "p1": close.iloc[i - 1],
+                "p2": close.iloc[i - 2],
+                "o": open_.iloc[i],
+                # 只用 T-1 及之前的成交额，避免用到当日信息。
+                "amt": amount.iloc[i - 20 : i].mean() / 10.0,
+                "nxo": open_.iloc[i + 1],
+            }
+        ).dropna()
+        frame = frame[(frame.p1 > 0) & (frame.p2 > 0) & (frame.nxo > 0) & (frame.amt >= spec.min_avg_amount_wan)]
+        if len(frame) < 50:
+            continue
+        frame["ret"] = (frame.c / frame.p1 - 1) * 100
+        frame["prev"] = (frame.p1 / frame.p2 - 1) * 100
+        frame["gap"] = (frame.o / frame.p1 - 1) * 100
+        hit = frame[
+            (frame.ret > spec.day_return_min_pct)
+            & (frame.prev < spec.prev_day_max_pct)
+            & (frame.gap <= spec.open_gap_max_pct)
+        ]
+        if hit.empty:
+            continue
+        if with_intraday:
+            intraday.append(float(((hit.c / hit.o - 1) * 100).mean()) - ROUND_TRIP_COST_PCT)
+        for horizon in spec.horizons:
+            exit_idx = i + 1 + horizon
+            if exit_idx >= len(dates):
+                continue
+            exit_px = close.iloc[exit_idx]
+            net = float((exit_px / hit.nxo - 1).mean() * 100) - ROUND_TRIP_COST_PCT
+            market_ret = float((exit_px / frame.nxo - 1).mean() * 100)
+            sink[horizon].append({"net": net, "market": market_ret, "hits": float(len(hit))})
+
+    report = PatternReport(spec=spec)
+    report.results = [summarize_horizon(h, sink[h]) for h in spec.horizons]
+    extra = {}
+    if intraday:
+        extra["intraday"] = {
+            "days": len(intraday),
+            "mean_pct": round(sum(intraday) / len(intraday), 4),
+            "positive_day_pct": round(100.0 * sum(1 for v in intraday if v > 0) / len(intraday), 1),
+            "caveat": "未来函数：用当日涨幅筛票再算当日收益，实盘开盘时不可知",
+        }
+    return report, extra
+
+
+def render(report: PatternReport, extra: dict) -> str:
+    lines = [
+        "**形态前瞻收益检验**",
+        "",
+        f"口径　{report.spec.describe()}",
+        f"买点　T+1 开盘（漏斗收盘后出信号，最早次日介入）　成本 {ROUND_TRIP_COST_PCT}%",
+        "",
+        "| 持有 | 天数 | 日均只数 | 净收益 | 市场 | 净超额 | 为正日% | 判定 |",
+        "| --- | --: | --: | --: | --: | --: | --: | --- |",
+    ]
+    for r in report.results:
+        if r.net_excess_pct is None:
+            lines.append(f"| T+{r.horizon} | {r.days} | — | — | — | — | — | {r.verdict} |")
+            continue
+        lines.append(
+            f"| T+{r.horizon} | {r.days} | {r.avg_hits:.0f} | {r.net_return_pct:+.2f}% | "
+            f"{r.market_return_pct:+.2f}% | {r.net_excess_pct:+.2f} | {r.positive_day_pct:.0f}% | {r.verdict} |"
+        )
+    if "intraday" in extra:
+        i = extra["intraday"]
+        lines += [
+            "",
+            f"日内对照　T 开盘买 / T 收盘卖：{i['mean_pct']:+.2f}%，{i['days']} 天中 {i['positive_day_pct']:.0f}% 为正",
+            f"　⚠️ {i['caveat']}",
+        ]
+    lines += ["", "**结论**"]
+    if report.any_actionable:
+        best = max((r for r in report.results if r.net_excess_pct is not None), key=lambda r: r.net_excess_pct)
+        lines.append(
+            f"- 净超额 {best.net_excess_pct:+.2f}pct 已过成本门槛 {ROUND_TRIP_COST_PCT}%，"
+            f"该形态值得考虑放宽对应通道；但仍需跨行情段确认后再改参数。"
+        )
+    else:
+        lines.append(
+            f"- 所有持有期的净超额均未过成本门槛 {ROUND_TRIP_COST_PCT}%，"
+            f"**不应为该形态放宽通道门槛**——放宽只会引入更多负 alpha 标的。"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    horizons = tuple(int(x) for x in args.horizons.split(",") if x.strip())
+    market = load_market(args.start, args.cache)
+    print(f"[pattern] 行情 {len(market):,} 行 / {market.ts_code.nunique()} 只")
+
+    gaps = [float(x) for x in args.sweep_gap.split(",") if x.strip()] or [args.open_gap_max]
+    rets = [float(x) for x in args.sweep_return.split(",") if x.strip()] or [args.day_return_min]
+    payload: list[dict] = []
+    for gap in gaps:
+        for ret in rets:
+            spec = PatternSpec(
+                prev_day_max_pct=args.prev_day_max,
+                open_gap_max_pct=gap,
+                day_return_min_pct=ret,
+                min_avg_amount_wan=args.min_amount_wan,
+                horizons=horizons,
+            )
+            report, extra = evaluate(market, spec, with_intraday=args.with_intraday)
+            print()
+            print(render(report, extra))
+            payload.append({**report.as_dict(), **extra})
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"\n[pattern] 已写 {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_pattern_forward_eval.py
+++ b/tests/core/test_pattern_forward_eval.py
@@ -1,0 +1,104 @@
+"""Tests for pattern forward-return evaluation.
+
+这个工具的职责是在放宽通道门槛**之前**先证伪：某类票抓到了到底赚不赚钱。
+2026-08-22 首轮九档全为负超额（-0.71 ~ -0.98pct）且随阈值收紧单调恶化，
+故未据此改动任何门槛。用例守住「不过成本门槛就不该行动」这条判定。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.pattern_forward_eval import (
+    MIN_DAYS,
+    MIN_HITS_PER_DAY,
+    ROUND_TRIP_COST_PCT,
+    HorizonResult,
+    PatternReport,
+    PatternSpec,
+    summarize_horizon,
+)
+
+
+def _daily(pairs, hits: float = 10.0):
+    return [{"net": n, "market": m, "hits": hits} for n, m in pairs]
+
+
+class TestSpec:
+    def test_defaults_match_first_run(self):
+        spec = PatternSpec()
+        assert spec.prev_day_max_pct == pytest.approx(3.0)
+        assert spec.open_gap_max_pct == pytest.approx(4.0)
+        assert spec.day_return_min_pct == pytest.approx(7.0)
+        assert spec.min_avg_amount_wan == pytest.approx(8000.0)
+
+    def test_describe_is_readable(self):
+        text = PatternSpec(open_gap_max_pct=3.0, day_return_min_pct=8.0).describe()
+        assert "T开盘<=3%" in text
+        assert "T涨幅>8%" in text
+
+
+class TestSummarize:
+    def test_requires_minimum_days(self):
+        result = summarize_horizon(5, _daily([(1.0, 0.0)] * (MIN_DAYS - 1)))
+        assert result.verdict == "样本不足"
+        assert result.net_excess_pct is None
+
+    def test_drops_days_with_too_few_hits(self):
+        """命中不足 3 只的日子不计入——个别票会主导当日均值。"""
+        rows = _daily([(1.0, 0.0)] * MIN_DAYS, hits=MIN_HITS_PER_DAY - 1)
+        assert summarize_horizon(5, rows).verdict == "样本不足"
+
+    def test_equal_weights_days_not_symbols(self):
+        rows = [{"net": 10.0, "market": 0.0, "hits": 500.0}, *_daily([(0.0, 0.0)] * (MIN_DAYS - 1))]
+        assert summarize_horizon(5, rows).net_excess_pct == pytest.approx(10.0 / MIN_DAYS)
+
+    def test_negative_verdict(self):
+        result = summarize_horizon(5, _daily([(-1.0, 0.5)] * MIN_DAYS))
+        assert result.verdict == "负贡献"
+        assert result.net_excess_pct == pytest.approx(-1.5)
+
+    def test_near_random_has_no_direction(self):
+        pairs = [(1.0, 0.0), (-1.0, 0.0)] * (MIN_DAYS // 2)
+        result = summarize_horizon(5, _daily(pairs))
+        assert result.positive_day_pct == pytest.approx(50.0)
+        assert result.verdict == "无方向性"
+
+
+class TestCostThreshold:
+    def test_small_positive_not_actionable(self):
+        """+0.1pct 撑不过 0.202% 往返成本，不足以支持放宽门槛。"""
+        assert HorizonResult(5, 200, 50.0, 0.1, 0.0, 70.0).actionable is False
+
+    def test_large_positive_actionable(self):
+        assert HorizonResult(5, 200, 50.0, 0.9, 0.0, 70.0).actionable is True
+
+    def test_none_excess_not_actionable(self):
+        assert HorizonResult(5, 0, 0.0, None, None, None).actionable is False
+
+    def test_first_run_values_are_not_actionable(self):
+        """首轮实测 -0.71/-0.82 必须判为不可行动。"""
+        for net, mkt in ((-0.27, 0.44), (-0.38, 0.44), (-0.14, 0.71)):
+            assert HorizonResult(5, 276, 84.0, net, mkt, 39.0).actionable is False
+
+
+class TestReport:
+    def test_any_actionable_false_when_all_negative(self):
+        report = PatternReport(spec=PatternSpec())
+        report.results = [
+            HorizonResult(5, 276, 84.0, -0.27, 0.44, 39.0),
+            HorizonResult(10, 276, 84.0, -0.14, 0.71, 43.0),
+        ]
+        assert report.any_actionable is False
+        assert report.at(10) is not None
+        assert report.at(99) is None
+
+    def test_serializable(self):
+        import json
+
+        report = PatternReport(spec=PatternSpec())
+        report.results = [HorizonResult(5, 276, 84.0, -0.27, 0.44, 39.0)]
+        payload = json.loads(json.dumps(report.as_dict(), ensure_ascii=False))
+        assert payload["any_actionable"] is False
+        assert payload["round_trip_cost_pct"] == pytest.approx(ROUND_TRIP_COST_PCT)
+        assert payload["results"][0]["verdict"] == "负贡献"


### PR DESCRIPTION
## Summary / 变更摘要

起因是一个具体质疑：每天都有「前一日平淡、当日大涨 7%+、次日未高开」的票，为什么漏斗抓不到。

此前每次遇到这类问题都临时写脚本、跑完即弃，下次重来。现在做成**每周自动跑的检验**：若哪天该形态的超额转正并稳定过成本门槛，才值得为它开通道；在此之前每次「感觉漏了机会」都能由数据当场否掉。

## 首轮结论：该形态是负 alpha，且收紧阈值更差

498 个交易日 / 2.3 万只次 / 扣 0.202% 往返成本，买点固定 **T+1 开盘**（漏斗收盘后出信号，实盘最早次日介入）：

| 开盘缺口≤ | 当日涨幅≥ | 日均只数 | 净收益 | **净超额** | 为正日 |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 4% | 7% | 84 | −0.27% | **−0.71** | 39% |
| 3% | 7% | 79 | −0.30% | −0.73 | 39% |
| 2% | 7% | 70 | −0.33% | −0.77 | 41% |
| 3% | 8% | 60 | −0.38% | **−0.82** | 41% |
| 2% | 8% | 54 | −0.42% | −0.86 | 40% |
| 2% | 10% | 28 | −0.55% | **−0.98** | 39% |

**九档全负且单调恶化** —— 当日涨幅要求越高、开盘要求越严，次日接力概率越低（动能已在当日释放完）。对照同期全市场（20 日均额 ≥ 8000 万）T+5 为 **+0.44%**，即买这批票不如随便买。**故不为该形态放宽任何通道门槛。**

## 顺带查明它们为何进不了八通道

T-1 日结构特征：仅 **12.8%** 距 60 日高 <5%、**19.7%** 处低位（距 250 日低 <35%）、**16.4%** 是缩量状态。

突破类要新高、底部类要低位缩量、趋势类要 RPS≥75，而这批票落在「三不像」的中间地带 —— **不是门槛设错，是它们确实不符合任何一种已实现结构**。

## 同时发现钱在日内，但那是未来函数

同一批票 T 日开盘买、T 日收盘卖为 **+10.35%**，276 天 **100% 为正**。

但这是用「当日涨幅」筛票再算「当日开盘到收盘」收益 —— 实盘开盘时并不知道哪只会收在高位。工具保留 `--with-intraday` 作对照，并在输出中**显式标注该 caveat**。

要验证「开盘 30 分钟能否预判」需历史分钟数据，而 TickFlow 的 `get_intraday` 无论 count 传 1200 还是 5000 都只返回当日 241 根，取不到历史，故该路径当前无法回测。

## 自动化

- 每周六北京时间 **12:10** 自动跑，默认扫 3×3 阈值网格 × 持有期 5/10 日
- 结果推飞书 + 落 `docs/evidence/pattern_forward_eval.json` 作 artifact
- `workflow_dispatch` 可手动传参随时用自己的口径复跑

排班避开既有评估任务与 Tushare 配额高峰：09:40 regime → 10:10 exit → 10:40 gate_alpha → 11:10 purity → **12:10 pattern**。

## Validation / 验证

- `pytest tests/` — **3273 passed, 22 skipped**（新增 13 个用例：按交易日等权而非按只数加权、命中不足 3 只的日子剔除、无方向性判定、+0.1pct 不过成本门槛、首轮实测值必须判为不可行动）
- 脚本以真实两年行情跑通，输出与手工测算**完全一致**（−0.71 / −0.82）
- `check_workflow_hygiene` PASS（inputs 已改为先落 env 再进 shell）
- `ruff check .` / `ruff format --check .`、`quality_gate --check-functions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)