### PR TITLE
fix(factor): 影子池因子名与 scanner 对齐——上线两天一直失败

### DIFF
--- a/core/ic_shadow_score.py
+++ b/core/ic_shadow_score.py
@@ -51,21 +51,30 @@ class ShadowScoreConfig:
     """影子池打分配置。默认权重来自 2026-08-22 首轮 IC 扫描的 T+10 结果。
 
     只收录三段方向全一致且通过可用门槛（|IC|>=0.02 且 |IC_IR|>=0.30）的因子。
-    2026-08-22 用生产 FunnelConfig 真实参数重测后，满足两条的恰好是这三个：
-    rps_fast（20 日横截面分位）、ret60、dry_vol_min10_q250（10 日最低量 / 250 日分位）。
 
-    vol_ratio_5_20 虽 IR -0.33 通过门槛，但只有 2/3 段同向，故不纳入——方向不稳的
-    因子进模型等于引入拟合。turnover_amt / bias_200 等为正日占比落在 45~55%
-    噪声带内，按 AGENTS.md 判定为无方向性。
+    **因子名必须与 scripts/scan_factor_ic.build_factors 的键逐字一致**——影子池的分位
+    面板由那个函数产出。2026-08-24 生产失败就源于此：默认权重曾写 dry_vol_min10_q250
+    与 vol_ratio_5_20，而 main 上的键是 dry_vol_q250 / vol_ratio，脚本直接
+    SystemExit「未知因子」。那两个名字来自一个未合并的本地版本，我按它写了权重却没
+    在 main 上验证。tests 现有用例断言两侧键集一致，防止再次漂移。
+
+    用 main 的真实因子定义重测（498 个交易日 / 3 段各约 75 日）后可用的是：
+
+        ret60         IC -0.0350  IR -0.35  三段同号
+        rps_slow      IC -0.0350  IR -0.35  三段同号
+        dry_vol_q250  IC -0.0320  IR -0.32  三段同号
+
+    rps_slow 与 ret60 的 IC 完全相同——前者就是后者的横截面分位，**只取其一**，
+    否则同一信息被计权两次。rps_fast（IR -0.25）、vol_ratio（IR -0.24 且仅 2/3 段
+    同向）未过门槛；turnover_amt / bias_200 / price_from_low250 等为正日占比落在
+    45~55% 噪声带内，按 AGENTS.md 判为无方向性。
     """
 
     weights: tuple[FactorWeight, ...] = (
-        # IC -0.0711 / IR -0.38，各段 -0.084 -0.058 -0.072
-        FactorWeight("rps_fast", -0.38),
-        # IC -0.0692 / IR -0.37，各段 -0.086 -0.051 -0.071
-        FactorWeight("ret60", -0.37),
-        # IC -0.0504 / IR -0.35，各段 -0.070 -0.017 -0.063
-        FactorWeight("dry_vol_min10_q250", -0.35),
+        # IC -0.0350 / IR -0.35，三段方向全一致
+        FactorWeight("ret60", -0.35),
+        # IC -0.0320 / IR -0.32，三段方向全一致
+        FactorWeight("dry_vol_q250", -0.32),
     )
     top_n: int = DEFAULT_TOP_N
     min_avg_amount_wan: float = 8000.0

