### PR TITLE
fix(ipc): 修好被网关拆开的字符,整轮回答不再变成一行编码错误

### DIFF
--- a/cli/ipc/remote.py
+++ b/cli/ipc/remote.py
@@ -29,6 +29,8 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+from cli.text_repair import repair_text
+
 logger = logging.getLogger(__name__)
 
 MAX_WORKERS = 4
@@ -78,7 +80,9 @@ class _Outbox:
         self._thread.start()
 
     def put(self, payload: dict[str, Any]) -> None:
-        raw = json.dumps(payload, ensure_ascii=False, default=str)
+        # 先修落单的代理字符（网关把一个字符拆到两个 chunk 里留下的）：紧接着的
+        # `encode("utf-8")` 是 strict 的，抛出去就是整轮回答变一行编码错误。
+        raw = repair_text(json.dumps(payload, ensure_ascii=False, default=str))
         if len(raw.encode("utf-8")) > MAX_FRAME_BYTES:
             raw = json.dumps(
                 {

--- a/cli/ipc/session.py
+++ b/cli/ipc/session.py
@@ -12,6 +12,8 @@ import uuid
 from collections.abc import Iterator
 from typing import Any
 
+from cli.text_repair import repair_text
+
 logger = logging.getLogger(__name__)
 
 # 与 TUI 一致：多轮对话保留在内存里，前端不必每次重传历史。
@@ -594,10 +596,18 @@ def _cap(value: Any) -> Any:
 
     截断而不是丢弃：前端拿到「前 768 KiB + 已截断」仍能显示个大概，而整个字段
     消失会让人以为工具什么都没返回。
+
+    进来的字符串先修一遍落单的代理字符。cli/runtime.py 已经在流式入口修过模型
+    正文，但走到这儿的不止那一条路 —— 工具结果、args 里的文件内容都可能带上
+    不可编码的字符。这里是 IPC 的最后一道关口，`len(...encode("utf-8"))` 一抛
+    UnicodeEncodeError 整轮回答就没了，所以在这层也兜一次。
     """
-    if isinstance(value, str) and len(value.encode("utf-8")) > MAX_IPC_FIELD_BYTES:
-        clipped = value.encode("utf-8")[:MAX_IPC_FIELD_BYTES].decode("utf-8", "ignore")
-        return clipped + "\n\n…（内容过大，已在 IPC 层截断）"
+    if isinstance(value, str):
+        value = repair_text(value)
+        if len(value.encode("utf-8")) > MAX_IPC_FIELD_BYTES:
+            clipped = value.encode("utf-8")[:MAX_IPC_FIELD_BYTES].decode("utf-8", "ignore")
+            return clipped + "\n\n…（内容过大，已在 IPC 层截断）"
+        return value
     if isinstance(value, dict):
         return {k: _cap(v) for k, v in value.items()}
     return value

--- a/cli/ipc/stdio.py
+++ b/cli/ipc/stdio.py
@@ -15,6 +15,8 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, wait
 from typing import Any, TextIO
 
+from cli.text_repair import repair_text
+
 logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = 1
@@ -65,7 +67,14 @@ def _emit(payload: dict[str, Any]) -> None:
     out = _protocol_out or sys.__stdout__
     line = json.dumps(payload, ensure_ascii=False, default=str)
     with _write_lock:
-        out.write(line + "\n")
+        try:
+            out.write(line + "\n")
+        except UnicodeEncodeError:
+            # 落单的代理字符编不成 UTF-8。上游（runtime 流式入口、IPC 的 _cap）
+            # 都会修，这里是最后一道：真漏过来时宁可让这一行带几个 U+FFFD，也不能
+            # 让异常冒出去 —— 那会连带把整轮回答变成一行编码错误。
+            # 整行一起修没问题：JSON 的结构字符都是 ASCII，动不到。
+            out.write(repair_text(line) + "\n")
         out.flush()
 
 

--- a/cli/runtime.py
+++ b/cli/runtime.py
@@ -48,6 +48,7 @@ from cli.loop_guard import (
 from cli.prepare_tool_call import PrepareDecision, accept, prepare_allowed_tools, prepare_exists, reject
 from cli.providers.base import LLMProvider
 from cli.scratchpad import AgentScratchpad
+from cli.text_repair import StreamTextRepair, repair_text
 from cli.tool_results import format_tool_result_for_context
 from cli.tools import ToolRegistry
 from cli.usage_metrics import as_int, enrich_usage, generation_seconds
@@ -128,6 +129,42 @@ def _iter_with_timeout(stream, timeout: float, cancel_check: Callable[[], bool] 
             with contextlib.suppress(Exception):
                 stream.close()
         raise
+
+
+# 哪些流式字段是「一段正文的一部分」，会被网关拆到两个 chunk 里。
+_STREAM_TEXT_FIELDS = ("text_delta", "thinking_delta")
+
+
+def _repair_split_chars(stream):
+    """接上被网关拆到两个 chunk 里的字符，落单的代理字符换成 U+FFFD。
+
+    在这里做而不是各 provider 里做：三家 provider 都可能遇到，而下游 IPC、
+    SQLite、JSONL 全是 strict UTF-8，漏一处就是整轮回答变一行报错。
+    """
+    repairs = {event_type: StreamTextRepair() for event_type in _STREAM_TEXT_FIELDS}
+
+    def flush_all() -> Iterator[RuntimeEvent]:
+        # 流结束在半个字符上时，攥着的尾巴要放出来，否则那点内容凭空消失。
+        for event_type, repair in repairs.items():
+            if tail := repair.flush():
+                yield {"type": event_type, "text": tail}
+
+    for chunk in stream:
+        chunk_type = chunk.get("type") if isinstance(chunk, dict) else None
+        if repair := repairs.get(chunk_type):
+            # 攥住尾巴等下一块拼上，所以这块可能什么都不剩 —— 那就别发空事件。
+            if fixed := repair.feed(str(chunk.get("text") or "")):
+                yield {**chunk, "text": fixed}
+            continue
+        # 出现非正文事件说明这一段正文到此为止，攥着的尾巴得先放出来，才能保持
+        # 「尾巴在前、本块在后」的顺序。
+        yield from flush_all()
+        if isinstance(chunk, dict) and isinstance(chunk.get("text"), str):
+            # tool_calls 也带 text，是 provider 自己累计的原始串，没走上面的逐块修复。
+            yield {**chunk, "text": repair_text(chunk["text"])}
+        else:
+            yield chunk
+    yield from flush_all()
 
 
 @dataclass
@@ -682,7 +719,8 @@ class AgentRuntime:
     ) -> Iterator[RuntimeEvent | RoundState]:
         round_state = RoundState(stream_started=time.monotonic())
         stream = self.provider.chat_stream(messages, self._tool_schemas(), system_prompt)
-        for chunk in _iter_with_timeout(stream, self.stream_chunk_timeout, self.cancel_check):
+        guarded = _repair_split_chars(_iter_with_timeout(stream, self.stream_chunk_timeout, self.cancel_check))
+        for chunk in guarded:
             event = self._consume_model_chunk(round_state, chunk, round_number)
             if event:
                 yield event

--- a/cli/scratchpad.py
+++ b/cli/scratchpad.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from cli.text_repair import repair_text
+
 _SENSITIVE_KEY_RE = re.compile(r"(api[_-]?key|token|password|secret|authorization|cookie)", re.IGNORECASE)
 _MAX_INLINE_STRING = 200_000
 
@@ -84,8 +86,12 @@ class AgentScratchpad:
 
     def append(self, entry: dict[str, Any]) -> None:
         safe_entry = scrub_sensitive_value(entry)
+        line = json.dumps(safe_entry, ensure_ascii=False, default=str)
         with self.path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(safe_entry, ensure_ascii=False, default=str))
+            # 落单的代理字符（网关把一个字符拆到两个 chunk 里）编不成 strict UTF-8。
+            # 这里的写没有 try 包着，而调用方在 runtime 的主流程上 —— 抛出去就是整轮
+            # 回答变一行编码错误。整行一起修没问题：JSON 结构字符都是 ASCII。
+            fh.write(repair_text(line))
             fh.write("\n")
 
     def record_thinking(self, content: str) -> None:

--- a/cli/text_repair.py
+++ b/cli/text_repair.py
@@ -1,0 +1,70 @@
+"""修复流式文本里落单的代理字符（lone surrogate）。
+
+网关会把一个字符拆到两个 SSE chunk 里。两种拆法都见过：
+
+- **UTF-16 代理对被拆开**：`💥` 是 `\\ud83d\\udca5`，两半分到相邻两个 delta。
+- **UTF-8 字节被拆开**：`股` 是 `e8 82 a1`，落单的字节以 surrogateescape
+  的形式（`\\udce8` 这类）到达。
+
+落单的代理字符没法用 strict UTF-8 编码。而下游全是 strict：IPC 协议通道写盘、
+chat_log 落 SQLite、scratchpad 落 JSONL、远程遥控算帧长 —— 任何一处抛
+UnicodeEncodeError，整轮回答都被 run_turn 的兜底 except 吞掉，界面上只剩一行
+`'utf-8' codec can't encode character ...`。
+
+所以在这里做两件事：把拆开的两半重新接上，接不上的换成 U+FFFD。
+"""
+
+from __future__ import annotations
+
+# 末尾攥住多少个代理字符等下文来拼。一个字符最多占 4 个 UTF-8 字节，UTF-16
+# 代理对占 2 个码位，所以 4 个足够拼出任何被拆开的字符；再多就不可能是「半个
+# 字符」了，只能是连续的多个字符，得放行，否则一直攥着不发。
+_MAX_PENDING = 4
+
+_SURROGATE_LOW = 0xD800
+_SURROGATE_HIGH = 0xDFFF
+
+
+def repair_text(text: str) -> str:
+    """把落单的代理字符换成 U+FFFD；能配对的先合起来。"""
+    if not text:
+        return text
+    try:
+        text.encode("utf-8")
+        return text
+    except UnicodeEncodeError:
+        pass
+    try:
+        # 先按「UTF-8 字节被拆开」解 —— surrogateescape 的逆运算能还原出原字符。
+        return text.encode("utf-8", "surrogateescape").decode("utf-8", "replace")
+    except UnicodeEncodeError:
+        # 掺了 UTF-16 代理对（表情符号被拆半），surrogateescape 只认 \\udc80-\\udcff。
+        # surrogatepass 能把配对的合起来，真落单的交给 replace。
+        return text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+
+
+def _split_pending(text: str) -> tuple[str, str]:
+    """切出末尾那段可能是「半个字符」的代理字符，留到下一块再拼。"""
+    cut = len(text)
+    while cut > 0 and _SURROGATE_LOW <= ord(text[cut - 1]) <= _SURROGATE_HIGH:
+        cut -= 1
+    return (text[:cut], text[cut:]) if len(text) - cut <= _MAX_PENDING else (text, "")
+
+
+class StreamTextRepair:
+    """逐块修复流式文本，末尾的半个字符攥到下一块拼上。
+
+    一路 feed，流结束时 flush 一次把攥着的尾巴放出来 —— 不 flush 的话，恰好
+    结束在半个字符上的那点内容会丢。
+    """
+
+    def __init__(self) -> None:
+        self._pending = ""
+
+    def feed(self, text: str) -> str:
+        body, self._pending = _split_pending(self._pending + text)
+        return repair_text(body)
+
+    def flush(self) -> str:
+        tail, self._pending = self._pending, ""
+        return repair_text(tail)

--- a/tests/cli/test_text_repair.py
+++ b/tests/cli/test_text_repair.py
@@ -1,0 +1,202 @@
+"""落单代理字符的修复 —— Windows 用户遇到的 `\\udca5` 报错。
+
+网关把 `💥`（UTF-16 代理对 `\\ud83d\\udca5`）拆到相邻两个 SSE delta 里，两半都
+成了落单的代理字符。落单代理没法 strict UTF-8 编码，而 IPC 写盘、chat_log 落
+SQLite、scratchpad 落 JSONL 全是 strict —— 任何一处抛异常，整轮回答都会被
+run_turn 的兜底 except 吞掉，界面上只剩一行编码错误。
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from cli.ipc.remote import _Outbox
+from cli.ipc.session import _cap, _project
+from cli.runtime import _repair_split_chars
+from cli.scratchpad import AgentScratchpad
+from cli.text_repair import StreamTextRepair, repair_text
+from tests.helpers.agent_loop_harness import AgentLoopHarness
+
+# 用户截图里的那个字符：U+1F4A5 💥 == 💥
+EMOJI_HIGH = "\ud83d"
+EMOJI_LOW = "\udca5"
+
+# 「股」= e8 82 a1，被按字节拆开时以 surrogateescape 形式到达
+CN_BYTES = ("\udce8\udc82", "\udca1")
+
+
+def encodable(text: str) -> str:
+    """编一次 strict UTF-8 —— 编不过就是本 bug 复现了。"""
+    text.encode("utf-8")
+    return text
+
+
+def test_lone_surrogate_is_not_encodable_without_repair():
+    # 先钉住前提：不修的话下游确实会炸。
+    with pytest.raises(UnicodeEncodeError):
+        (EMOJI_HIGH + EMOJI_LOW).encode("utf-8")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("正常文本 💥 ok", "正常文本 💥 ok"),  # 干净的内容原样放过
+        ("\udce8\udc82\udca1", "股"),  # 一块里的 UTF-8 字节碎片能还原
+        (EMOJI_HIGH + EMOJI_LOW, "💥"),  # 相邻的代理对合起来
+        ("x" + EMOJI_LOW, "x�"),  # 真落单的换成 U+FFFD
+        ("a" + EMOJI_HIGH + "b", "a�b"),
+    ],
+)
+def test_repair_text(raw: str, expected: str):
+    assert encodable(repair_text(raw)) == expected
+
+
+def test_split_emoji_across_chunks_is_rejoined():
+    repair = StreamTextRepair()
+    out = "".join(repair.feed(c) for c in ("大盘", EMOJI_HIGH, EMOJI_LOW + " 走弱"))
+    assert encodable(out + repair.flush()) == "大盘💥 走弱"
+
+
+def test_split_utf8_bytes_across_chunks_is_rejoined():
+    repair = StreamTextRepair()
+    out = "".join(repair.feed(c) for c in (CN_BYTES[0], CN_BYTES[1] + "票"))
+    assert encodable(out + repair.flush()) == "股票"
+
+
+def test_stream_ending_mid_character_still_emits_the_tail():
+    """流结束在半个字符上时，攥着的尾巴要放出来 —— 否则那点内容凭空消失。"""
+    repair = StreamTextRepair()
+    body = repair.feed("收盘" + EMOJI_HIGH)
+    assert encodable(body) == "收盘"
+    assert encodable(repair.flush()) == "�"
+
+
+def test_runtime_stream_repairs_split_emoji_and_keeps_other_chunks():
+    chunks = [
+        {"type": "text_delta", "text": "大盘", "round": 1},
+        {"type": "text_delta", "text": EMOJI_HIGH, "round": 1},
+        {"type": "text_delta", "text": EMOJI_LOW + " 走弱", "round": 1},
+        {"type": "usage", "input_tokens": 10, "output_tokens": 20},
+    ]
+
+    events = list(_repair_split_chars(iter(chunks)))
+
+    text = "".join(encodable(e["text"]) for e in events if e["type"] == "text_delta")
+    assert text == "大盘💥 走弱"
+    # 非文本 chunk 原样透传，round 之类的字段不能丢
+    assert {"type": "usage", "input_tokens": 10, "output_tokens": 20} in events
+    assert all(e.get("round") == 1 for e in events if e["type"] == "text_delta")
+
+
+def test_runtime_stream_repairs_tool_calls_accumulated_text():
+    """tool_calls 也带 text，是 provider 自己累计的串，不走逐块修复。"""
+    chunks = [{"type": "tool_calls", "tool_calls": [], "text": "调用前正文" + EMOJI_LOW}]
+
+    (event,) = list(_repair_split_chars(iter(chunks)))
+
+    assert encodable(event["text"]) == "调用前正文�"
+
+
+def test_runtime_stream_flushes_tail_before_non_text_chunk():
+    """攥着的尾巴要排在 tool_calls 之前 —— 那块带的是累计正文，顺序颠倒会读乱。"""
+    chunks = [
+        {"type": "text_delta", "text": "正文" + EMOJI_HIGH},
+        {"type": "tool_calls", "tool_calls": [], "text": ""},
+    ]
+
+    types = [e["type"] for e in _repair_split_chars(iter(chunks))]
+
+    assert types == ["text_delta", "text_delta", "tool_calls"]
+
+
+def test_runtime_stream_repairs_thinking_deltas_independently():
+    """思维链和正文各自攥尾巴 —— 交错时不能把两条流的半个字符拼到一起。"""
+    chunks = [
+        {"type": "thinking_delta", "text": EMOJI_HIGH},
+        {"type": "text_delta", "text": "正文"},
+        {"type": "thinking_delta", "text": EMOJI_LOW},
+    ]
+
+    events = list(_repair_split_chars(iter(chunks)))
+
+    thinking = "".join(encodable(e["text"]) for e in events if e["type"] == "thinking_delta")
+    assert thinking == "💥"
+
+
+def test_full_turn_answer_survives_split_emoji():
+    """用户遇到的那一幕：整轮回答本来会被换成一行编码错误。
+
+    done 事件的 text 由 runtime 累加得来，也是落 chat_log SQLite 的那份，
+    所以这里同时钉住了持久化不会炸。
+    """
+    harness = AgentLoopHarness(
+        rounds=[
+            [
+                {"type": "text_delta", "text": "今日市场观察：大盘"},
+                {"type": "text_delta", "text": EMOJI_HIGH},
+                {"type": "text_delta", "text": EMOJI_LOW + " 走弱。"},
+                {"type": "usage", "input_tokens": 8, "output_tokens": 7},
+            ]
+        ]
+    )
+
+    outcome = harness.run_turn([{"role": "user", "content": "跑今天的市场观察，给我研报"}])
+
+    assert encodable(outcome["result"]["text"]) == "今日市场观察：大盘💥 走弱。"
+
+
+def test_ipc_projection_survives_lone_surrogate():
+    """_cap 里的 len(...encode("utf-8")) 是原来的抛出点。"""
+    event = _project({"type": "text_delta", "text": "大" + EMOJI_LOW})
+    assert encodable(event["text"]) == "大�"
+
+
+def test_ipc_cap_still_truncates_after_repair():
+    """修复不能破坏原有的截断行为。"""
+    from cli.ipc.session import MAX_IPC_FIELD_BYTES
+
+    capped = _cap("阿" * MAX_IPC_FIELD_BYTES)
+    assert "已在 IPC 层截断" in capped
+    assert len(encodable(capped).encode("utf-8")) < MAX_IPC_FIELD_BYTES + 200
+
+
+def test_repaired_text_can_be_written_to_sqlite_and_json():
+    """chat_log 的 SQLite 写：绑参是 strict UTF-8。"""
+    repaired = repair_text("大" + EMOJI_LOW + "盘")
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (x TEXT)")
+    conn.execute("INSERT INTO t VALUES (?)", (repaired,))
+    assert conn.execute("SELECT x FROM t").fetchone()[0] == repaired
+
+    assert json.dumps({"content": repaired}, ensure_ascii=False).encode("utf-8")
+
+
+def test_scratchpad_append_survives_lone_surrogate(tmp_path):
+    """scratchpad 的 JSONL 写在 runtime 主流程上，没有 try 包着。"""
+    scratchpad = AgentScratchpad("市场观察", session_id="enc-test", scratchpad_dir=tmp_path)
+
+    scratchpad.record_thinking("盘中" + EMOJI_LOW)
+
+    written = json.loads(scratchpad.path.read_text(encoding="utf-8").splitlines()[-1])
+    assert encodable(written["content"]) == "盘中�"
+
+
+def test_remote_outbox_survives_lone_surrogate():
+    """远程通道的帧长计算 len(raw.encode("utf-8")) 也是 strict 的。"""
+    sent: list[str] = []
+    outbox = _Outbox(sent.append)
+    try:
+        outbox.put({"type": "text_delta", "text": "大盘" + EMOJI_LOW})
+        deadline = time.monotonic() + 2.0
+        while not sent and time.monotonic() < deadline:
+            time.sleep(0.01)
+    finally:
+        outbox.close()
+
+    assert sent, "帧没发出去"
+    assert encodable(json.loads(sent[0])["text"]) == "大盘�"


