### PR TITLE
feat(step3): 研报绑定 dataSnapshotHash 缓存

### DIFF
--- a/core/report_snapshot_cache.py
+++ b/core/report_snapshot_cache.py
@@ -1,0 +1,95 @@
+"""Bind Step3 LLM reports to a hash of the data that produced them."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from utils.env import env_bool
+
+PROMPT_VERSION = "wyckoff_funnel_system_v3"
+CACHE_VERSION = "step3_snapshot_v1"
+
+
+def snapshot_cache_enabled() -> bool:
+    return env_bool("STEP3_SNAPSHOT_CACHE", True)
+
+
+def data_snapshot_hash(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, ensure_ascii=True, sort_keys=True, default=str).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    return f"{CACHE_VERSION}:{digest}"
+
+
+def build_step3_snapshot_payload(
+    *,
+    trade_date: str,
+    regime: str,
+    model: str,
+    selected_rows: list[dict[str, Any]],
+    rag_veto_lines: list[str],
+    prompt_version: str = PROMPT_VERSION,
+) -> dict[str, Any]:
+    return {
+        "trade_date": str(trade_date or ""),
+        "regime": str(regime or ""),
+        "model": str(model or ""),
+        "prompt_version": prompt_version,
+        "rag_veto_lines": list(rag_veto_lines),
+        "selected_rows": [_row_fingerprint(row) for row in selected_rows],
+    }
+
+
+def cache_file(snapshot_hash: str, cache_dir: Path) -> Path:
+    safe = snapshot_hash.replace(":", "_")
+    return Path(cache_dir) / f"{safe}.json"
+
+
+def load_cached_report(snapshot_hash: str, cache_dir: Path) -> dict[str, Any] | None:
+    path = cache_file(snapshot_hash, cache_dir)
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if payload.get("data_snapshot_hash") != snapshot_hash:
+        return None
+    return payload
+
+
+def store_cached_report(snapshot_hash: str, report: dict[str, Any], cache_dir: Path) -> Path:
+    path = cache_file(snapshot_hash, cache_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = dict(report)
+    body["data_snapshot_hash"] = snapshot_hash
+    path.write_text(json.dumps(body, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def default_cache_dir() -> Path:
+    import os
+
+    raw = os.getenv("STEP3_SNAPSHOT_CACHE_DIR") or os.path.join(os.getenv("LOGS_DIR", "logs"), "step3_cache")
+    return Path(raw)
+
+
+def selected_rows_from_df(frame: Any) -> list[dict[str, Any]]:
+    if frame is None or getattr(frame, "empty", True):
+        return []
+    return frame.to_dict(orient="records")
+
+
+def _row_fingerprint(row: dict[str, Any]) -> dict[str, Any]:
+    keep = (
+        "code",
+        "signal_type",
+        "score",
+        "watch_score",
+        "close",
+        "industry",
+        "tag",
+    )
+    return {key: row.get(key) for key in keep if key in row}

--- a/docs/STEP3_SNAPSHOT_CACHE.md
+++ b/docs/STEP3_SNAPSHOT_CACHE.md
@@ -1,0 +1,7 @@
+# Step3 dataSnapshotHash 缓存
+
+Step3 研报缓存键绑定交易日、水温、候选指纹、RAG 否决清单、prompt 版本和模型。候选分数变了必须重跑 LLM，避免行情已变仍复用旧结论。
+
+默认 `STEP3_SNAPSHOT_CACHE=1`。目录：`STEP3_SNAPSHOT_CACHE_DIR` 或 `logs/step3_cache`。
+
+**影响范围**：Step3 AI 研报 / 飞书正文复用。不改漏斗分层、跨日确认、OMS、TUI。

--- a/tests/test_report_snapshot_cache.py
+++ b/tests/test_report_snapshot_cache.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from core.report_snapshot_cache import (
+    build_step3_snapshot_payload,
+    data_snapshot_hash,
+    load_cached_report,
+    store_cached_report,
+)
+
+
+def _payload(**overrides):
+    base = {
+        "trade_date": "2026-08-21",
+        "regime": "NEUTRAL",
+        "model": "gemini-x",
+        "selected_rows": [{"code": "000001", "score": 1.2}],
+        "rag_veto_lines": [],
+    }
+    base.update(overrides)
+    return build_step3_snapshot_payload(**base)
+
+
+def test_hash_changes_when_candidate_score_changes():
+    first = data_snapshot_hash(_payload())
+    second = data_snapshot_hash(_payload(selected_rows=[{"code": "000001", "score": 9.9}]))
+    assert first != second
+    assert first.startswith("step3_snapshot_v1:")
+
+
+def test_cache_roundtrip_rejects_stale_hash(tmp_path):
+    payload = _payload()
+    snapshot = data_snapshot_hash(payload)
+    store_cached_report(snapshot, {"report": "ok", "used_models": {"Trend": "m"}}, tmp_path)
+    hit = load_cached_report(snapshot, tmp_path)
+    assert hit is not None
+    assert hit["report"] == "ok"
+    assert load_cached_report("step3_snapshot_v1:deadbeef", tmp_path) is None

--- a/workflows/step3_batch_report.py
+++ b/workflows/step3_batch_report.py
@@ -19,6 +19,7 @@ from workflows.step3_inputs import (
 from workflows.step3_llm import call_step3_track_reports, route_label
 from workflows.step3_models import (
     Step3CandidateBundle,
+    Step3LlmResult,
     Step3RagResult,
     Step3RunOptions,
     Step3SelectionState,
@@ -130,13 +131,13 @@ def _run_step3_selection(
     preview_result = maybe_return_step3_preview(options, track_plan.track_requests, WYCKOFF_FUNNEL_SYSTEM_PROMPT)
     if preview_result:
         return preview_result
-    llm_result = call_step3_track_reports(
-        track_plan.track_requests,
-        track_plan.track_inputs,
-        selected_df,
-        options,
-        WYCKOFF_FUNNEL_SYSTEM_PROMPT,
-        report_progress,
+    llm_result = _step3_llm_or_cache(
+        options=options,
+        selected_df=selected_df,
+        rag_lines=rag_result.veto_lines,
+        market_context=market_context,
+        track_plan=track_plan,
+        report_progress=report_progress,
     )
     if not llm_result.ok:
         return (False, llm_result.status, "")
@@ -211,3 +212,49 @@ def run(
         selection=selection,
         report_progress=report_progress,
     )
+
+
+def _step3_llm_or_cache(
+    *,
+    options: Step3RunOptions,
+    selected_df: pd.DataFrame,
+    rag_lines: list[str],
+    market_context,
+    track_plan: Step3TrackPlan,
+    report_progress,
+) -> Step3LlmResult:
+    from core.report_snapshot_cache import (
+        build_step3_snapshot_payload,
+        data_snapshot_hash,
+        default_cache_dir,
+        load_cached_report,
+        selected_rows_from_df,
+        snapshot_cache_enabled,
+        store_cached_report,
+    )
+
+    payload = build_step3_snapshot_payload(
+        trade_date=str(getattr(market_context.window, "end_trade_date", "")),
+        regime=str(market_context.regime or ""),
+        model=options.model,
+        selected_rows=selected_rows_from_df(selected_df),
+        rag_veto_lines=rag_lines,
+    )
+    snapshot = data_snapshot_hash(payload)
+    cache_dir = default_cache_dir()
+    if snapshot_cache_enabled():
+        hit = load_cached_report(snapshot, cache_dir)
+        if hit and hit.get("report"):
+            print(f"[step3] 命中 snapshot cache {snapshot[:24]}")
+            return Step3LlmResult(True, "ok_cache", str(hit["report"]), dict(hit.get("used_models") or {}))
+    result = call_step3_track_reports(
+        track_plan.track_requests,
+        track_plan.track_inputs,
+        selected_df,
+        options,
+        WYCKOFF_FUNNEL_SYSTEM_PROMPT,
+        report_progress,
+    )
+    if result.ok and snapshot_cache_enabled():
+        store_cached_report(snapshot, {"report": result.report, "used_models": result.used_models}, cache_dir)
+    return result


### PR DESCRIPTION
## Summary / 变更摘要

Step3 批量研报按 `dataSnapshotHash` 命中磁盘缓存，同一数据快照不再重复烧 LLM。默认 `STEP3_SNAPSHOT_CACHE=1`，目录可用 `STEP3_SNAPSHOT_CACHE_DIR` 覆盖。

对照来源：FinSight 快照哈希缓存。不改买入许可。

## 影响范围

| 模块 | 是否影响 | 说明 |
| --- | --- | --- |
| **Step3 研报生成** | 是 | `workflows/step3_batch_report.py` 读写缓存 |
| **漏斗打分 / 候选** | 否 | |
| **OMS / Step4** | 否 | |
| **TUI** | 否 | |
| **多市场** | 否（只碰 Step3 批跑路径） | |
| **买入许可** | 否 | |

## Validation / 验证

- 本地：`.venv/bin/python -m pytest -q tests/test_report_snapshot_cache.py` → 2 passed
- 本地：fast gate（ruff + quality_gate）通过
- 请以本 PR 的 CI 绿为合入依据


Made with [Cursor](https://cursor.com)