### PR TITLE
fix(signals): 去重键对齐唯一约束，一行冲突不再回滚整天的触发信号

### DIFF
--- a/integrations/supabase_signal_pending.py
+++ b/integrations/supabase_signal_pending.py
@@ -1,4 +1,15 @@
-"""Supabase signal_pending 表读写，模式同 supabase_recommendation.py。"""
+"""Supabase signal_pending 表读写，模式同 supabase_recommendation.py。
+
+去重键必须与库里的唯一约束同源。生产约束 ``uq_signal_pending_active`` 建在
+``(code, signal_type)`` 上、只作用于活跃态（pending/survived），**与 signal_date 无关**；
+而写入前的去重一度只按 ``(code, signal_type, signal_date)`` 且只查当天，看不见跨日仍活跃
+的行。2026-08-31 因此整批写失败：912/sos 在 8-28 还是 survived，当天 140 条触发信号被
+PostgREST 的单语句批量 insert 一起回滚，signal_pending 里 8-31 一行都没有（8-28 有 38 行、
+8-27 有 60 行）。日志只有一行 ``write pending signals failed``，外层 except 吞掉后返回 0。
+
+所以这里做两件事：按约束自己的键（活跃态 code+signal_type）过滤，以及批量撞约束时退化为
+逐行插入——让残留竞态只吃掉冲突那一行，而不是一整天的信号。
+"""
 
 from __future__ import annotations
 
@@ -15,6 +26,8 @@ from integrations.supabase_base import require_server_write_context
 logger = logging.getLogger(__name__)
 
 _OPTIONAL_REPORT_COLUMNS = {"candidate_theme", "candidate_phase", "candidate_role"}
+# 与库里 uq_signal_pending_active 的作用范围一致：只有活跃态占用唯一键。
+ACTIVE_SIGNAL_STATUSES = ("pending", "survived")
 
 
 def insert_pending_signal_rows(rows: list[dict[str, Any]]) -> int:
@@ -25,42 +38,106 @@ def insert_pending_signal_rows(rows: list[dict[str, Any]]) -> int:
 
     try:
         client = _admin()
-        signal_dates = sorted({str(row.get("signal_date") or "") for row in rows if row.get("signal_date")})
-        query = client.table(TABLE_SIGNAL_PENDING).select("code,signal_type,signal_date")
-        if signal_dates:
-            query = query.in_("signal_date", signal_dates)
-        existing = query.execute()
-        existing_keys = {
-            (int(r["code"]), r["signal_type"], str(r.get("signal_date") or "")) for r in (existing.data or [])
-        }
-        to_insert = [
-            row
-            for row in rows
-            if (int(row["code"]), row["signal_type"], str(row.get("signal_date") or "")) not in existing_keys
-        ]
+        to_insert = _rows_not_yet_active(client, rows)
         if not to_insert:
             logger.info("%s pending signals already exist; skipped", len(rows))
             return 0
-        try:
-            client.table(TABLE_SIGNAL_PENDING).insert(to_insert).execute()
-        except Exception as exc:
-            if not _looks_like_schema_miss(exc):
-                raise
-            legacy_rows = [
-                {key: value for key, value in row.items() if key not in _OPTIONAL_REPORT_COLUMNS} for row in to_insert
-            ]
-            client.table(TABLE_SIGNAL_PENDING).insert(legacy_rows).execute()
-            logger.warning("signal_pending report columns missing; wrote compatible payload")
-        logger.info("inserted %s pending signals; skipped %s existing", len(to_insert), len(rows) - len(to_insert))
-        return len(to_insert)
+        written = _insert_with_fallbacks(client, to_insert)
+        logger.info(
+            "inserted %s pending signals; skipped %s existing, %s conflicted",
+            written,
+            len(rows) - len(to_insert),
+            len(to_insert) - written,
+        )
+        return written
     except Exception as e:
         logger.warning("write pending signals failed: %s", e)
         return 0
 
 
