### PR TITLE
fix(step4): 新开仓裁剪层与 OMS 闸门同源，补 recommendation_tracking 缺列

### DIFF
--- a/core/recommendation_tracking_schema.py
+++ b/core/recommendation_tracking_schema.py
@@ -1,0 +1,78 @@
+"""``recommendation_tracking`` 缺失可选列的补列语句。
+
+本项目不保留 .sql 文件（``scripts/quality_gate.py --check-no-sql`` 会拦），且 Supabase
+Python SDK 走 REST 不支持 DDL、环境也无 psycopg2/asyncpg 与连接串，故 schema 以 Python
+常量形式版本化，由 ``scripts/print_recommendation_tracking_ddl.py`` 打印后人工在 SQL
+Editor 执行一次。与 ``core/factor_ic_schema.py``、``core/shadow_ledger_schema.py``
+同一套做法。
+
+这里只补列、不建表：``recommendation_tracking`` 早已存在（实测 76 列），是写入侧的
+``RECOMMENDATION_OPTIONAL_COLUMNS`` 长出了三列而生产表没跟上。
+
+## 为什么只有这三列缺
+
+``integrations/recommendation_payload.py`` 的 ``upsert_recommendation_payload_rows``
+在 400 之后会剔掉报错列重试，所以缺列不会让写入失败 —— 但也因此没人会注意到。
+2026-08-31 那轮日志里 ``POST /rest/v1/recommendation_tracking ... 400`` 紧跟一条
+去掉 ``capital_migration_bonus`` 的 ``201 Created``，就是这个降级在生效。
+
+实测（2026-09-01 对生产表取一行比对 56 个可选列）缺的是：
+
+- ``capital_migration_bonus`` —— **不只是审计损失**。``workflows/step4_from_supabase.py``
+  的 ``fetch_recommendation_rows`` 把它写进了 ``select`` 列表，那条读路径**硬失败**：
+  ``column recommendation_tracking.capital_migration_bonus does not exist``（42703）。
+  该工作流只有 ``workflow_dispatch``、最近一次成功运行是 2026-05-17，所以定时链路没受
+  影响；但只要有人手动跑「从 Supabase 复用今日候选」就会直接报错。
+- ``dynamic_shadow_score`` / ``dynamic_shadow_promotion`` —— 审计损失。同一轮内
+  Step2→Step3 靠 ``daily_job_persistence`` 的内存 dict 传递（见
+  ``_dynamic_shadow_review_symbols``），不回读这张表，所以当轮判读不受影响；
+  丢的是跨轮复盘「动态影子晋级当时给了多少分、卡在哪一条」的证据。
+
+补完这三列后，那条 400 → 201 的降级路径不再被触发（机制保留，作为下次加列的兜底）。
+"""
+
+from __future__ import annotations
+
+from core.constants import TABLE_RECOMMENDATION_TRACKING
+
+# (列名, 类型, 注释)。类型与表内同类列对齐：分数用 numeric，结构化 payload 用 jsonb
+# （实测 candidate_metrics / candidate_reasons 回来就是 dict）。
+MISSING_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    (
+        "capital_migration_bonus",
+        "numeric",
+        "资金迁移加分。step4_from_supabase 的读路径 select 了它，缺列会 42703 硬失败",
+    ),
+    (
+        "dynamic_shadow_score",
+        "numeric",
+        "动态影子晋级分。仅 Step3 复核资格用，跨轮复盘需要",
+    ),
+    (
+        "dynamic_shadow_promotion",
+        "jsonb",
+        "动态影子晋级判定详情：status/eligible/checks/blockers",
+    ),
+)
+
+
+def build_ddl() -> str:
+    """生成补列语句。幂等——``add column if not exists`` 可重复执行。"""
+    lines = [
+        f"-- 补 public.{TABLE_RECOMMENDATION_TRACKING} 的三个缺失可选列。",
+        "-- 写入侧有「剔掉报错列重试」的降级，所以缺列此前只表现为静默丢字段；",
+        "-- 但 capital_migration_bonus 同时在 step4_from_supabase 的 select 里，那条读路径是硬失败。",
+        "",
+        f"alter table public.{TABLE_RECOMMENDATION_TRACKING}",
+    ]
+    clauses = [f"    add column if not exists {name} {ddl_type}" for name, ddl_type, _ in MISSING_COLUMNS]
+    lines.append(",\n".join(clauses) + ";")
+    lines.append("")
+    for name, _, comment in MISSING_COLUMNS:
+        lines.append(f"comment on column public.{TABLE_RECOMMENDATION_TRACKING}.{name} is")
+        lines.append(f"    '{comment}';")
+    return "\n".join(lines)
+
+
+def column_names() -> frozenset[str]:
+    return frozenset(name for name, _, _ in MISSING_COLUMNS)