--- a/tests/core/test_ic_shadow_score.py
+++ b/tests/core/test_ic_shadow_score.py
@@ -27,9 +27,43 @@ from core.ic_shadow_score import (
 
 
 class TestConfig:
-    def test_defaults_are_the_three_stable_factors(self):
+    def test_default_factor_names_exist_in_scanner(self):
+        """**最关键的一条**：权重里的因子名必须真实存在于 build_factors。
+
+        2026-08-24 生产失败就源于此——默认权重写 dry_vol_min10_q250 / vol_ratio_5_20，
+        而 main 上的键是 dry_vol_q250 / vol_ratio，脚本直接 SystemExit「未知因子」。
+        那两个名字来自未合并的本地版本，我按它写了权重却没在 main 上验证。
+        """
+        import pandas as pd
+
+        from scripts.scan_factor_ic import build_factors
+
+        # 造一份最小行情，只为取出因子键集，不关心数值。
+        dates = pd.date_range("2024-01-01", periods=3, freq="B")
+        frame = pd.DataFrame(
+            {
+                "ts_code": ["000001"] * 3,
+                "d": dates,
+                "open": [10.0] * 3,
+                "close": [10.0] * 3,
+                "high": [10.0] * 3,
+                "low": [10.0] * 3,
+                "vol": [100.0] * 3,
+                "amount": [1000.0] * 3,
+            }
+        )
+        available = set(build_factors(frame)[0])
+        missing = {w.name for w in ShadowScoreConfig().weights} - available
+        assert not missing, f"权重引用了不存在的因子: {sorted(missing)}；可选 {sorted(available)}"
+
+    def test_defaults_are_the_stable_factors(self):
         names = {w.name for w in ShadowScoreConfig().weights}
-        assert names == {"rps_fast", "ret60", "dry_vol_min10_q250"}
+        assert names == {"ret60", "dry_vol_q250"}
+
+    def test_does_not_double_count_ret60_and_rps_slow(self):
+        """rps_slow 就是 ret60 的横截面分位，两者 IC 完全相同，不得同时入选。"""
+        names = {w.name for w in ShadowScoreConfig().weights}
+        assert not {"ret60", "rps_slow"} <= names
 
     def test_all_defaults_are_reverse(self):
         """三个因子 IC 全为负，必须都反向使用。"""
@@ -51,9 +85,8 @@ class TestCombine:
     def _panels(self):
         # A 极弱势极缩量、C 极强势放量——反向打分应把 A 排首位、C 垫底。
         return {
-            "rps_fast": {"A": 3.0, "B": 50.0, "C": 97.0},
             "ret60": {"A": 5.0, "B": 50.0, "C": 95.0},
-            "dry_vol_min10_q250": {"A": 2.0, "B": 50.0, "C": 96.0},
+            "dry_vol_q250": {"A": 2.0, "B": 50.0, "C": 96.0},
         }
 
     def test_weak_and_dry_ranks_first(self):
@@ -70,7 +103,7 @@ class TestCombine:
     def test_drops_codes_missing_any_factor(self):
         """缺值不补 50——否则无信息标的会被抬进 top-N。"""
         panels = self._panels()
-        panels["rps_fast"]["D"] = 1.0  # D 只有一个因子有值
+        panels["ret60"]["D"] = 1.0  # D 只有一个因子有值
         picks = combine_scores(panels, ShadowScoreConfig(top_n=10))
         assert "D" not in {p.code for p in picks}
 
@@ -80,7 +113,8 @@ class TestCombine:
         assert "A" not in {p.code for p in combine_scores(panels, ShadowScoreConfig(top_n=3))}
 
     def test_unknown_factor_ignored(self):
-        picks = combine_scores({"rps_fast": {"A": 1.0}}, ShadowScoreConfig(top_n=3))
+        """只提供部分因子面板时，按可用部分打分（缺全部因子才返回空）。"""
+        picks = combine_scores({"ret60": {"A": 1.0}}, ShadowScoreConfig(top_n=3))
         assert [p.code for p in picks] == ["A"]
 
     def test_no_panels_returns_empty(self):
@@ -117,17 +151,17 @@ class TestObservationRows:
 
         from scripts.run_ic_shadow_pool import to_rows
 
-        pick = ShadowPick("600363.SH", -1.06, 1, {"ret60": 0.0, "rps_fast": 3.0})
+        pick = ShadowPick("600363.SH", -1.06, 1, {"ret60": 0.0, "dry_vol_q250": 3.0})
         payload = json.loads(to_rows([pick], "2026-08-14", ShadowScoreConfig())[0]["features_json"])
         assert payload["ic_shadow_rank"] == 1
-        assert payload["factor_percentiles"]["rps_fast"] == pytest.approx(3.0)
+        assert payload["factor_percentiles"]["dry_vol_q250"] == pytest.approx(3.0)
 
     def test_strategy_version_carries_weights(self):
         """便于事后区分不同权重版本写入的行。"""
         from scripts.run_ic_shadow_pool import to_rows
 
         row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
-        assert "rps_fast" in row["strategy_version"]
+        assert "ret60" in row["strategy_version"]
 
 
 class TestDailyWorkflow:


### PR DESCRIPTION
## Summary / 变更摘要

影子池自 8/23 上线起两次定时**全部失败**，原因是默认权重里的因子名与 scanner 不一致。与 ETF 改动无关（失败早一天）。

## 失败原因

```
未知因子 dry_vol_min10_q250；可选 ['dry_vol_q250', 'vol_ratio', ...]
```

默认权重写的是 `dry_vol_min10_q250` / `vol_ratio_5_20`，而 main 上 `scan_factor_ic.build_factors` 的键是 `dry_vol_q250` / `vol_ratio`。

那两个名字来自一个**未合并到 main 的本地版本**（该版本把因子改为读 `FunnelConfig` 真实参数、名字随之变化），我按它重测并写了权重，**却没在 main 上验证过一次**。

排查时我一度怀疑 OOM（310 万行 × 22 个面板），实测 6 个基础面板仅 120 MB、含衍生共约 441 MB，远未触及 runner 的 7 GB，故排除。

## 用 main 的真实因子定义重测

498 个交易日 / 3 段各约 75 日，可用且三段方向全一致的是：

| 因子 | IC | IC_IR |
| --- | ---: | ---: |
| **ret60** | −0.0350 | −0.35 |
| rps_slow | −0.0350 | −0.35 |
| **dry_vol_q250** | −0.0320 | −0.32 |

`rps_slow` 与 `ret60` 的 IC **完全相同** —— 前者就是后者的横截面分位，**只取其一**，否则同一信息被计权两次。

`rps_fast`（IR −0.25）与 `vol_ratio`（IR −0.24 且仅 2/3 段同向）未过门槛；`turnover_amt` / `bias_200` / `price_from_low250` 等为正日占比落在 45~55% 噪声带内，按 `AGENTS.md` 判为无方向性。

**方向结论不变**（全部为负、三段一致），变的只是入选因子与权重：现为 `ret60 -0.522` / `dry_vol_q250 -0.478`。

## 根本修复：加防漂移用例

新增 `test_default_factor_names_exist_in_scanner` —— 用最小行情调 `build_factors` 取出真实键集，断言权重引用的因子全部存在。**这条用例若早存在，两天的失败当场就会被拦住。**

另加 `test_does_not_double_count_ret60_and_rps_slow` 防止重复计权。

## 真实跑通验证（上次漏掉的一步）

```
[shadow] 信号日 2026-08-14　可选标的 5254　选出 10 只
  1 688737  -2.06  ret60=2 dry_vol_q250=2
  2 688556  -2.31  ret60=2 dry_vol_q250=2
  3 000559  -2.71  ret60=3 dry_vol_q250=2
```

选出标的两个因子分位均在 2~5，即**极弱势 + 极缩量**，与 IC 指向的方向一致。

## Validation / 验证

- `pytest tests/` — **3298 passed, 22 skipped**（新增 2 个防漂移用例，另同步 5 处旧因子名断言）
- 以 96MB 真实快照 dry-run 跑通
- `ruff check .` / `format`、`quality_gate --check-functions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)