### PR TITLE
feat(factor): IC 反向打分影子池——只观察不下单

### DIFF
--- a/core/ic_shadow_score.py
+++ b/core/ic_shadow_score.py
@@ -1,0 +1,135 @@
+"""IC 反向打分影子池：把阈值门换成横截面排序的验证载体。
+
+## 为什么不直接改八通道
+
+2026-08-22 的 IC 扫描显示 32 个因子-前瞻组合**全为负 IC**，其中 19 个在 3 段样本上
+方向全一致——生产四条通道（主升 rps_slow>=75、趋势延续 ret60 高、加速突破
+ret20>=15% 且放量、点火破局放量破新高）方向都反了。
+
+但 IC 只说明**方向**反了，不说明该设什么阈值；而阈值化本身就是过拟合来源
+（同期参数网格 walk-forward 仅 1/16 个窗口为正）。所以正确做法是先并行跑一个
+按 IC 加权排序的影子池，只写 observation 不下单，观察两三周再谈替换。
+
+## 打分方式
+
+对每个因子做**横截面分位**（0~100），按 `sign * |IC_IR|` 归一化权重加权求和。
+反向因子（IC<0）取负号后参与，故最终分数越高越好。
+
+与阈值门的关键差别：`RPS 69.3` 与 `RPS 75` 只是分数略低，不再是进/不进的鸿沟——
+这消除了「门槛线上的票本质随机」这个问题。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# 影子池在 signal_observations 里的标识。source 已有 shadow_added/shadow_removed
+# 等用法，这里沿用同一列避免新建表。
+SHADOW_SOURCE = "ic_shadow"
+SHADOW_CHANNEL = "IC反向打分"
+# 每日写入上限。取 top-N 而非全部：影子池的目的是模拟「每天买 1~2 只」的实盘约束，
+# 留一点余量便于观察排序质量。
+DEFAULT_TOP_N = 10
+# 权重绝对值低于此值的因子不参与——避免长尾噪声稀释主因子。
+MIN_ABS_WEIGHT = 0.05
+
+
+@dataclass(frozen=True)
+class FactorWeight:
+    """单个因子的合成配置。weight 已含方向：负值表示因子值越大越差。"""
+
+    name: str
+    weight: float
+
+    @property
+    def reversed_use(self) -> bool:
+        return self.weight < 0
+
+
+@dataclass
+class ShadowScoreConfig:
+    """影子池打分配置。默认权重来自 2026-08-22 首轮 IC 扫描的 T+10 结果。
+
+    只收录三段方向全一致且通过可用门槛（|IC|>=0.02 且 |IC_IR|>=0.30）的因子。
+    2026-08-22 用生产 FunnelConfig 真实参数重测后，满足两条的恰好是这三个：
+    rps_fast（20 日横截面分位）、ret60、dry_vol_min10_q250（10 日最低量 / 250 日分位）。
+
+    vol_ratio_5_20 虽 IR -0.33 通过门槛，但只有 2/3 段同向，故不纳入——方向不稳的
+    因子进模型等于引入拟合。turnover_amt / bias_200 等为正日占比落在 45~55%
+    噪声带内，按 AGENTS.md 判定为无方向性。
+    """
+
+    weights: tuple[FactorWeight, ...] = (
+        # IC -0.0711 / IR -0.38，各段 -0.084 -0.058 -0.072
+        FactorWeight("rps_fast", -0.38),
+        # IC -0.0692 / IR -0.37，各段 -0.086 -0.051 -0.071
+        FactorWeight("ret60", -0.37),
+        # IC -0.0504 / IR -0.35，各段 -0.070 -0.017 -0.063
+        FactorWeight("dry_vol_min10_q250", -0.35),
+    )
+    top_n: int = DEFAULT_TOP_N
+    min_avg_amount_wan: float = 8000.0
+    horizon: int = 10
+
+    def normalized(self) -> dict[str, float]:
+        """归一化到绝对值和为 1，并剔除权重过小的因子。"""
+        keep = [w for w in self.weights if abs(w.weight) >= MIN_ABS_WEIGHT]
+        total = sum(abs(w.weight) for w in keep)
+        if total <= 0:
+            return {}
+        return {w.name: w.weight / total for w in keep}
+
+    def describe(self) -> str:
+        parts = [f"{name}{weight:+.3f}" for name, weight in self.normalized().items()]
+        return f"top{self.top_n} / T+{self.horizon} / " + " ".join(parts)
+
+
+@dataclass
+class ShadowPick:
+    code: str
+    score: float
+    rank: int
+    factor_ranks: dict[str, float] = field(default_factory=dict)
+
+    def as_features(self) -> dict[str, object]:
+        """写入 features_json 的内容，便于事后核对分数构成。"""
+        return {
+            "ic_shadow_score": round(self.score, 4),
+            "ic_shadow_rank": self.rank,
+            "factor_percentiles": {k: round(v, 2) for k, v in self.factor_ranks.items()},
+        }
+
+
+def combine_scores(
+    factor_percentiles: dict[str, dict[str, float]],
+    config: ShadowScoreConfig,
+) -> list[ShadowPick]:
+    """按权重合成分数并取 top-N。
+
+    factor_percentiles: {因子名: {代码: 横截面分位 0~100}}。分位由调用方计算，
+    这样核心逻辑可脱离 pandas 单测。
+    """
+    weights = config.normalized()
+    if not weights:
+        return []
+    usable = {name: factor_percentiles[name] for name in weights if name in factor_percentiles}
+    if not usable:
+        return []
+    # 只对所有可用因子都有值的标的打分——缺值补 50 会把无信息标的抬进 top-N。
+    codes: set[str] | None = None
+    for panel in usable.values():
+        present = {code for code, value in panel.items() if value is not None and value == value}
+        codes = present if codes is None else (codes & present)
+    if not codes:
+        return []
+
+    scored: list[tuple[str, float, dict[str, float]]] = []
+    for code in codes:
+        ranks = {name: float(usable[name][code]) for name in usable}
+        score = sum(weights[name] * ranks[name] for name in usable)
+        scored.append((code, score, ranks))
+    scored.sort(key=lambda item: -item[1])
+    return [
+        ShadowPick(code=code, score=score, rank=index + 1, factor_ranks=ranks)
+        for index, (code, score, ranks) in enumerate(scored[: max(config.top_n, 0)])
+    ]

--- a/scripts/run_ic_shadow_pool.py
+++ b/scripts/run_ic_shadow_pool.py
@@ -1,0 +1,164 @@
+"""IC 反向打分影子池：每日取 top-N 写 observation，只观察不下单。
+
+## 为什么需要它
+
+2026-08-22 的 IC 扫描显示生产四条通道方向都反了（主升 rps_slow>=75 的 IC 是
+-0.0697、加速突破的放量 vol_ratio 是 -0.0262），且该结论在 3 段样本上方向全一致
+——是当日唯一跨段稳定的发现。
+
+但不能据此直接改八通道：IC 只说明方向反了，不说明该设什么阈值，而阈值化本身就是
+过拟合来源（参数网格 walk-forward 仅 1/16 个窗口为正）。故先并行跑影子池，
+用 source='ic_shadow' 写入 signal_observations，两三周后与现有通道对比再决定。
+
+写入复用既有表而非新建：signal_observations 已有 channel / priority_score /
+features_json 字段，且 source 列已有 shadow_added / shadow_removed 等用法。
+
+用法::
+
+    # 干跑，只打印不写库
+    python scripts/run_ic_shadow_pool.py --cache /tmp/snap/hist_full.csv.gz --dry-run
+
+    # 正式写入
+    python scripts/run_ic_shadow_pool.py --cache /tmp/snap/hist_full.csv.gz
+
+    # 用自定义权重（默认取首轮 IC 扫描结果）
+    python scripts/run_ic_shadow_pool.py --weights ret60=-0.37,dry_vol_q250=-0.31
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import _bootstrap  # noqa: F401
+import pandas as pd
+
+from core.ic_shadow_score import (
+    SHADOW_CHANNEL,
+    SHADOW_SOURCE,
+    FactorWeight,
+    ShadowPick,
+    ShadowScoreConfig,
+    combine_scores,
+)
+
+WARMUP = 260
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="IC 反向打分影子池")
+    p.add_argument("--cache", required=True, help="行情快照（hist_full.csv.gz 或 tushare CSV）")
+    p.add_argument("--trade-date", default="", help="信号日 YYYY-MM-DD，默认取行情最后一日")
+    p.add_argument("--top-n", type=int, default=10)
+    p.add_argument("--min-amount-wan", type=float, default=8000.0)
+    p.add_argument("--weights", default="", help="因子=权重，逗号分隔；留空用首轮 IC 默认值")
+    p.add_argument("--dry-run", action="store_true", help="只打印不写库")
+    return p.parse_args()
+
+
+def build_config(args: argparse.Namespace) -> ShadowScoreConfig:
+    if not args.weights:
+        return ShadowScoreConfig(top_n=args.top_n, min_avg_amount_wan=args.min_amount_wan)
+    parsed: list[FactorWeight] = []
+    for item in args.weights.split(","):
+        if not item.strip():
+            continue
+        name, _, raw = item.partition("=")
+        parsed.append(FactorWeight(name.strip(), float(raw)))
+    if not parsed:
+        raise SystemExit("--weights 解析为空")
+    return ShadowScoreConfig(weights=tuple(parsed), top_n=args.top_n, min_avg_amount_wan=args.min_amount_wan)
+
+
+def compute_percentiles(
+    market: pd.DataFrame, config: ShadowScoreConfig, trade_date: str
+) -> tuple[dict[str, dict[str, float]], str, int]:
+    """算出信号日各因子的横截面分位。返回 (面板, 实际信号日, 参与标的数)。
+
+    因子构造与 scripts/scan_factor_ic.py 保持一致，否则影子池打分与 IC 结论会脱节。
+    """
+    from scripts.scan_factor_ic import build_factors
+
+    factors, close, _open = build_factors(market)
+    dates = list(close.index)
+    if len(dates) <= WARMUP:
+        raise SystemExit(f"行情不足：需 >{WARMUP} 个交易日，实际 {len(dates)}")
+    if trade_date:
+        target = pd.Timestamp(trade_date)
+        if target not in close.index:
+            raise SystemExit(f"{trade_date} 不在行情交易日内")
+        idx = dates.index(target)
+    else:
+        idx = len(dates) - 1
+    liquidity = (factors["turnover_amt"] / 10.0).iloc[idx]
+    eligible = liquidity[liquidity >= config.min_avg_amount_wan].index
+
+    panels: dict[str, dict[str, float]] = {}
+    for name in config.normalized():
+        if name not in factors:
+            raise SystemExit(f"未知因子 {name}；可选 {sorted(factors)}")
+        row = factors[name].iloc[idx].reindex(eligible).dropna()
+        if row.empty:
+            continue
+        panels[name] = (row.rank(pct=True) * 100).to_dict()
+    return panels, str(dates[idx].date()), len(eligible)
+
+
+def to_rows(picks: list[ShadowPick], trade_date: str, config: ShadowScoreConfig) -> list[dict]:
+    """转成 signal_observations 行。signal_type 用 ic_shadow 便于与真实买点区分。"""
+    import json
+
+    return [
+        {
+            "market": "cn",
+            "trade_date": trade_date,
+            "code": pick.code.split(".")[0],
+            "signal_type": SHADOW_SOURCE,
+            "source": SHADOW_SOURCE,
+            "channel": SHADOW_CHANNEL,
+            "candidate_rank": pick.rank,
+            "priority_score": round(pick.score, 4),
+            # 影子池不进推荐、不下单——这两个标记确保下游不会误取。
+            "ai_recommended": False,
+            "selected_for_ai": False,
+            "candidate_status": "shadow_observe",
+            "strategy_version": config.describe(),
+            "features_json": json.dumps(pick.as_features(), ensure_ascii=False),
+        }
+        for pick in picks
+    ]
+
+
+def main() -> int:
+    args = parse_args()
+    config = build_config(args)
+    from scripts.scan_factor_ic import load_market
+
+    market = load_market(args.cache, "2024-01-01")
+    print(f"[shadow] 行情 {len(market):,} 行 / {market.ts_code.nunique()} 只")
+    print(f"[shadow] 配置 {config.describe()}")
+
+    panels, trade_date, universe = compute_percentiles(market, config, args.trade_date)
+    picks = combine_scores(panels, config)
+    print(f"[shadow] 信号日 {trade_date}　可选标的 {universe}　选出 {len(picks)} 只\n")
+    if not picks:
+        print("[shadow] 无标的入选")
+        return 0
+
+    print(f"{'#':>3} {'代码':12}{'分数':>9}  各因子分位")
+    for pick in picks:
+        detail = " ".join(f"{k}={v:.0f}" for k, v in pick.factor_ranks.items())
+        print(f"{pick.rank:>3} {pick.code:12}{pick.score:>+9.2f}  {detail}")
+
+    rows = to_rows(picks, trade_date, config)
+    if args.dry_run:
+        print(f"\n[shadow] dry-run：本应写入 {len(rows)} 行")
+        return 0
+    from integrations.supabase_signal_feedback import upsert_signal_observations
+
+    written = upsert_signal_observations(rows)
+    print(f"\n[shadow] 已写入 {written} 行到 signal_observations（source={SHADOW_SOURCE}）")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_ic_shadow_score.py
+++ b/tests/core/test_ic_shadow_score.py
@@ -1,0 +1,130 @@
+"""Tests for the IC reverse-scoring shadow pool.
+
+2026-08-22 的 IC 扫描（用生产 FunnelConfig 真实参数）显示生产四条通道方向都反了，
+且三个因子同时满足「可用」与「三段方向全一致」：
+
+    rps_fast            IC -0.0711  IR -0.38  各段 -0.084 -0.058 -0.072
+    ret60               IC -0.0692  IR -0.37  各段 -0.086 -0.051 -0.071
+    dry_vol_min10_q250  IC -0.0504  IR -0.35  各段 -0.070 -0.017 -0.063
+
+影子池把这三个反向加权成横截面排序，只写 observation 不下单——因为 IC 只说明方向反了，
+不说明该设什么阈值，而阈值化本身就是过拟合来源（参数网格 walk-forward 仅 1/16）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.ic_shadow_score import (
+    MIN_ABS_WEIGHT,
+    SHADOW_CHANNEL,
+    SHADOW_SOURCE,
+    FactorWeight,
+    ShadowPick,
+    ShadowScoreConfig,
+    combine_scores,
+)
+
+
+class TestConfig:
+    def test_defaults_are_the_three_stable_factors(self):
+        names = {w.name for w in ShadowScoreConfig().weights}
+        assert names == {"rps_fast", "ret60", "dry_vol_min10_q250"}
+
+    def test_all_defaults_are_reverse(self):
+        """三个因子 IC 全为负，必须都反向使用。"""
+        assert all(w.reversed_use for w in ShadowScoreConfig().weights)
+
+    def test_weights_normalize_to_one(self):
+        weights = ShadowScoreConfig().normalized()
+        assert sum(abs(v) for v in weights.values()) == pytest.approx(1.0, abs=1e-9)
+
+    def test_drops_negligible_weights(self):
+        config = ShadowScoreConfig(weights=(FactorWeight("big", -0.4), FactorWeight("tiny", -MIN_ABS_WEIGHT / 2)))
+        assert set(config.normalized()) == {"big"}
+
+    def test_empty_weights_yield_nothing(self):
+        assert ShadowScoreConfig(weights=()).normalized() == {}
+
+
+class TestCombine:
+    def _panels(self):
+        # A 极弱势极缩量、C 极强势放量——反向打分应把 A 排首位、C 垫底。
+        return {
+            "rps_fast": {"A": 3.0, "B": 50.0, "C": 97.0},
+            "ret60": {"A": 5.0, "B": 50.0, "C": 95.0},
+            "dry_vol_min10_q250": {"A": 2.0, "B": 50.0, "C": 96.0},
+        }
+
+    def test_weak_and_dry_ranks_first(self):
+        picks = combine_scores(self._panels(), ShadowScoreConfig(top_n=3))
+        assert [p.code for p in picks] == ["A", "B", "C"]
+        assert picks[0].rank == 1
+
+    def test_respects_top_n(self):
+        assert len(combine_scores(self._panels(), ShadowScoreConfig(top_n=2))) == 2
+
+    def test_zero_top_n_returns_empty(self):
+        assert combine_scores(self._panels(), ShadowScoreConfig(top_n=0)) == []
+
+    def test_drops_codes_missing_any_factor(self):
+        """缺值不补 50——否则无信息标的会被抬进 top-N。"""
+        panels = self._panels()
+        panels["rps_fast"]["D"] = 1.0  # D 只有一个因子有值
+        picks = combine_scores(panels, ShadowScoreConfig(top_n=10))
+        assert "D" not in {p.code for p in picks}
+
+    def test_nan_treated_as_missing(self):
+        panels = self._panels()
+        panels["ret60"]["A"] = float("nan")
+        assert "A" not in {p.code for p in combine_scores(panels, ShadowScoreConfig(top_n=3))}
+
+    def test_unknown_factor_ignored(self):
+        picks = combine_scores({"rps_fast": {"A": 1.0}}, ShadowScoreConfig(top_n=3))
+        assert [p.code for p in picks] == ["A"]
+
+    def test_no_panels_returns_empty(self):
+        assert combine_scores({}, ShadowScoreConfig()) == []
+
+
+class TestObservationRows:
+    def test_rows_marked_as_non_tradeable(self):
+        """影子池不得进推荐或下单链路——三个标记必须同时成立。"""
+        from scripts.run_ic_shadow_pool import to_rows
+
+        picks = [ShadowPick(code="600363.SH", score=-1.06, rank=1, factor_ranks={"ret60": 0.0})]
+        row = to_rows(picks, "2026-08-14", ShadowScoreConfig())[0]
+        assert row["ai_recommended"] is False
+        assert row["selected_for_ai"] is False
+        assert row["candidate_status"] == "shadow_observe"
+
+    def test_source_and_channel_tagged(self):
+        from scripts.run_ic_shadow_pool import to_rows
+
+        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
+        assert row["source"] == SHADOW_SOURCE
+        assert row["channel"] == SHADOW_CHANNEL
+        assert row["signal_type"] == SHADOW_SOURCE
+
+    def test_code_stripped_of_suffix(self):
+        from scripts.run_ic_shadow_pool import to_rows
+
+        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
+        assert row["code"] == "600363"
+
+    def test_features_json_records_composition(self):
+        import json
+
+        from scripts.run_ic_shadow_pool import to_rows
+
+        pick = ShadowPick("600363.SH", -1.06, 1, {"ret60": 0.0, "rps_fast": 3.0})
+        payload = json.loads(to_rows([pick], "2026-08-14", ShadowScoreConfig())[0]["features_json"])
+        assert payload["ic_shadow_rank"] == 1
+        assert payload["factor_percentiles"]["rps_fast"] == pytest.approx(3.0)
+
+    def test_strategy_version_carries_weights(self):
+        """便于事后区分不同权重版本写入的行。"""
+        from scripts.run_ic_shadow_pool import to_rows
+
+        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
+        assert "rps_fast" in row["strategy_version"]


### PR DESCRIPTION
## Summary / 变更摘要

IC 扫描显示生产四条通道方向都反了，但**不能据此直接改阈值** —— IC 只说明方向反了、不说明该设什么值，而阈值化本身就是过拟合来源（参数网格 walk-forward 仅 **1/16** 个窗口为正）。

故先并行跑影子池：按 IC 加权排序取 top-N，用 `source='ic_shadow'` 写 `signal_observations`，**只观察不下单**，两三周后与现有八通道对比再谈替换。

## 用当前生产参数重测后的权重

上一轮 PR 我已把 `scan_factor_ic` 的因子改为读 `FunnelConfig` 真实参数（`dry_vol_lookback`、`amount_avg_window`、`rps_window_fast`），因子名随之变化 —— 我一度按记忆里的旧名写权重而报「未知因子 `dry_vol_q250`」，重测后修正。

三段方向全一致且通过可用门槛的恰好三个：

| 因子 | IC | IC_IR | 各段 IC |
| --- | ---: | ---: | --- |
| **rps_fast** | −0.0711 | −0.38 | −0.084 −0.058 −0.072 |
| **ret60** | −0.0692 | −0.37 | −0.086 −0.051 −0.071 |
| **dry_vol_min10_q250** | −0.0504 | −0.35 | −0.070 −0.017 −0.063 |

`vol_ratio_5_20` 虽 IR −0.33 过门槛，但**仅 2/3 段同向，不纳入** —— 方向不稳的因子进模型等于引入拟合。`turnover_amt` / `bias_200` / `price_from_low250` 等为正日占比落在 45~55% 噪声带内，按 `AGENTS.md` 判为无方向性。

## 与阈值门的关键差别

对每个因子取**横截面分位**（0~100），按 `sign × |IC_IR|` 归一化加权。

`RPS 69.3` 与 `RPS 75` 只是分数略低，**不再是进/不进的鸿沟** —— 这消除了「门槛线上的票本质随机」这个问题，并天然可排序（实盘每天只买 1~2 只，过滤器给不出「哪只最好」）。

2026-08-14 实跑（5254 只可选）选出的 8 只，**三个因子分位全部落在 0~8**，即极弱势 + 极缩量，正是 IC 指向的方向：

```
  1 600363   -1.06  rps_fast=0 ret60=0 dry_vol=3
  2 002796   -2.00  rps_fast=4 ret60=1 dry_vol=1
  3 600577   -2.98  rps_fast=3 ret60=1 dry_vol=6
```

## 安全设计

- **复用 `signal_observations` 而非新建表**：该表已有 `channel`/`priority_score`/`features_json`，且 `source` 列已有 `shadow_added`/`shadow_removed` 等用法
- 每行强制 `ai_recommended=False`、`selected_for_ai=False`、`candidate_status='shadow_observe'`，确保**不进推荐与下单链路**（有用例守）
- 缺任一因子的标的**直接剔除而非补 50 分** —— 补中位会把无信息标的抬进 top-N
- `strategy_version` 记录权重组合，便于事后区分不同版本写入的行

## Validation / 验证

- `pytest tests/` — **3324 passed, 22 skipped**（新增 17 个用例：默认即三个稳定因子且全部反向、权重归一化、剔除过小权重、弱势缩量者排首位、缺值与 NaN 视为缺失、影子行三个禁用标记必须同时成立、代码去后缀、`features_json` 记录分数构成）
- 以 96MB 真实快照 dry-run 跑通
- `ruff check .` / `ruff format --check .`、`quality_gate --check-functions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)