### PR DESCRIPTION
## 问题

Windows 用户问「跑今天的市场观察」,整轮回答被替换成一行红字:

```
'utf-8' codec can't encode character '\udca5' in position 1: surrogates not allowed
```

`\udca5` 是 `💥`(U+1F4A5)的后半个。网关把一个字符拆到了相邻两个 SSE delta 里,
两半各自都成了落单的代理字符。`json.loads` 不校验代理配对,所以它们一路进到应用里。

下游全是 strict UTF-8:IPC 协议通道写盘、chat_log 落 SQLite、scratchpad 落 JSONL、
远程遥控算帧长 —— 任何一处抛 `UnicodeEncodeError`,都会被 `_run_turn` 的兜底 except
接住变成 `turn_failed`。所以**只是一个表情符号坏了,整篇研报就没了**。

跟操作系统无关:在本机 macOS(Darwin arm64)上实测,同一个半截字符在 UTF-8、
SQLite、IPC 写盘上报的错和用户截图一字不差。GBK / UTF-16 / latin-1 也都编不出来,
不是换编码能解决的事。只有 Windows 反馈是运气问题 —— 要正好赶上输出里带表情符号
或生僻字,**并且**网关正好在那个字中间切一刀。

## 改动

拆法见过两种,一种解法覆盖不了:UTF-16 代理对被拆开(表情符号),以及 UTF-8 字节
被拆开(`股` = `e8 82 a1`,落单字节以 surrogateescape 形式到达)。所以
`cli/text_repair.py` 分两层:先按 surrogateescape 逆运算解,掺了代理对再走
`utf-16` + `surrogatepass`,真落单的换成 `U+FFFD`。