--- a/scripts/print_recommendation_tracking_ddl.py
+++ b/scripts/print_recommendation_tracking_ddl.py
@@ -1,0 +1,24 @@
+"""打印 recommendation_tracking 的补列语句，供人工在 Supabase SQL Editor 执行。
+
+本项目不保留 .sql 文件，且 Supabase Python SDK 走 REST 不支持 DDL，
+故 schema 以 core/recommendation_tracking_schema.py 的常量形式版本化并由此脚本输出。
+
+用法::
+
+    python scripts/print_recommendation_tracking_ddl.py
+"""
+
+from __future__ import annotations
+
+import _bootstrap  # noqa: F401
+
+from core.recommendation_tracking_schema import build_ddl
+
+
+def main() -> int:
+    print(build_ddl())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_recommendation_tracking_schema.py
+++ b/tests/core/test_recommendation_tracking_schema.py
@@ -1,0 +1,53 @@
+"""``recommendation_tracking`` 补列语句的约束。
+
+背景：写入侧 ``upsert_recommendation_payload_rows`` 在 400 后会剔掉报错列重试，缺列
+因此只表现为静默丢字段 —— 2026-08-31 那轮日志里 ``400`` 紧跟一条少了
+``capital_migration_bonus`` 的 ``201 Created``。但 ``capital_migration_bonus`` 同时在
+``step4_from_supabase.fetch_recommendation_rows`` 的 ``select`` 里，那条读路径是**硬失败**
+（42703），降级救不了它。
+
+这些用例不连生产库，只钉住「三处清单互相自洽」，让下次加可选列时错位能被 CI 抓到。
+"""
+
+from __future__ import annotations
+
+from core.recommendation_payload import RECOMMENDATION_OPTIONAL_COLUMNS
+from core.recommendation_tracking_schema import MISSING_COLUMNS, build_ddl, column_names
+
+
+def test_every_missing_column_is_a_declared_optional_column() -> None:
+    """补的列必须确实是写入侧会发的列，否则补了也没人用。"""
+    assert column_names() <= set(RECOMMENDATION_OPTIONAL_COLUMNS)
+
+
+def test_ddl_is_idempotent_add_column() -> None:
+    """人工执行一次，重跑不能炸 —— 不确定当前表状态时得能安全重放。"""
+    ddl = build_ddl()
+    assert ddl.count("add column if not exists") == len(MISSING_COLUMNS)
+    # 只补列，不建表也不删列。
+    assert "create table" not in ddl.lower()
+    assert "drop" not in ddl.lower()
+
+
+def test_ddl_covers_every_declared_column() -> None:
+    ddl = build_ddl()
+    for name, ddl_type, _ in MISSING_COLUMNS:
+        assert f"add column if not exists {name} {ddl_type}" in ddl
+
+
+def test_read_path_select_columns_are_all_schema_backed() -> None:
+    """读路径 select 的列若不在表里就是硬失败，降级机制救不了。
+
+    ``fetch_recommendation_rows`` 的列表是手写字符串，容易先加进 select 再忘了补表。
+    这条把它和「已知缺列」清单对上：select 里出现的可选列，要么表里已有，要么必须
+    在 MISSING_COLUMNS 里等着人工执行 DDL。
+    """
+    import inspect
+
+    from workflows import step4_from_supabase
+
+    source = inspect.getsource(step4_from_supabase.fetch_recommendation_rows)
+    selected = {col for col in RECOMMENDATION_OPTIONAL_COLUMNS if f"{col}," in source or f'{col}"' in source}
+    # capital_migration_bonus 是当下唯一一个「被 select 且生产表没有」的列。
+    assert "capital_migration_bonus" in selected
+    assert "capital_migration_bonus" in column_names()