+def _active_key(row: dict[str, Any]) -> tuple[int, str]:
+    return int(row["code"]), row["signal_type"]
+
+
+def _day_key(row: dict[str, Any]) -> tuple[int, str, str]:
+    return int(row["code"]), row["signal_type"], str(row.get("signal_date") or "")
+
+
+def _rows_not_yet_active(client: Any, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """两道过滤，缺一不可。
+
+    1. 活跃态的 ``(code, signal_type)``——这是库里 ``uq_signal_pending_active`` 的键。
+       不能只查当天：8-28 的 survived 行同样占用唯一键，跨日照样撞。
+    2. 当天的 ``(code, signal_type, signal_date)``，不分状态——一天内跑第二遍时，
+       已 confirmed/expired 的当天信号不该被重新挂成 pending。这是原有语义，保留。
+
+    同一批入参里重复的键也要去掉，否则批量 insert 会自己跟自己冲突。
+    """
+    signal_dates = sorted({str(row.get("signal_date") or "") for row in rows if row.get("signal_date")})
+    active = (
+        client.table(TABLE_SIGNAL_PENDING)
+        .select("code,signal_type")
+        .in_("status", list(ACTIVE_SIGNAL_STATUSES))
+        .execute()
+    )
+    taken_active = {_active_key(r) for r in (active.data or [])}
+    taken_day: set[tuple[int, str, str]] = set()
+    if signal_dates:
+        same_day = (
+            client.table(TABLE_SIGNAL_PENDING).select("code,signal_type,signal_date").in_("signal_date", signal_dates)
+        ).execute()
+        taken_day = {_day_key(r) for r in (same_day.data or [])}
+    deduped: list[dict[str, Any]] = []
+    for row in rows:
+        if _active_key(row) in taken_active or _day_key(row) in taken_day:
+            continue
+        taken_active.add(_active_key(row))
+        taken_day.add(_day_key(row))
+        deduped.append(row)
+    return deduped
+
+
+def _insert_with_fallbacks(client: Any, to_insert: list[dict[str, Any]]) -> int:
+    """批量插入；撞唯一约束时退化为逐行，避免一行冲突回滚一整天的信号。"""
+    try:
+        client.table(TABLE_SIGNAL_PENDING).insert(to_insert).execute()
+        return len(to_insert)
+    except Exception as exc:
+        if _looks_like_schema_miss(exc):
+            legacy_rows = [
+                {key: value for key, value in row.items() if key not in _OPTIONAL_REPORT_COLUMNS} for row in to_insert
+            ]
+            client.table(TABLE_SIGNAL_PENDING).insert(legacy_rows).execute()
+            logger.warning("signal_pending report columns missing; wrote compatible payload")
+            return len(legacy_rows)
+        if not _looks_like_unique_conflict(exc):
+            raise
+        logger.warning("signal_pending batch hit unique conflict; retrying row by row: %s", exc)
+        return _insert_row_by_row(client, to_insert)
+
+
+def _insert_row_by_row(client: Any, to_insert: list[dict[str, Any]]) -> int:
+    written = 0
+    for row in to_insert:
+        try:
+            client.table(TABLE_SIGNAL_PENDING).insert([row]).execute()
+            written += 1
+        except Exception as exc:
+            if not _looks_like_unique_conflict(exc):
+                raise
+            logger.info("signal_pending skip conflicting row code=%s type=%s", row.get("code"), row.get("signal_type"))
+    return written
+
+
 def _looks_like_schema_miss(exc: Exception) -> bool:
     text = str(exc).lower()
     return "column" in text or "schema cache" in text or "could not find" in text
+
+
+def _looks_like_unique_conflict(exc: Exception) -> bool:
+    """PostgREST 把唯一约束冲突报成 409 / SQLSTATE 23505。"""
+    text = str(exc).lower()
+    return "23505" in text or "duplicate key" in text or "already exists" in text
 
 
 def load_pending_signals() -> list[dict[str, Any]]:

--- a/tests/integrations/test_supabase_signal_pending.py
+++ b/tests/integrations/test_supabase_signal_pending.py
@@ -1,68 +1,195 @@
 from __future__ import annotations
 
+import pytest
+
 from integrations import supabase_signal_pending as mod
 
 
+class _UniqueConflict(Exception):
+    """模拟 PostgREST 报回来的 23505，文本照抄 2026-08-31 生产日志。"""
+
+    def __init__(self, code: int, signal_type: str) -> None:
+        super().__init__(
+            "{'message': 'duplicate key value violates unique constraint "
+            f"\"uq_signal_pending_active\"', 'code': '23505', 'details': 'Key (code, signal_type)=({code}, "
+            f"{signal_type}) already exists.'}}"
+        )
+
+
 class _Query:
-    def __init__(self, existing: list[dict]) -> None:
+    """按 uq_signal_pending_active 的语义建模：活跃态的 (code, signal_type) 占用唯一键。"""
+
+    def __init__(self, existing: list[dict], *, enforce_unique: bool = True) -> None:
         self.existing = existing
         self.inserted: list[dict] = []
+        self.insert_calls = 0
+        self.enforce_unique = enforce_unique
+        # 快照里看不见、insert 时才冲突的键，用来模拟读后写竞态。
+        self.conflict_keys: set[tuple[int, str]] = set()
+        self._status_filter: list[str] | None = None
+        self._date_filter: list[str] | None = None
 
     def select(self, *_args):
+        self._status_filter = None
+        self._date_filter = None
         return self
 
     def eq(self, *_args):
         return self
 
-    def in_(self, *_args):
+    def in_(self, column, values):
+        if column == "status":
+            self._status_filter = list(values)
+        elif column == "signal_date":
+            self._date_filter = [str(v) for v in values]
         return self
 
     def execute(self):
-        return type("Result", (), {"data": self.existing})()
+        rows = self.existing
+        if self._status_filter is not None:
+            rows = [r for r in rows if r.get("status", "pending") in self._status_filter]
+        if self._date_filter is not None:
+            rows = [r for r in rows if str(r.get("signal_date") or "") in self._date_filter]
+        return type("Result", (), {"data": rows})()
+
+    def _active_keys(self) -> set[tuple[int, str]]:
+        return {
+            (int(r["code"]), r["signal_type"])
+            for r in self.existing
+            if r.get("status", "pending") in mod.ACTIVE_SIGNAL_STATUSES
+        }
 
     def insert(self, rows):
+        self.insert_calls += 1
+        if self.enforce_unique:
+            taken = self._active_keys() | self.conflict_keys
+            for row in rows:
+                key = (int(row["code"]), row["signal_type"])
+                if key in taken:
+                    raise _UniqueConflict(*key)
+                taken.add(key)
         self.inserted.extend(rows)
-        self.existing = []
+        self.existing = [*self.existing, *rows]
         return self
 
 
 class _Client:
-    def __init__(self, existing: list[dict]) -> None:
-        self.query = _Query(existing)
+    def __init__(self, existing: list[dict], *, enforce_unique: bool = True) -> None:
+        self.query = _Query(existing, enforce_unique=enforce_unique)
 
     def table(self, _name):
         return self.query
 
 
-def test_pending_dedup_keeps_new_trade_date(monkeypatch) -> None:
-    client = _Client([{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-15"}])
+@pytest.fixture
+def _writable(monkeypatch):
     monkeypatch.setattr(mod, "_configured", lambda: True)
-    monkeypatch.setattr(mod, "_admin", lambda: client)
     monkeypatch.setattr(mod, "require_server_write_context", lambda *_args: None)
+
+    def _bind(client):
+        monkeypatch.setattr(mod, "_admin", lambda: client)
+        return client
+
+    return _bind
+
+
+def test_new_date_blocked_while_prior_signal_still_active(_writable) -> None:
+    """跨日但旧行仍活跃 → 不能写。
+
+    这是 2026-08-31 的真实形状：912/sos 在 8-28 是 survived，8-31 又触发。
+    唯一约束只看 (code, signal_type) + 活跃态，不看 signal_date，所以必须在写之前挡住。
+    """
+    client = _writable(
+        _Client([{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-15", "status": "survived"}])
+    )
+    rows = [{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16"}]
+
+    assert mod.insert_pending_signal_rows(rows) == 0
+    assert client.query.inserted == []
+
+
+def test_new_date_allowed_once_prior_signal_settled(_writable) -> None:
+    """旧行已 expired/confirmed → 不再占用唯一键，同一票可以重新挂 pending。"""
+    client = _writable(
+        _Client([{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-15", "status": "expired"}])
+    )
     rows = [{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16"}]
 
     assert mod.insert_pending_signal_rows(rows) == 1
     assert client.query.inserted == rows
 
 
-def test_pending_dedup_skips_same_trade_date(monkeypatch) -> None:
-    existing = [{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16"}]
-    client = _Client(existing)
-    monkeypatch.setattr(mod, "_configured", lambda: True)
-    monkeypatch.setattr(mod, "_admin", lambda: client)
-    monkeypatch.setattr(mod, "require_server_write_context", lambda *_args: None)
+def test_pending_dedup_skips_same_trade_date(_writable) -> None:
+    existing = [{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16", "status": "pending"}]
+    client = _writable(_Client(existing))
 
-    assert mod.insert_pending_signal_rows(existing) == 0
+    assert mod.insert_pending_signal_rows([dict(existing[0])]) == 0
     assert client.query.inserted == []
 
 
-def test_pending_dedup_skips_same_date_after_confirmation(monkeypatch) -> None:
-    existing = [{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16", "status": "confirmed"}]
-    client = _Client(existing)
-    monkeypatch.setattr(mod, "_configured", lambda: True)
-    monkeypatch.setattr(mod, "_admin", lambda: client)
-    monkeypatch.setattr(mod, "require_server_write_context", lambda *_args: None)
+def test_pending_dedup_skips_same_date_after_confirmation(_writable) -> None:
+    """已 confirmed 的当天信号不该被重复挂回 pending。
+
+    这一条不由唯一约束保证（confirmed 不占活跃键），靠当天那道过滤挡住 —— 同一天
+    重跑漏斗时不能把已判定的信号重新挂成 pending。
+    """
+    client = _writable(
+        _Client([{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16", "status": "confirmed"}])
+    )
     pending = [{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16"}]
 
     assert mod.insert_pending_signal_rows(pending) == 0
     assert client.query.inserted == []
+
+
+def test_duplicate_keys_within_one_batch_collapse(_writable) -> None:
+    """同一批里重复的键要先自去重，否则批量 insert 会自己跟自己撞。"""
+    client = _writable(_Client([]))
+    rows = [
+        {"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16", "signal_score": 1.0},
+        {"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16", "signal_score": 2.0},
+    ]
+
+    assert mod.insert_pending_signal_rows(rows) == 1
+    assert client.query.inserted == [rows[0]]
+
+
+def test_one_conflict_does_not_lose_the_whole_batch(_writable) -> None:
+    """核心回归：残留竞态只该吃掉冲突那一行。
+
+    2026-08-31 是 140 条触发信号被一行 912/sos 的冲突整批回滚（signal_pending 里 8-31
+    零行，8-28 有 38 行、8-27 有 60 行）。这里让过滤读到的快照是空的、insert 时才冒出
+    冲突，模拟读后写竞态：批量失败后应逐行重试，只丢冲突那一行。
+    """
+    client = _writable(_Client([]))
+    # 快照为空（过滤读不到），但 insert 时 912/sos 已被占用 —— 读后写的竞态窗口。
+    client.query.conflict_keys = {(912, "sos")}
+    rows = [
+        {"code": 100, "signal_type": "sos", "signal_date": "2026-08-31"},
+        {"code": 912, "signal_type": "sos", "signal_date": "2026-08-31"},
+        {"code": 300, "signal_type": "lps", "signal_date": "2026-08-31"},
+    ]
+
+    assert mod.insert_pending_signal_rows(rows) == 2
+    assert [r["code"] for r in client.query.inserted] == [100, 300]
+    # 一次批量（失败）+ 三次逐行，而不是整批丢掉。
+    assert client.query.insert_calls == 4
+
+
+def test_schema_miss_still_falls_back_to_legacy_payload(_writable) -> None:
+    """老的缺列降级不能被新的冲突分支挤掉。"""
+    client = _writable(_Client([], enforce_unique=False))
+    calls: list[list[dict]] = []
+
+    def _insert(rows):
+        calls.append(rows)
+        if len(calls) == 1:
+            raise RuntimeError("Could not find the 'candidate_theme' column of 'signal_pending' in the schema cache")
+        client.query.inserted.extend(rows)
+        return client.query
+
+    client.query.insert = _insert  # type: ignore[method-assign]
+    rows = [{"code": 600611, "signal_type": "sos", "signal_date": "2026-07-16", "candidate_theme": "AI"}]
+
+    assert mod.insert_pending_signal_rows(rows) == 1
+    assert "candidate_theme" not in client.query.inserted[0]


### PR DESCRIPTION
## 问题

一行冲突回滚一整天的触发信号，2026-08-31 丢了 140 条。生产日志（run `33417439459`，
2026-08-31 漏斗）：

```
WARNING integrations.supabase_signal_pending: write pending signals failed:
{'message': 'duplicate key value violates unique constraint "uq_signal_pending_active"',
 'code': '23505',
 'details': 'Key (code, signal_type)=(912, sos) already exists.'}
```

外层 `except` 吞掉后返回 0，日志只留这一行，链路继续往下跑，看不出丢了东西。

**去重键和库里的唯一约束不是一个键。** 生产约束 `uq_signal_pending_active` 建在
`(code, signal_type)` 上、只作用于活跃态（pending/survived），**与 `signal_date` 无关**。
而写入前的去重按 `(code, signal_type, signal_date)`，且 SELECT 只查当天 —— 跨日仍然活跃的行
它根本看不见。

912/sos 当时是 `id=3452 date=2026-08-28 status=survived days=1/2`，活跃、占着唯一键，
但 `signal_date` 是 8-28，被当天口径的过滤器漏掉了。

**PostgREST 的批量 insert 是单语句，一行冲突整批回滚。**

### 量出来的后果

| signal_date | 写入行数 |
|---|---|
| 2026-08-31 | **0** |
| 2026-08-28 | 38 |
| 2026-08-27 | 60 |
| 2026-08-26 | 44 |
| 2026-08-24 | 35 |
| 2026-08-17 | 88 |

同一次 run 的日志里 `各触发={'sos': 17, 'spring': 8, 'lps': 41, 'evr': 0, 'compression': 32,
'trend_pullback': 42}`，合计 **140 条触发信号**，被 912/sos 这一行全部带走。当日 10 条活跃行
全部来自 8-28，对当天口径的过滤器一概不可见。

**不是偶发。** 抽查前四次漏斗：8-30 12:46 和 8-27 12:52 各撞了一次 23505，而 8-30 14:24、
8-27 19:49 分别干净写入 38 和 60 行 —— 每天较早那次容易踩，较晚那次因为前一天的信号已经
`expired` 而放行。

**代价是延后显现的。** 8-31 当晚下游照常 `updated 44 pending signals` / `confirmed=18`，
用的是 8-28 留下的行；丢的是*未来*的确认。近 8 个交易日 pending→confirmed 为 110/330 = 33.3%，
按此比率 8-31 那 140 条里约 **47 条**本该在 9-01/9-02 转成确认信号。这批快照是当日 OHLCV
在 run 内算出来的，**无法回补**。

## 改动

`integrations/supabase_signal_pending.py`，两件事：

1. **按约束自己的键去重。** 两道过滤缺一不可：
   - 活跃态的 `(code, signal_type)`，不限日期 —— 这是 `uq_signal_pending_active` 的键；
   - 当天的 `(code, signal_type, signal_date)`，不分状态 —— 一天内跑第二遍时，已
     confirmed/expired 的当天信号不该被重新挂成 pending。这是原有语义，保留。

   同一批入参里重复的键也要去掉，否则批量 insert 会自己跟自己冲突。

2. **批量撞约束时退化为逐行插入。** SELECT 快照和 insert 之间仍有残留竞态窗口，但退化之后
   它只吃掉冲突那一行，而不是一整天。

`_looks_like_schema_miss` 那条老的兼容降级路径（缺 report 列时剥掉可选列重试）保持不变，
新分支排在它后面。

本地 SQLite 镜像不用改：`integrations/local_db.py:80` 声明的是
`UNIQUE(code, signal_type, signal_date)`，`_bulk_upsert` 走 `INSERT OR REPLACE`，且它是
Supabase 的只读缓存。

## 更正 #355 的描述

#355 的 PR 说明把这个 409 写成「读后写竞态，三元组幂等性完好」。那是错的 —— 当时只从行形状
（453 行、三元组全唯一）推断了约束，没看生产日志。真因是去重键与 `uq_signal_pending_active`
不同源，竞态只是残留的次要窗口。

## 验证

7 个测试，`tests/integrations/test_supabase_signal_pending.py` 重写。原来的 mock 忽略所有
filter，其中一个测试还编码了错的信念；新 mock 按约束语义建模，认 `status` 和 `signal_date`
两个 filter，冲突异常文本照抄 8-31 生产日志。

- `test_new_date_blocked_while_prior_signal_still_active` —— 8-31 的形状，断言写入 0
- `test_new_date_allowed_once_prior_signal_settled` —— expired 行释放唯一键
- `test_pending_dedup_skips_same_trade_date`
- `test_pending_dedup_skips_same_date_after_confirmation` —— 断言 0，靠同日过滤而非约束
- `test_duplicate_keys_within_one_batch_collapse`
- `test_one_conflict_does_not_lose_the_whole_batch` —— 核心回归：2 行写入、1 行跳过，
  insert 调用 4 次（1 次失败批量 + 3 次逐行），而不是整批丢掉
- `test_schema_miss_still_falls_back_to_legacy_payload` —— 老降级路径必须活着

反向对照：stash 掉实现、拿新测试跑旧代码 → **3 failed, 4 passed**，日志里能看到那段 23505 原文。

全量 4393 passed / 22 skipped；`tests/test_architecture_boundaries.py` 17 passed；
`quality_gate.py --ci` OK（0 active legacy functions over limit）；`--check-no-sql` OK；
ruff check / format 干净。

## 顺带提醒（不在本 PR 范围）

#355 加的三列 DDL **仍未执行**，需要人在 Supabase SQL Editor 里跑一次，CI 里没有任何东西能替代：

```
alter table public.recommendation_tracking
    add column if not exists capital_migration_bonus numeric,
    add column if not exists dynamic_shadow_score numeric,
    add column if not exists dynamic_shadow_promotion jsonb;
```
