### PR TITLE
feat(ci): 影子池接每日定时——开始积累对比样本

### DIFF
--- a/.github/workflows/ic_shadow_pool.yml
+++ b/.github/workflows/ic_shadow_pool.yml
@@ -1,0 +1,104 @@
+name: IC Shadow Pool
+
+# IC 反向打分影子池：每交易日取 top-N 写 signal_observations，只观察不下单。
+#
+# 起因：IC 扫描显示生产四条通道方向都反了（主升 rps_slow>=75、趋势延续 ret60 高、
+# 加速突破 ret20>=15% 且放量、点火破局放量破新高），且三个因子在 3 段样本上方向全一致：
+#
+#   rps_fast            IC -0.0711  IR -0.38  各段 -0.084 -0.058 -0.072
+#   ret60               IC -0.0692  IR -0.37  各段 -0.086 -0.051 -0.071
+#   dry_vol_min10_q250  IC -0.0504  IR -0.35  各段 -0.070 -0.017 -0.063
+#
+# 但 IC 只说明方向反了、不说明该设什么阈值，而阈值化本身就是过拟合来源
+# （参数网格 walk-forward 仅 1/16 个窗口为正）。故先并行积累影子样本，
+# 两三周后用同一套评估口径与现有八通道对比，再决定是否替换通道。
+#
+# 安全性：写入行强制 ai_recommended=False / selected_for_ai=False /
+# candidate_status='shadow_observe'，不进推荐与下单链路（tests 有用例守）。
+on:
+  schedule:
+    # 北京时间周日至周四 18:20（UTC 10:20）。排在主漏斗 17:17 之后——用同一交易日的
+    # 收盘数据；也避开 19:25 的 review_list_replay，不争 Tushare 配额。
+    - cron: "20 10 * * 0-4"
+  workflow_dispatch:
+    inputs:
+      trade_date:
+        description: "信号日 YYYY-MM-DD，留空取行情最后一日"
+        default: ""
+      top_n:
+        description: "每日写入条数"
+        default: "10"
+      weights:
+        description: "因子=权重，逗号分隔；留空用 IC 扫描默认值"
+        default: ""
+      dry_run:
+        description: "只打印不写库"
+        type: boolean
+        default: false
+
+concurrency:
+  group: ic-shadow-pool-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      PYTHONUNBUFFERED: "1"
+      # 只写 signal_observations 的影子行。
+      WYCKOFF_WRITE_CONTEXT: "server_job"
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
+      TZ: Asia/Shanghai
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Fetch market snapshot
+        run: |
+          # 因子需要 250 日以上回看窗口，故起点比信号日早约 1.5 年。
+          python scripts/backtest_snapshot_fetch.py \
+            --start "$(date -d '-560 days' +%Y-%m-%d 2>/dev/null || date -v-560d +%Y-%m-%d)" \
+            --end "$(date +%Y-%m-%d)" \
+            --board all \
+            --output-dir /tmp/shadow_snap
+
+      - name: Score and write shadow pool
+        env:
+          # inputs 先落 env 再进 shell，避免表达式直接拼进命令行。
+          IN_TRADE_DATE: ${{ inputs.trade_date }}
+          IN_TOP_N: ${{ inputs.top_n || '10' }}
+          IN_WEIGHTS: ${{ inputs.weights }}
+          IN_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          EXTRA=()
+          if [ -n "$IN_TRADE_DATE" ]; then
+            EXTRA+=(--trade-date "$IN_TRADE_DATE")
+          fi
+          if [ -n "$IN_WEIGHTS" ]; then
+            EXTRA+=(--weights "$IN_WEIGHTS")
+          fi
+          if [ "$IN_DRY_RUN" = "true" ]; then
+            EXTRA+=(--dry-run)
+          fi
+          python scripts/run_ic_shadow_pool.py \
+            --cache /tmp/shadow_snap/hist_full.csv.gz \
+            --top-n "$IN_TOP_N" \
+            "${EXTRA[@]}"

--- a/tests/core/test_ic_shadow_score.py
+++ b/tests/core/test_ic_shadow_score.py
@@ -128,3 +128,40 @@ class TestObservationRows:
 
         row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
         assert "rps_fast" in row["strategy_version"]
+
+
+class TestDailyWorkflow:
+    """影子池已接每日定时——这些用例守住它不会误入下单链路或撞车其它任务。"""
+
+    def _workflow(self) -> dict:
+        from pathlib import Path
+
+        import yaml
+
+        data = yaml.safe_load(Path(".github/workflows/ic_shadow_pool.yml").read_text(encoding="utf-8"))
+        # PyYAML 把 `on:` 解析成布尔 True，这是已知怪癖。
+        return data
+
+    def test_runs_after_main_funnel(self):
+        """必须在主漏斗（北京 17:17 / UTC 9:17）之后，才能用同一交易日的收盘数据。"""
+        data = self._workflow()
+        on = data.get("on") or data.get(True)
+        minute, hour, _dom, _mon, dow = on["schedule"][0]["cron"].split()
+        assert int(hour) > 9 or (int(hour) == 9 and int(minute) > 17)
+        # 与主漏斗同为周日至周四。
+        assert dow == "0-4"
+
+    def test_does_not_collide_with_review_replay(self):
+        """review_list_replay 在 UTC 11:25；影子池须早于它，避免争 Tushare 配额。"""
+        data = self._workflow()
+        on = data.get("on") or data.get(True)
+        minute, hour, *_ = on["schedule"][0]["cron"].split()
+        assert (int(hour), int(minute)) < (11, 25)
+
+    def test_write_context_is_server_job(self):
+        env = self._workflow()["jobs"]["run"]["env"]
+        assert env["WYCKOFF_WRITE_CONTEXT"] == "server_job"
+
+    def test_has_timeout(self):
+        """快照抓取 + 打分约 30 分钟；设上限避免卡死占用额度。"""
+        assert self._workflow()["jobs"]["run"]["timeout-minutes"] <= 120


### PR DESCRIPTION
## Summary / 变更摘要

影子池上一个 PR（#321）只有手动脚本 —— **不接定时就无法积累样本，也就无法与现有八通道对比**。现每交易日自动跑。

## 排班（北京时间，周日至周四）

| 时间 | 任务 |
| --- | --- |
| 17:17 | `wyckoff_funnel` 主漏斗 |
| **18:20** | **`ic_shadow_pool` 影子池 ← 本次** |
| 19:25 | `review_list_replay` 复盘 |

选 18:20 的两个约束**都写成了用例**：必须**晚于主漏斗**（才能用同一交易日收盘数据）、必须**早于 `review_list_replay`**（避免争 Tushare 配额）。

## 实现细节

快照起点取信号日前 **560 天**：因子需 250 日以上回看窗口（`dry_vol_min10_q250` 用 250 日分位、`ret60` 需 60 日），留足余量。`date` 命令同时兼容 GNU（`-d`）与 BSD（`-v`）。

`inputs` 先落 env 再进 shell（`check_workflow_hygiene` 要求），支持手动指定 `trade_date` / `top_n` / `weights` / `dry_run`，便于回填历史日或试新权重。

## 安全性

写入行强制 `ai_recommended=False` / `selected_for_ai=False` / `candidate_status='shadow_observe'` —— #321 已有用例守，本 PR 再加 `WYCKOFF_WRITE_CONTEXT=server_job` 断言。

## Validation / 验证

- `pytest tests/` — **3326 passed, 22 skipped**（新增 4 个用例）
- `check_workflow_hygiene` PASS、`ruff check`/`format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)