--- a/tests/workflows/test_allow_regimes_chain.py
+++ b/tests/workflows/test_allow_regimes_chain.py
@@ -19,6 +19,8 @@ import pytest
 
 from core.market_trade_mode import resolve_market_trade_mode
 from workflows.step4_decision_parser import NewBuyLimits, max_new_buy_names
+from workflows.step4_decisions import complete_step4_decisions
+from workflows.step4_models import DecisionItem, PortfolioState, Step4RuntimeConfig
 
 LIMITS = NewBuyLimits(neutral=3, caution=1)
 PROD_BLOCK = "UNKNOWN,NEUTRAL,PANIC_REPAIR,RISK_OFF,CRASH,BLACK_SWAN"
@@ -34,6 +36,38 @@ def _blocked() -> frozenset[str]:
     from workflows.step4_order_config import step4_order_config_from_env
 
     return frozenset(step4_order_config_from_env().buy_block_regimes)
+
+
+def _new_buy(code: str, score: float) -> DecisionItem:
+    return DecisionItem(
+        code=code,
+        name="测试",
+        action="PROBE",
+        entry_zone_min=10.0,
+        entry_zone_max=11.0,
+        stop_loss=9.0,
+        trim_ratio=None,
+        tape_condition="",
+        invalidate_condition="",
+        is_add_on=False,
+        reason="主线买点确认",
+        confidence=0.7,
+        funnel_score=score,
+    )
+
+
+def _complete(regime: str, decisions: list[DecisionItem], *, pass_order_config: bool = True):
+    """跑生产那条真实链路：``_run_step4_decision_flow`` → ``complete_step4_decisions``。"""
+    from workflows.step4_order_config import step4_order_config_from_env
+
+    return complete_step4_decisions(
+        decisions,
+        PortfolioState(positions=[], free_cash=100_000.0, total_equity=100_000.0),
+        {},
+        regime,
+        Step4RuntimeConfig(new_buy_limits=LIMITS),
+        step4_order_config_from_env() if pass_order_config else None,
+    )
 
 
 class TestAllowedRegimeOpensEveryLayer:
@@ -54,6 +88,31 @@ class TestAllowedRegimeOpensEveryLayer:
 
         assert "BEAR_REBOUND" not in _live_buy_block_regimes()
 
+    def test_actual_trim_keeps_the_new_buy(self):
+        """第四个断点：实际裁剪那一层。
+
+        #308 打通了 OMS 闸门、提示词配额与 trade mode 三处，却漏了
+        ``complete_step4_decisions`` 里真正执行裁剪的调用 —— 它不传 blocked_regimes，
+        落回硬编码集合把 BEAR_REBOUND 重新拦成 0。2026-08-31 那轮就此丢掉唯一新开
+        候选 002292（funnel_score=108.00）。
+        """
+        out = _complete("BEAR_REBOUND", [_new_buy("002292", 108.0)])
+        # 与生产同一套判据：step4_decision_parser 按 `not dec.system_reject_reason` 取值，
+        # 未被拒时字段是空串而非 None。
+        assert [d.code for d in out if not d.system_reject_reason] == ["002292"]
+
+    def test_prompt_quota_and_actual_trim_agree(self):
+        """提示词说几只、就得真能留几只 —— 两处必须读同一份禁买集合。
+
+        错位的形态是「告诉模型可以买 1 只，模型照给，系统再以配额 0 丢掉」，
+        日志只留一行 ``组合级限购拦截``，看不出配额是从哪来的。
+        """
+        promised = max_new_buy_names("BEAR_REBOUND", LIMITS, _blocked())
+        out = _complete("BEAR_REBOUND", [_new_buy(f"00000{i}", 100.0 - i) for i in range(1, 5)])
+        kept = [d for d in out if not d.system_reject_reason]
+        assert promised > 0
+        assert len(kept) == promised
+
 
 class TestPanicRepairStaysBlocked:
     """BEAR_REBOUND 与 PANIC_REPAIR 共用 REPAIR_REVIEW_REGIMES，不得连带放行。"""