主修复在流式入口 `cli/runtime.py`,不在各 provider 里 —— 三家 provider 都可能遇到,
而这里同时覆盖了 `round_state.text` → `done` → chat_log 那条持久化链路。`StreamTextRepair`
会攥住末尾可能是「半个字符」的部分等下一块拼上,所以两半是真的接回去了,不是双双变成 `�`。

IPC 的 `_cap`、stdio 的 `_emit`、remote 的帧长、scratchpad 的写各自再兜一道 ——
工具结果和 args 里的文件内容走的不是流式那条路。

另外 `tool_calls` chunk 也带 `text`,是 provider 自己累计的原始串,不走逐块修复;
且在它之后 flush 尾巴会导致内容重复。已按事件类型切换时先 flush 再放行处理。

## 验证

- 新增 19 个测试(`tests/cli/test_text_repair.py`),含一个端到端用例:用用户原话
  「跑今天的市场观察,给我研报」配上被拆开的 delta 过真实 runtime,断言输出
  `今日市场观察:大盘💥 走弱。`
- 全量 `pytest`: 4090 passed, 22 skipped
- `scripts/quality_gate.py --ci`: 无新增违规(LOC 警告是既有基线漂移)
- `ruff format` / `ruff check` 干净

## 影响范围

bug 在已发出的 `desktop-v0.1.0` 里,**Mac 和 Windows 都需要重新打包**才能拿到修复。
`cli/text_repair.py` 是已打包模块的普通静态 import,PyInstaller 自动收,无需改 spec。

🤖 Generated with [Claude Code](https://claude.com/claude-code)