### PR TITLE
fix: repair TUI provider fallback routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### 修复
+- **TUI 模型故障切换**：本地和云端的 `deepseek` 配置统一走 OpenAI-compatible transport；备用配置不可用时不再覆盖默认模型的原始错误，状态栏同步显示实际活跃模型。
+
 ## 0.9.3 (2026-05-19)
 
 ### 改进

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -350,7 +350,7 @@ flowchart LR
 | **Steering** | 忙时注入本轮新指令（`!…` / `/steer`），经 `steering_queue` 在下一跳 model 调用前写入 messages；与排队到下一 turn 的 `input_queue` 不同。安卓对标：改正在跑 Job 的参数，而不是再 enqueue 一个新 Work。 |
 | **follow-ups（TUI）** | Agent 忙碌时普通输入进入 `input_queue`，输入框上方列出待发跟进。边框与标题用 `_UI_PALETTES.brand`（品牌主色：transparent 为 ANSI yellow / 终端标准黄，暗色主题琥珀金 `#e6b450`，浅色主题深金 `#9a6700`）。`enter` 立即排队；↑ 把最近一条用户跟进拉回编辑；esc 清空草稿或丢掉队尾跟进。与 Steering 分层。 |
 | **Auto-continuation** | 模型停了但工作未完时由 `decide_agent_loop` 自动注入续跑 prompt（截断 / 轮次上限 / 未完成必需工具），最多 2 次；与用户「继续」ResumeTurn 分层。 |
-| **FallbackProvider** | Provider 层自动切换备用模型；与用户主动 ResumeTurn **分层**，不混为一个概念。 |
+| **FallbackProvider** | Provider 层自动切换备用模型；TUI 状态栏显示实际活跃模型，无效备用配置不会掩盖默认模型的原始可恢复错误。与用户主动 ResumeTurn **分层**，不混为一个概念。 |
 | **output tok/s** | 输出生成速率：`output_tokens / generation_seconds`。`generation_seconds` 只累计模型生成窗口（首个 text/thinking delta → 该段 stream/step 结束），多步 tool 循环**不含**工具执行时间。Web 用量横幅末尾标为 `Xs gen`（模型窗口）；CLI footer 末尾 `elapsed` 仍是整轮墙钟。 |
 | **cache hit rate** | 提示缓存命中率：`cache_read_tokens / input_tokens`。仅当 provider/网关实际回报了 cache 字段时展示（含 0%）。Anthropic 原始 `input_tokens` 不含 cache，CLI 先归一化为 `input + cache_read + cache_write`。DeepSeek 优先用 `prompt_cache_hit_tokens`。与沙箱 CPU/网络 `usage` 无关。 |
 | **stream_chunk_timeout_seconds** | CLI 模型流式空闲超时（秒，默认 120，范围 10–600）：相邻 chunk 间隔（含 TTFT）超限则中断。写入 `~/.wyckoff/wyckoff.json`，控制面板可改。 |

