### PR TITLE
ci(funnel): 开启影子账本记账

### DIFF
--- a/.github/workflows/wyckoff_funnel.yml
+++ b/.github/workflows/wyckoff_funnel.yml
@@ -73,6 +73,10 @@ jobs:
       SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       SUPABASE_USER_ID: ${{ secrets.SUPABASE_USER_ID }}
+      # 影子账本（paper ledger）：shadow_* 五张表与 seed 账户已建好，开启记账。
+      # 只写 USER_SHADOW:*（写入侧有前缀硬断言），挂在 Step4 之后且异常被吞，不影响实盘。
+      # 需要停掉时把 vars.SHADOW_LEDGER_ENABLED 设为 0，不必改 workflow。
+      SHADOW_LEDGER_ENABLED: ${{ vars.SHADOW_LEDGER_ENABLED || '1' }}
       RAG_SEMANTIC_VETO_ENABLED: ${{ vars.RAG_SEMANTIC_VETO_ENABLED || '1' }}
       RAG_SEMANTIC_PROVIDER: ${{ vars.RAG_SEMANTIC_PROVIDER || secrets.RAG_SEMANTIC_PROVIDER || 'efficiency' }}
       # 实盘风控：ATR/结构止损优先，-12% 仅灾难地板；非主线 5 日时间管理见 holding_time_policy


### PR DESCRIPTION
## Summary

`shadow_*` 五张表与 seed 账户已在线上建好,把 `SHADOW_LEDGER_ENABLED` 注入漏斗 workflow,影子账本开始记账。

此前默认关是因为建表未完成 —— 开着会每天在 summary 留一行 `failed_soft`。现在表有了,显式打开。

用 `vars.SHADOW_LEDGER_ENABLED || '1'`,**需要停时改 repo variable 即可,不必再动 workflow**。

## 已对真实表 dry-run

```
开关读取: SHADOW_LEDGER_ENABLED -> True
账户常量: USER_SHADOW:e66942b7-be66-46fe-95ed-ebc7f3b47928
读账本 OK: cash=100000.0 持仓=0
最近推荐日 20260825，取 8 只喂给买许可
规则准入: 通过 8 只, 拦掉 0 只
```

过程中顺带确认 `require_server_write_context` 守卫是有效的 —— 本地不带 `WYCKOFF_WRITE_CONTEXT=server_job` 会被直接拒绝写入:

```
PermissionError: write shadow_account requires WYCKOFF_WRITE_CONTEXT=server_job
```

## 风险面(合 #330 时已验证)

- 挂在 **Step4 之后**,异常被吞(`except` 返回 `ok: True`),不阻断漏斗
- 写入侧有 `USER_SHADOW:` 前缀**硬断言**,拒绝任何非影子账户
- 五张表与 `USER_LIVE` 的 portfolios / positions / trade_orders / daily_nav 完全隔离
- 买许可复用 `step4_candidate_meta`,与实盘同一套准入口径(confirmed / VALIDATED)

## 今晚会发生什么

漏斗 Step2/3 成功 → 影子账本挑候选 → **只写下夜计划**(`entry_mode=next_open`)。成交要等明天开盘价,所以 `shadow_events` 明日才开始有数据。会多一条独立飞书卡,标题带「影子账本 / paper」。

## Validation

- yaml 解析确认 env 生效
- `check_workflow_hygiene.py` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
