### PR TITLE
feat(research): Signal→Event→Position 研究层

### DIFF
--- a/core/signal_event_position.py
+++ b/core/signal_event_position.py
@@ -1,0 +1,62 @@
+"""Research-only Signal → Event → Position view of existing L4 types."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+SIGNAL_CATALOG = {
+    "spring": {"family": "accum", "event": "test_supply"},
+    "lps": {"family": "accum", "event": "last_point_support"},
+    "compression": {"family": "accum", "event": "coil"},
+    "sos": {"family": "trend", "event": "sign_of_strength"},
+    "evr": {"family": "trend", "event": "effort_vs_result"},
+    "trend_pullback": {"family": "trend", "event": "pullback"},
+    "utad": {"family": "distrib", "event": "upthrust_after_distribution"},
+    "upthrust": {"family": "distrib", "event": "upthrust"},
+}
+
+
+def to_signal(signal_type: str, code: str, trade_date: str, **fields: Any) -> dict[str, Any]:
+    key = str(signal_type or "").strip().lower()
+    meta = SIGNAL_CATALOG.get(key, {"family": "unknown", "event": key or "unknown"})
+    return {
+        "signal_type": key,
+        "code": str(code),
+        "trade_date": str(trade_date),
+        "family": meta["family"],
+        "event": meta["event"],
+        **fields,
+    }
+
+
+def event_matches(
+    signals: Iterable[dict[str, Any]],
+    *,
+    all_of: Iterable[str] = (),
+    any_of: Iterable[str] = (),
+    not_of: Iterable[str] = (),
+) -> bool:
+    present = {str(item.get("signal_type") or "") for item in signals}
+    required = {str(item) for item in all_of}
+    optional = {str(item) for item in any_of}
+    forbidden = {str(item) for item in not_of}
+    if required and not required.issubset(present):
+        return False
+    if optional and present.isdisjoint(optional):
+        return False
+    if forbidden and not present.isdisjoint(forbidden):
+        return False
+    return True
+
+
+def position_intent(matched: bool, family: str) -> str:
+    if not matched:
+        return "FLAT"
+    if family == "distrib":
+        return "EXIT"
+    if family == "accum":
+        return "PROBE"
+    if family == "trend":
+        return "HOLD"
+    return "FLAT"

--- a/docs/SIGNAL_EVENT_POSITION.md
+++ b/docs/SIGNAL_EVENT_POSITION.md
@@ -1,0 +1,5 @@
+# Signal → Event → Position
+
+研究层把已有 L4 信号编成可组合事件（`all_of` / `any_of` / `not_of`），再映射 `FLAT/PROBE/HOLD/EXIT`。默认不接入生产漏斗打分。
+
+**影响范围**：研究/回测事件组合。不改生产漏斗、OMS、TUI、多市场。

--- a/tests/test_signal_event_position.py
+++ b/tests/test_signal_event_position.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from core.signal_event_position import event_matches, position_intent, to_signal
+
+
+def test_compose_spring_and_not_utad():
+    signals = [
+        to_signal("spring", "000001", "2026-08-21"),
+        to_signal("lps", "000001", "2026-08-21"),
+    ]
+    assert event_matches(signals, all_of=("spring",), any_of=("lps", "sos"), not_of=("utad",))
+    assert not event_matches(signals, all_of=("sos",))
+    assert position_intent(True, "accum") == "PROBE"
+    assert position_intent(True, "distrib") == "EXIT"
+    assert position_intent(False, "trend") == "FLAT"


### PR DESCRIPTION
## Summary / 变更摘要

新增只读研究层：Signal（信号）→ Event（事件）→ Position（仓位意图）的组合抽象，方便对照 czsc 的三层写法。

**不接入生产打分、不改漏斗、不改 OMS。** 这是研究脚手架，合入后也不会自动改买入许可。

## 影响范围

| 模块 | 是否影响 | 说明 |
| --- | --- | --- |
| **研究层 / 文档** | 是 | `core/signal_event_position.py` + docs |
| **漏斗打分** | 否 | 未接线 |
| **OMS / Step4** | 否 | |
| **Step3** | 否 | |
| **TUI** | 否 | |
| **买入许可** | 否 | |

## Validation / 验证

- 本地：`.venv/bin/python -m pytest -q tests/test_signal_event_position.py` → 1 passed
- 本地：fast gate 通过
- 请以本 PR 的 CI 绿为合入依据


Made with [Cursor](https://cursor.com)