--- a/cli/provider_factory.py
+++ b/cli/provider_factory.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+_PROVIDER_ALIASES = {
+    "deepseek": ("openai", "https://api.deepseek.com/v1"),
+}
+
 
 def provider_config_kwargs(config: dict[str, Any]) -> dict[str, Any]:
     return {
@@ -26,12 +30,14 @@ def create_provider(
 
     from cli.providers import PROVIDERS
 
-    cls = PROVIDERS.get(provider_name)
+    resolved_name, default_base_url = _PROVIDER_ALIASES.get(provider_name, (provider_name, ""))
+    cls = PROVIDERS.get(resolved_name)
     if cls is None:
         install_hints = {
             "gemini": "pip install google-genai",
             "claude": "pip install anthropic",
             "openai": "pip install openai",
+            "deepseek": "pip install openai",
         }
         hint = install_hints.get(provider_name, "")
         return None, f"Provider '{provider_name}' 不可用，请先安装依赖：{hint}"
@@ -39,14 +45,15 @@ def create_provider(
     kwargs = {"api_key": api_key}
     if model:
         kwargs["model"] = model
-    if base_url:
-        kwargs["base_url"] = base_url
+    resolved_base_url = base_url or default_base_url
+    if resolved_base_url:
+        kwargs["base_url"] = resolved_base_url
 
     sig = inspect.signature(cls.__init__)
     kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters}
 
     provider = cls(**kwargs)
-    window = _resolved_window(context_window, model, base_url)
+    window = _resolved_window(context_window, model, resolved_base_url)
     if window > 0:
         provider.context_window = window
     return provider, None

--- a/cli/providers/fallback.py
+++ b/cli/providers/fallback.py
@@ -80,6 +80,17 @@ class FallbackProvider(LLMProvider):
         except Exception:
             return None
 
+    @property
+    def active_provider_name(self) -> str:
+        return str(self._active_config().get("provider_name") or "")
+
+    @property
+    def active_model(self) -> str:
+        return str(self._active_config().get("model") or "")
+
+    def _active_config(self) -> dict[str, Any]:
+        return next(c for c in self._configs if c["id"] == self._active_id)
+
     def chat(self, messages, tools, system_prompt=""):
         return self._with_fallback(
             lambda p: p.chat(messages, tools, system_prompt),
@@ -109,7 +120,10 @@ class FallbackProvider(LLMProvider):
                 return fn(provider)
             except Exception as e:
                 if not _is_retriable(e):
-                    raise
+                    if last_exc is None:
+                        raise
+                    logger.warning("Fallback provider %s is unusable: %s, skipping", cfg["id"], e)
+                    continue
                 last_exc = e
                 logger.warning("Provider %s failed: %s, trying next", cfg["id"], e)
                 self.last_fallback_msg = f"{cfg['id']} 失败 ({type(e).__name__})，已切换"
@@ -132,7 +146,10 @@ class FallbackProvider(LLMProvider):
                 return
             except Exception as e:
                 if not _is_retriable(e):
-                    raise
+                    if last_exc is None:
+                        raise
+                    logger.warning("Fallback provider %s is unusable: %s, skipping", cfg["id"], e)
+                    continue
                 last_exc = e
                 logger.warning("Provider %s stream failed: %s, trying next", cfg["id"], e)
                 self.last_fallback_msg = f"{cfg['id']} 失败 ({type(e).__name__})，已切换"

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -2450,8 +2450,8 @@ class WyckoffTUI(App):
 
     def _build_status_right(self) -> str:
         parts = []
-        prov = self._state.get("provider_name", "")
-        model = self._state.get("model", "")
+        prov = getattr(self._provider, "active_provider_name", "") or self._state.get("provider_name", "")
+        model = getattr(self._provider, "active_model", "") or self._state.get("model", "")
         if prov and model:
             parts.append(f"{prov}:{model}")
         email = self._tools.state.get("email", "") if self._tools else ""

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -361,7 +361,9 @@ chunk 类型：`thinking_delta` | `text_delta` | `tool_calls` | `usage` | `finis
 **输出 tok/s** = `output_tokens / generation_seconds`（首个 text/thinking delta → 该轮 stream 结束；多步 tool 循环只累计模型生成窗口，不含工具时间）。  
 **缓存命中率** = `cache_read_tokens / input_tokens`（有 cache 字段时展示，含 0%）。Anthropic 的 `input_tokens` 不含 cache，CLI 会先归一化为 `input + cache_read + cache_write`。OpenAI 兼容通道优先读 DeepSeek 的 `prompt_cache_hit_tokens`，其次 `prompt_tokens_details.cached_tokens`。
 
-OpenAI provider 兼容所有 OpenAI API 格式端点（DeepSeek / Qwen / Kimi / LongCat / Minimax 等），支持推理模型的 `reasoning_content` thinking 流，以及 `<tool_call>` XML 标签兜底解析。
+OpenAI provider 兼容所有 OpenAI API 格式端点（DeepSeek / Qwen / Kimi / LongCat / Minimax 等），支持推理模型的 `reasoning_content` thinking 流，以及 `<tool_call>` XML 标签兜底解析。CLI 会把本地或云端配置中的 `provider_name=deepseek` 映射到同一 OpenAI-compatible transport；未填写 `base_url` 时使用 DeepSeek 官方 `/v1` 地址。
+
+`FallbackProvider` 会暴露当前实际运行的 provider/model，TUI 状态栏因此随故障切换更新。默认模型发生可恢复错误后，如果某个备用配置本身不可构造，该备用项会被记录并跳过；所有备用项都不可用时保留默认模型的原始网络/上游错误，避免用次级配置错误掩盖首因。
 
 ### MCP Server
 

--- a/tests/cli/test_cli_provider_factory.py
+++ b/tests/cli/test_cli_provider_factory.py
@@ -14,3 +14,24 @@ def test_openai_provider_accepts_minimax_compatible_endpoint():
     assert err is None
     assert isinstance(provider, OpenAIProvider)
     assert provider.context_window == 1_000_000
+
+
+def test_deepseek_provider_uses_openai_compatible_transport():
+    provider, err = create_provider(
+        "deepseek",
+        "test-key",
+        model="deepseek-v4-flash",
+        base_url="https://api.deepseek.com/v1",
+    )
+
+    assert err is None
+    assert isinstance(provider, OpenAIProvider)
+    assert str(provider._client.base_url) == "https://api.deepseek.com/v1/"
+
+
+def test_deepseek_provider_defaults_to_official_endpoint():
+    provider, err = create_provider("deepseek", "test-key", model="deepseek-v4-pro")
+
+    assert err is None
+    assert isinstance(provider, OpenAIProvider)
+    assert str(provider._client.base_url) == "https://api.deepseek.com/v1/"

--- a/tests/cli/test_fallback_provider.py
+++ b/tests/cli/test_fallback_provider.py
@@ -1,0 +1,97 @@
+from unittest.mock import Mock
+
+import pytest
+
+from cli.providers.fallback import FallbackProvider
+
+
+def _config(model_id: str, provider_name: str, model: str) -> dict:
+    return {
+        "id": model_id,
+        "provider_name": provider_name,
+        "api_key": "test-key",
+        "model": model,
+        "base_url": "https://example.com/v1",
+    }
+
+
+def test_fallback_exposes_the_provider_that_actually_ran(monkeypatch):
+    provider = FallbackProvider(
+        [
+            _config("primary", "openai", "primary-model"),
+            _config("backup", "deepseek", "backup-model"),
+        ],
+        "primary",
+    )
+    primary = Mock()
+    primary.chat.side_effect = TimeoutError("primary timeout")
+    backup = Mock()
+    backup.chat.return_value = {"type": "text", "text": "ok"}
+    monkeypatch.setattr(provider, "_get_provider", lambda model_id: {"primary": primary, "backup": backup}[model_id])
+
+    assert provider.chat([], []) == {"type": "text", "text": "ok"}
+    assert provider.active_provider_name == "deepseek"
+    assert provider.active_model == "backup-model"
+
+
+def test_unusable_backup_does_not_mask_primary_network_error(monkeypatch):
+    provider = FallbackProvider(
+        [
+            _config("primary", "openai", "primary-model"),
+            _config("broken", "missing-provider", "broken-model"),
+        ],
+        "primary",
+    )
+    primary = Mock()
+    primary.chat.side_effect = TimeoutError("primary timeout")
+
+    def get_provider(model_id: str):
+        if model_id == "primary":
+            return primary
+        raise RuntimeError("backup is not configured")
+
+    monkeypatch.setattr(provider, "_get_provider", get_provider)
+
+    with pytest.raises(TimeoutError, match="primary timeout"):
+        provider.chat([], [])
+
+
+def test_streaming_fallback_updates_active_model(monkeypatch):
+    provider = FallbackProvider(
+        [
+            _config("primary", "openai", "primary-model"),
+            _config("backup", "deepseek", "backup-model"),
+        ],
+        "primary",
+    )
+    primary = Mock()
+    primary.chat_stream.side_effect = TimeoutError("primary timeout")
+    backup = Mock()
+    backup.chat_stream.return_value = iter([{"type": "text_delta", "text": "ok"}])
+    monkeypatch.setattr(provider, "_get_provider", lambda model_id: {"primary": primary, "backup": backup}[model_id])
+
+    assert list(provider.chat_stream([], [])) == [{"type": "text_delta", "text": "ok"}]
+    assert provider.active_provider_name == "deepseek"
+    assert provider.active_model == "backup-model"
+
+
+def test_unusable_streaming_backup_preserves_primary_error(monkeypatch):
+    provider = FallbackProvider(
+        [
+            _config("primary", "openai", "primary-model"),
+            _config("broken", "missing-provider", "broken-model"),
+        ],
+        "primary",
+    )
+    primary = Mock()
+    primary.chat_stream.side_effect = TimeoutError("primary timeout")
+
+    def get_provider(model_id: str):
+        if model_id == "primary":
+            return primary
+        raise RuntimeError("backup is not configured")
+
+    monkeypatch.setattr(provider, "_get_provider", get_provider)
+
+    with pytest.raises(TimeoutError, match="primary timeout"):
+        list(provider.chat_stream([], []))

--- a/tests/cli/test_tui_rendering.py
+++ b/tests/cli/test_tui_rendering.py
@@ -1102,6 +1102,19 @@ def test_new_chat_notice_does_not_insert_blank_log_line():
     assert list(app._queue) == []
 
 
+def test_status_bar_shows_active_fallback_model():
+    app = object.__new__(WyckoffTUI)
+    app._provider = SimpleNamespace(active_provider_name="deepseek", active_model="deepseek-v4-flash")
+    app._state = {"provider_name": "openai", "model": "primary-model"}
+    app._tools = None
+    app._session_tokens = {"input": 0, "output": 0, "rounds": 0}
+
+    status = WyckoffTUI._build_status_right(app)
+
+    assert status.startswith("deepseek:deepseek-v4-flash")
+    assert "primary-model" not in status
+
+
 def test_schedule_trigger_notice_does_not_insert_blank_log_line():
     app = object.__new__(WyckoffTUI)
     log = _FakeLog()


### PR DESCRIPTION
## Summary

- route local and cloud `deepseek` configs through the existing OpenAI-compatible transport
- preserve the primary upstream error when a fallback configuration is unusable
- show the actually active fallback provider/model in the TUI status bar
- document the provider and fallback contract

## Validation

- `ruff check .`
- `ruff format --check .`
- `python scripts/quality_gate.py --ci`
- `python scripts/check_workflow_hygiene.py`
- `python scripts/check_dependency_hygiene.py`
- `python -m pytest tests/ -q` (4111 passed, 22 skipped)
- live smoke: DeepSeek Flash, DeepSeek Pro, and OpenRouter Nemotron all returned ChatCompletion