### PR TITLE
fix: keep TUI confirmation actions visible

### DIFF
--- a/cli/tui.py
+++ b/cli/tui.py
@@ -25,7 +25,7 @@ from rich.text import Text
 from textual import events, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Vertical
+from textual.containers import Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList, RichLog, Static
 from textual.widgets.option_list import Option
@@ -1828,8 +1828,11 @@ class ToolConfirmScreen(ModalScreen[dict]):
         align: center middle;
     }
     #confirm-box {
-        width: 64;
-        max-height: 20;
+        width: 80%;
+        min-width: 64;
+        max-width: 100;
+        height: auto;
+        max-height: 90%;
         background: $surface;
         border: thick $accent;
         padding: 1 2;
@@ -1838,13 +1841,19 @@ class ToolConfirmScreen(ModalScreen[dict]):
         text-style: bold;
         margin-bottom: 1;
     }
-    #confirm-summary {
-        color: $text-muted;
+    #confirm-summary-scroll {
+        height: auto;
+        max-height: 8;
+        overflow-y: auto;
         margin-bottom: 1;
     }
+    #confirm-summary {
+        width: 100%;
+        color: $text-muted;
+    }
     #confirm-options {
-        height: auto;
-        max-height: 6;
+        height: 6;
+        min-height: 6;
     }
     #confirm-edit {
         display: none;
@@ -1866,7 +1875,8 @@ class ToolConfirmScreen(ModalScreen[dict]):
                 f"⚠ [bold]{self.display_name}[/bold] 需要确认",
                 id="confirm-title",
             )
-            yield Static(self._format_summary(), id="confirm-summary")
+            with VerticalScroll(id="confirm-summary-scroll"):
+                yield Static(self._format_summary(), id="confirm-summary")
             yield OptionList(
                 Option("允许一次", id="once"),
                 Option("本次会话总是允许", id="always"),

--- a/tests/cli/test_tui_tool_confirm.py
+++ b/tests/cli/test_tui_tool_confirm.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from cli.tui import ToolConfirmScreen
+
+
+class _ConfirmHarness(App):
+    def compose(self) -> ComposeResult:
+        yield Static("background")
+
+
+def test_long_command_keeps_confirmation_options_visible() -> None:
+    asyncio.run(_assert_long_command_layout())
+
+
+async def _assert_long_command_layout() -> None:
+    command = 'python3 -c "\n' + "\n".join(f"print({line!r})" for line in range(24)) + '\n"'
+    app = _ConfirmHarness()
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.push_screen(ToolConfirmScreen("exec_command", {"command": command}, "执行命令"))
+        await pilot.pause()
+
+        box = app.screen.query_one("#confirm-box")
+        summary_scroll = app.screen.query_one("#confirm-summary-scroll")
+        options = app.screen.query_one("#confirm-options")
+
+        assert summary_scroll.size.height <= 8
+        assert summary_scroll.virtual_size.height > summary_scroll.size.height
+        assert options.size.height == 4
+        assert options.region.bottom <= box.region.bottom


### PR DESCRIPTION
## Summary

- make the TUI tool-confirmation modal responsive up to 100 columns
- keep long command details in a bounded scrollable area
- reserve enough height for all four confirmation actions
- add a terminal-layout regression test for long commands

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python scripts/quality_gate.py --ci`
- `.venv/bin/python scripts/check_workflow_hygiene.py`
- `.venv/bin/python scripts/check_dependency_hygiene.py`
- `.venv/bin/python -m pytest tests/ -x -q` (4098 passed, 22 skipped)