@@ -68,6 +127,12 @@ class TestPanicRepairStaysBlocked:
         mode = resolve_market_trade_mode("PANIC_REPAIR")
         assert mode.allow_recommendation_write is False
         assert mode.mode == "repair_review"
+
+    def test_actual_trim_still_drops_the_new_buy(self):
+        """把 order_config 传下去不等于全面放开：未豁免的档位仍须归零。"""
+        out = _complete("PANIC_REPAIR", [_new_buy("002292", 108.0)])
+        assert out[0].system_reject_reason is not None
+        assert "max_new_buy_names=0" in out[0].system_reject_reason
 
 
 class TestRiskOnStaysBlocked:
@@ -87,6 +152,19 @@ class TestRollback:
         assert "BEAR_REBOUND" in _blocked()
         assert max_new_buy_names("BEAR_REBOUND", LIMITS, _blocked()) == 0
         assert resolve_market_trade_mode("BEAR_REBOUND").allow_recommendation_write is False
+        # 退路必须在真实裁剪那一层也生效，否则「移出 ALLOW」只关掉三层。
+        out = _complete("BEAR_REBOUND", [_new_buy("002292", 108.0)])
+        assert out[0].system_reject_reason is not None
+
+    def test_omitting_order_config_keeps_old_behavior(self):
+        """不传 order_config 时保持旧语义，与 max_new_buy_names(..., None) 一致。
+
+        这不是「建议这么调用」——生产必须传。留这条是为了让默认值的语义有明确断言，
+        避免以后有人以为省略参数也能放行。
+        """
+        out = _complete("BEAR_REBOUND", [_new_buy("002292", 108.0)], pass_order_config=False)
+        assert out[0].system_reject_reason is not None
+        assert "max_new_buy_names=0" in out[0].system_reject_reason
 
     def test_defensive_regimes_never_openable_by_allow(self, monkeypatch):
         """CRASH/RISK_OFF 属 NO_NEW_BUY，即便误加进 ALLOW 也不应打开写入。"""

--- a/workflows/step4_decisions.py
+++ b/workflows/step4_decisions.py
@@ -45,7 +45,17 @@ def complete_step4_decisions(
     candidate_meta_map: dict[str, CandidateMeta],
     market_regime: str,
     runtime_config: Step4RuntimeConfig,
+    order_config: Step4OrderConfig | None = None,
 ) -> list[DecisionItem]:
+    """补全 Step4 决策，并按组合级限购裁掉超额新开仓。
+
+    ``order_config`` 只为拿 ``buy_block_regimes`` —— 那是 OMS 闸门与提示词配额
+    (``step4_rebalancer.py:293``) 共用的同一份禁买集合，这一层必须同源。留空则回退到
+    ``max_new_buy_names`` 的硬编码集合（旧行为），与 ``trim_new_buy_decisions`` 的
+    ``blocked_regimes=None`` 语义一致；生产链路一律要传，否则 ``STEP4_BUY_ALLOW_REGIMES``
+    豁免掉的档位会在这里被重新拦成配额 0，模型照配额给的票被"组合级限购拦截"丢掉。
+    不变量由 ``tests/workflows/test_allow_regimes_chain.py`` 看住。
+    """
     mentioned_codes = {d.code for d in decisions}
     for position in portfolio.positions:
         if position.code in mentioned_codes:
@@ -75,6 +85,9 @@ def complete_step4_decisions(
         held_codes=held_codes,
         market_regime=market_regime,
         limits=runtime_config.new_buy_limits,
+        # 与 OMS 闸门、提示词配额同源。缺这个参数会落回硬编码集合，把 ALLOW 豁免
+        # 掉的档位重新拦成 0，见本函数 docstring。
+        blocked_regimes=frozenset(order_config.buy_block_regimes) if order_config else None,
     )
     if dropped:
         logger.info(

--- a/workflows/step4_rebalancer.py
+++ b/workflows/step4_rebalancer.py
@@ -496,6 +496,8 @@ def _run_step4_decision_flow(
         context.candidate_meta_map,
         context.market_regime,
         options.runtime_config,
+        # 传 order_config 才能让裁剪配额与上面提示词里的 max_new_buy_names 同源。
+        options.order_config,
     )
     backfill_step4_decision_market_data(
         decisions,


### PR DESCRIPTION
## 变更摘要

两处独立问题，共同点是「配置只有一半生效」。

### 1. 新开仓配额的第四个断点：三层放行，第四层归零

#308 把 `STEP4_BUY_ALLOW_REGIMES` 打通到了三处：OMS 的 `buy_block_regimes`、提示词里告诉模型的 `max_new_buy_names`（`workflows/step4_rebalancer.py:293`）、以及 `resolve_market_trade_mode` 的 `allow_recommendation_write`。**漏了第四处**——`complete_step4_decisions` 里真正执行裁剪的那一层不传 `blocked_regimes`，落回硬编码的 `EXECUTE_BLOCK_NEW_BUY_REGIMES`（含 `BEAR_REBOUND`），配额直接归零。

同一份环境变量下实测两侧不一致：

```
gate2 prompt (同源, rebalancer:293) : 1
gate2 trim   (硬编码, decisions:73) : 0
```

**这不是理论问题，2026-08-31 那轮已经吃掉了一只票。** 提示词告诉模型可以开 1 只新仓，模型照配额给了 1 只，系统随后把它丢了：

```
组合级限购生效: regime=BEAR_REBOUND, max_new_buy_names=0, dropped=002292
```

被丢的 002292（影视音像）是当晚**唯一**的新开候选：`funnel_score=108.00`、`main_force_entry` 车道、PROBE、主线买点确认、板块共振 +8.0。本地复现出的拒绝理由与生产日志逐字一致：

```
code=002292 action=PROBE reject='组合级限购拦截: regime=BEAR_REBOUND, max_new_buy_names=0'
```

失败形状本身就不可见：日志只有 `组合级限购拦截` 一行，不透露配额是从哪份集合算出来的。所以运维把 `BEAR_REBOUND` 加进 ALLOW 之后，看到的是「AI 就是没给新开仓」，而不是「系统把 AI 给的丢了」。

修法与 #308 相同：让这一层读 OMS 那份集合，而不是各自维护一套。`order_config` 参数可选，留空即旧行为，其它调用方语义不变。

### 2. `recommendation_tracking` 生产表缺三列

写路径 `upsert_recommendation_payload_rows` 遇到 400 会按错误文本把冒犯的列剔掉重试，**静默降级**——什么都不失败，所以表结构漂移从来没被发现。读路径 `fetch_recommendation_rows` 却把列名手写进 `select` 字符串，缺列时 PostgREST 直接 `42703` 硬失败，没有兜底。

生产表 76 列，写入方声明 56 个可选列，实际缺三个。严重性分两档：

| 列 | 影响 |
|---|---|
| `capital_migration_bonus` | **不只是审计缺失**——读路径 select 了它，缺列硬失败（`column recommendation_tracking.capital_migration_bonus does not exist`）。爆炸半径有界：唯一调用方是 `step4_from_supabase.yml`，`workflow_dispatch` only，最后一次成功 2026-05-17。**没有定时任务被打断**，但手动 dispatch「复用今天 Supabase 里的候选」会立刻报错。 |
| `dynamic_shadow_score` | 纯审计缺失。Step2→Step3 靠内存 dict 传递（`workflows/daily_job_persistence.py:150-201` → `workflows/step3_inputs.py:179`），当轮判断不受影响；丢的是跨轮复盘证据。 |
| `dynamic_shadow_promotion` | 同上，丢的是「晋级判定卡在哪一项 check」的记录。 |

按项目规矩（不允许出现 `.sql` 文件），DDL 是 `core/recommendation_tracking_schema.py` 里的 Python 常量，配 `scripts/print_recommendation_tracking_ddl.py` 打印。列类型按现存同类列的实测取值定：分数 → `numeric`，结构化载荷 → `jsonb`（`candidate_metrics`/`candidate_reasons` 读回来是 `dict`）。

**⚠️ 合并后需人工在 Supabase SQL Editor 执行一次**，CI 里没有任何东西能替你跑（Supabase Python SDK 是 REST-only，环境里没有连接串）。语句幂等（`add column if not exists`），可重复执行：

```sql
alter table public.recommendation_tracking
    add column if not exists capital_migration_bonus numeric,
    add column if not exists dynamic_shadow_score numeric,
    add column if not exists dynamic_shadow_promotion jsonb;
```

## 验证

- `pytest tests -q` → **4148 passed, 22 skipped**（全量）
- `pytest tests/workflows/test_allow_regimes_chain.py tests/core/test_recommendation_tracking_schema.py tests/workflows/test_step4_buy_allow_regimes.py tests/workflows/test_step4_pipeline.py tests/workflows/test_step4_trade_date.py tests/workflows/test_step4_from_supabase.py -q` → **121 passed**
- `pytest tests/test_architecture_boundaries.py -q` → 17 passed
- `scripts/quality_gate.py --ci` → OK: No new violations
- `scripts/quality_gate.py --check-no-sql` → OK: 无 .sql 文件
- `ruff check .` → All checks passed；`ruff format --check .` → 920 files already formatted

新增测试都走生产那条真实链路（`complete_step4_decisions`，读 `step4_order_config_from_env()`），不是对着裁剪函数单测：

- `test_actual_trim_keeps_the_new_buy` — 第四层：`BEAR_REBOUND` + ALLOW 下 002292 留得住
- `test_prompt_quota_and_actual_trim_agree` — 提示词说几只就得真能留几只（这条是不变量本体）
- `test_actual_trim_still_drops_the_new_buy` — `PANIC_REPAIR` 经同一条路径仍归零，没把闸门拆了
- `test_empty_allow_restores_block` — 清空 ALLOW 在裁剪层同样回滚
- `test_omitting_order_config_keeps_old_behavior` — 省略参数保持旧语义
- `test_read_path_select_columns_are_all_schema_backed` — 看住读路径 `select` 不再领先于 schema 模块

断言用的是生产自己的判据（`not dec.system_reject_reason`）而非跟 `None` 比——该字段默认空串，早先照 `None` 写的断言会假失败。

## 顺带观察（本 PR 不动）

2026-08-31 那轮日志里还有一次 `POST /rest/v1/signal_pending → 409 Conflict`。`insert_pending_signal_rows` 先 SELECT 出已存在的 `(code, signal_type, signal_date)` 再过滤、然后 insert，是读后写竞态；唯一的重试分支 `_looks_like_schema_miss` 匹配的是 "column"/"schema cache"/"could not find"，409 匹配不上，落到外层 `except Exception` → `logger.warning` → `return 0`。生产表实测 453 行，`(code, signal_type, signal_date)` 三元组全唯一（`(code, signal_type)` 二元组跨日最多重复 3 次），说明唯一约束确实建在三元组上、幂等语义是对的，那一次 409 是同轮并发或重跑撞上。**后果是那一批 pending 信号整批没写进去**（`insert` 是单次批量调用，一行冲突整批回滚），影响下一轮的确认/过期循环。留待单独修，避免把这个 PR 的范围搅浑。

## 注意

`trigger` 信号目前在两条不兼容的量纲上各记一次分：路径 A（`watch_score` 里的 `trigger_q`，权重 0.30，满摆幅 2.4 个最终分）与路径 B（`core/ai_candidate_allocation.py:518` 的 `_trigger_score()`，硬编码 12~50 分）。**两条不可同时下调。** 本 PR 未触碰任何一条。
