### PR TITLE
feat(factor): 量学 5 个候选因子进 scanner 观测（不进生产）

### DIFF
--- a/scripts/scan_factor_ic.py
+++ b/scripts/scan_factor_ic.py
@@ -113,6 +113,38 @@ def build_factors(market: pd.DataFrame) -> tuple[dict[str, pd.DataFrame], pd.Dat
     factors["amplitude60"] = (hi60 / low.rolling(60).min() - 1) * 100
     rng = high - low
     factors["close_position"] = ((close - low) / rng.where(rng > 0)) * 100
+
+    # --- 量学（A 股本土量价流派）候选因子 ---
+    # 量学与威科夫同源：都主张「量在价先、跟随大资金意图」，只是量学更贴 A 股微观结构
+    # （涨停板制度、散户主导、题材轮动）。这里把它的核心量柱形态做成因子持续观测。
+    #
+    # 2026-08-25 首轮实测（498 个交易日，3 段各约 75 日）：**无一通过可用门槛**——
+    #   vs_multiple_vol（倍量柱）      IC -0.0038  近乎零
+    #   vs_golden_vol（黄金柱）        IC +0.0051  近乎零
+    #   vs_volume_pit（量坑）          方向仅 2/3 段一致
+    #   vs_vol_stair（阶梯量）         方向仅 2/3 段一致
+    #   vs_price_vol_divergence       IC +0.0327 但样本仅 73 天，且拆开四象限后
+    #                                 「涨+缩量」净超额 -0.08、为正日 48%（无方向性），
+    #                                 即它是排序器而非选股器，不可据此建通道
+    # 故只进 scanner 观测、不进生产形态。若某个因子日后转为三段一致且过门槛，再评估。
+    v5 = vol.rolling(5).mean()
+    v10 = vol.rolling(10).mean()
+    prev_vol = vol.shift(1)
+    # 倍量柱：当日量 / 前日量。量学视 >=2 为主力进场。
+    factors["vs_multiple_vol"] = vol / prev_vol.where(prev_vol > 0)
+    # 黄金柱：当日量相对 5 日与 10 日均量中较大者的倍数。
+    golden_base = v5.where(v5 > 0).clip(lower=v10.where(v10 > 0))
+    factors["vs_golden_vol"] = vol / golden_base
+    # 量坑：当日量在近 20 日中的分位，越低越"坑"。
+    factors["vs_volume_pit"] = vol.rolling(20).rank(pct=True) * 100
+    # 阶梯量：5 日均量相对 10 日均量的抬升幅度，衡量量能是否逐级放大。
+    factors["vs_vol_stair"] = (v5 / v10.where(v10 > 0) - 1) * 100
+    # 价量背离：5 日涨幅 × 量能收缩程度。量学认为"涨而缩量"是主力控盘特征。
+    # 注意该构造把「涨+缩量」与「跌+放量」混为同号，判读时须拆象限看。
+    v5_prev = v5.shift(5)
+    factors["vs_price_vol_divergence"] = (close.pct_change(5, fill_method=None) * 100) * (
+        1 - v5 / v5_prev.where(v5_prev > 0)
+    )
     return factors, close, open_
 
 


### PR DESCRIPTION
## Summary / 变更摘要

把量学的 5 个核心量柱形态做成因子，**只进 scanner 观测、不进生产形态** —— 实测无一通过可用门槛。

## 背景：量学可视为更本土化的威科夫

两者同源 —— 都主张「量在价先、跟随大资金意图」，量学只是更贴 A 股微观结构（涨停板制度、散户主导、题材轮动）。

**现有数据支持往这个方向靠**：唯一跨段稳定的因子（`ret60` IC −0.0692、`dry_vol_q250` IC −0.0504）正是「反动量 + 缩量」，即威科夫吸筹逻辑；而失效的四条通道（主升/趋势延续/加速突破/点火）全在追动量。

## 但量学自己的买点信号在 A 股同样不灵

2026-08-25 实测（498 个交易日，3 段各约 75 日），**无一通过可用门槛**：

| 因子 | IC | 判定 |
| --- | ---: | --- |
| `vs_multiple_vol`（倍量柱） | −0.0038 | 近乎零 |
| `vs_golden_vol`（黄金柱） | +0.0051 | 近乎零 |
| `vs_volume_pit`（量坑） | — | 方向仅 2/3 段一致 |
| `vs_vol_stair`（阶梯量） | — | 方向仅 2/3 段一致 |
| `vs_price_vol_divergence` | **+0.0327** | 样本仅 73 天 |

## price_vol_divergence 看似最优，拆开后不成立

该因子构造为 `ret5 × (1 - v5/v5_prev)`，**把两种相反状态混为同号**：涨+缩量为正，跌+放量也为正。故按四象限拆开重测 T+5 净超额（221 天，扣 0.202%）：

| 象限 | 日均只数 | 净超额 | 为正日 |
| --- | ---: | ---: | ---: |
| **涨+缩量**（量学所指「主力控盘」） | 700 | **−0.08** | **48%** |
| 涨+放量 | 1038 | −0.20 | 43% |
| 跌+缩量 | 1448 | −0.34 | 34% |
| 跌+放量 | 627 | −0.43 | 33% |

**四象限无一为正。** 「涨+缩量」净超额 −0.08、为正日 48% —— 按 `AGENTS.md` 属无方向性。

IC +0.0327 来自**象限间的单调排序**（−0.08 → −0.20 → −0.34 → −0.43），即它是**有效的避险排序器、而非选股器**：最好的那一档也只是「不亏」而非「能赚」。若按 IC 建通道取 top-N，选出的是「涨+缩量」中最极端者，而该档整体无方向性，**取不出正收益**。故不进生产形态。

## 处置

5 个因子只进 scanner，随每周六 13:10 的定时扫描持续观测、落 `factor_ic_daily`。成本近零；**若某个因子日后转为三段方向一致且过门槛，那才是真信号**，届时再评估。

实现上修一处：`vs_golden_vol` 原用 `v5.combine(v10, max)` 触发「truth value of a Series is ambiguous」，改为 `v5.clip(lower=v10)`。

## Validation / 验证

- `pytest tests/` — **3312 passed, 22 skipped**
- 以 300 日 × 3 只合成行情验证 5 个因子末日取值均非空
- `ruff check .` / `format`、`quality_gate --check-functions`
- 本次未跑完整 IC 扫描 —— 本地 `/tmp` 快照已被系统清理，将由周六定时任务产出含新因子的结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)