### PR TITLE
feat(reading-room): 注入实测时间与复权口径，威科夫结构改由模型判断 + 代码算数

### DIFF
--- a/web/apps/api/src/routes/chat-prompt-cache.test.ts
+++ b/web/apps/api/src/routes/chat-prompt-cache.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { assessTradingDay, formatSessionClockContext, resolveSessionClock } from '@wyckoff/shared'
 import { appendMarketWatchModelMessage, buildStableChatSystemPrompt } from '../services/chat-prompt-prefix'
 
 describe('reading-room prompt cache prefix', () => {
@@ -30,5 +31,27 @@ describe('reading-room prompt cache prefix', () => {
   it('skips empty market watch context', () => {
     const messages = [{ role: 'user' as const, content: '你好' }]
     expect(appendMarketWatchModelMessage(messages, '   ')).toEqual(messages)
+  })
+
+  it('时间口径也走 user 消息 —— 写进 system 会每轮击穿缓存', () => {
+    const clock = resolveSessionClock(new Date('2026-08-28T02:00:00Z'))
+    const context = formatSessionClockContext(clock, assessTradingDay(clock, ['2026-08-28T02:00:00Z']))
+    const system = buildStableChatSystemPrompt({ rolePrompt: 'STATIC_SYSTEM' })
+    expect(system).not.toContain('北京时间')
+
+    const next = appendMarketWatchModelMessage([{ role: 'user' as const, content: '看看 600519' }], context)
+    expect(next).toHaveLength(2)
+    expect(next[1]).toMatchObject({ role: 'user' })
+    expect((next[1] as { content: string }).content).toContain('当前北京时间:2026-08-28 10:00(UTC+8)')
+  })
+
+  it('时间与行情各占一条 user 消息，顺序是时间在前', () => {
+    const next = appendMarketWatchModelMessage(
+      appendMarketWatchModelMessage([{ role: 'user' as const, content: '复盘' }], '## 当前时间与交易时段'),
+      '## 观察篮临时行情',
+    )
+    expect(next.map((message) => (message as { content: string }).content)).toEqual([
+      '复盘', '## 当前时间与交易时段', '## 观察篮临时行情',
+    ])
   })
 })

--- a/web/apps/api/src/routes/chat.ts
+++ b/web/apps/api/src/routes/chat.ts
@@ -16,7 +16,10 @@ import {
   execStrategyDecision,
   execViewPortfolio,
   fetchMarketWatchSnapshot,
+  assessTradingDay,
   formatMarketWatchContext,
+  formatSessionClockContext,
+  resolveSessionClock,
   selectMarketWatchCodes,
   ALLOWED_PROXY_TARGET_ORIGINS,
   normalizeGeminiStream,
@@ -129,7 +132,10 @@ const WYCKOFF_CHAT_SYSTEM_PROMPT = `# 角色设定
 4. 风险声明：涉及具体操作建议时，附带风险提示。
 5. 技术面为主：价值面只用于质量、风险、置信度和仓位校准，不能替代 K 线事实。
 6. 策略归因问题必须调用 query_attribution，先确认返回结果是否来自远端表或提示本地 --no-write 报告，再优先读取 operator_summary / latest_operator_summary 作为运营结论，然后读取 latest_policy_display、latest_execution_summary、promotion_checklist 和 latest_operations 后判断信号升降权、是否能晋级 dynamic=on，以及 shadow 新增/移除样本；raw next_action/promotion_status 只作追证据，不直接复述给用户。
-7. 只有用户明确要求进行 Python 计算、回测或统计时，才可调用 run_python_research。先说明计算目的；该工具必须等待用户确认，脚本只处理已知、有限的数据，不能把猜测当作数据来源。`
+7. 只有用户明确要求进行 Python 计算、回测或统计时，才可调用 run_python_research。先说明计算目的；该工具必须等待用户确认，脚本只处理已知、有限的数据，不能把猜测当作数据来源。
+8. 时间与交易时段以本轮注入的「当前时间与交易时段」为准，不得自行推算或编造。涉及盘面的回复先写出那一行北京时间；处于非交易日/非交易时段时，只做盘后复盘、次日计划与 T+1 委托策略，不给「立刻买/立刻卖」的指令。
+9. 复权口径以本轮注入的「复权口径」为准：结构价位来自前复权，委托价须是不复权实时价。两者被判定错开时，先说明差异，不得把结构价位直接当作委托价。
+10. analyze_stock 的 chart_plan 用于前端作图：日期必须取自工具返回的真实交易日，判断不出的阶段就留空，不要为了凑齐五个阶段而编。若处于可盘中交易时段且该股已有持仓，则不填 chart_plan（置为 null），直接给结论与操作口径 —— 盘中持仓看的是当下怎么办，不是回顾结构。`
 
 const WEB_SEARCH_GUIDANCE = `# 联网搜索
 
@@ -333,13 +339,19 @@ async function runChatWithResilience(args: ChatResilienceArgs): Promise<void> {
   const marketWatch = await fetchMarketWatchSnapshot(args.deps, args.userId, selectedCodes, args.marketWatchCache)
   if (marketWatch.state !== 'empty') writeMarketWatchStatus(args.writer, marketWatch)
   const marketWatchContext = formatMarketWatchContext(marketWatch)
+  // 时间取本轮实测，交易日用行情时间戳证实 —— 节假日算不出来，只能观测。
+  const clock = resolveSessionClock(new Date())
+  const sessionClockContext = formatSessionClockContext(
+    clock,
+    assessTradingDay(clock, marketWatch.state === 'ready' ? marketWatch.quotes.map((quote) => quote.asOf) : []),
+  )
   let lastError: unknown = new Error('没有可用的模型配置')
   for (let index = 0; index < args.configs.length; index += 1) {
     const config = args.configs[index]
     if (!config) continue
     for (let attempt = 1; attempt <= 2; attempt += 1) {
       try {
-        await runChatAttempt(args, config, marketWatchContext)
+        await runChatAttempt(args, config, marketWatchContext, sessionClockContext)
         return
       } catch (error) {
         lastError = error
@@ -489,7 +501,31 @@ function buildChatSystemPrompt(transport: 'chat' | 'responses'): string {
   })
 }
 
-async function runChatAttempt(args: ChatResilienceArgs, config: ChatModelConfig, marketWatchContext: string): Promise<void> {
+/** 当轮消息：历史前缀 + 挂在末尾的时间和行情。 */
+async function buildTurnModelMessages(
+  args: ChatResilienceArgs,
+  resolved: ReturnType<typeof resolveChatLanguageModel>,
+  tools: any,
+  sessionClockContext: string,
+  marketWatchContext: string,
+) {
+  const recentMessages = removeSupersededToolApprovals(args.messages.slice(-40))
+  const normalizedMessages = resolved.transport === 'chat'
+    ? sanitizeMessagesForChatTransport(recentMessages)
+    : recentMessages
+  const modelMessages = await convertToModelMessages(normalizedMessages, {
+    tools,
+    ignoreIncompleteToolCalls: true,
+  })
+  // 时间与行情都作为当轮额外 user 消息挂在末尾，不改写 system / 历史前缀。
+  // 时间每轮都变，写进 system 等于每轮击穿 prompt cache。
+  return appendMarketWatchModelMessage(
+    appendMarketWatchModelMessage(modelMessages, sessionClockContext),
+    marketWatchContext,
+  )
+}
+
+async function runChatAttempt(args: ChatResilienceArgs, config: ChatModelConfig, marketWatchContext: string, sessionClockContext: string): Promise<void> {
   writeRunEvent(args, { type: 'model_started', label: `开始使用 ${config.model}` })
   writeStageProgress(args.writer, { stage: 'model', state: 'started', message: '正在分析', model: config.model })
   let succeeded = false
@@ -497,16 +533,7 @@ async function runChatAttempt(args: ChatResilienceArgs, config: ChatModelConfig,
   try {
     const resolved = resolveChatLanguageModel(config, createProviderFetch(config.reasoning_level))
     const tools = buildTools(args, config, resolved.nestedModel, resolved.providerTools)
-    const recentMessages = removeSupersededToolApprovals(args.messages.slice(-40))
-    const normalizedMessages = resolved.transport === 'chat'
-      ? sanitizeMessagesForChatTransport(recentMessages)
-      : recentMessages
-    let modelMessages = await convertToModelMessages(normalizedMessages, {
-      tools,
-      ignoreIncompleteToolCalls: true,
-    })
-    // 行情作为当轮额外 user 消息挂在末尾，不改写 system / 历史前缀。
-    modelMessages = appendMarketWatchModelMessage(modelMessages, marketWatchContext)
+    let modelMessages = await buildTurnModelMessages(args, resolved, tools, sessionClockContext, marketWatchContext)
     let continuationCount = 0
     let totalSteps = 0
     let segmentIndex = 0

--- a/web/apps/web/src/components/kline-chart.tsx
+++ b/web/apps/web/src/components/kline-chart.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useMemo, useRef } from 'react'
 import { watchChartResize } from '@/lib/chart-resize'
 import { formatSignedPercent } from '@/lib/format'
 import { avg, rsi as calcRSI, macd as calcMACD, bollinger as calcBollinger } from '@/lib/math'
-import type { KlineRow } from '@wyckoff/shared'
+import { deriveForecastSeries, deriveWyckoffZones, formatChartPlanNotes, type KlineRow, type WyckoffChartPlan } from '@wyckoff/shared'
+import { WyckoffZonePrimitive } from '@/components/wyckoff-zone-primitive'
 import {
   createChart,
   CandlestickSeries,
@@ -41,6 +42,8 @@ interface KlineChartProps {
   tradingRange?: { support: number; resistance: number }
   stage?: string
   showIndicators?: boolean
+  /** 模型给的威科夫作图计划:阶段、事件、推演。给了就画长周期均线、底色、预测线。 */
+  chartPlan?: WyckoffChartPlan | null
   onBarClick?: (date: string) => void
 }
 
@@ -62,23 +65,27 @@ interface ChartRefs {
   ma5: ISeriesApi<'Line'>
   ma20: ISeriesApi<'Line'>
   ma50: ISeriesApi<'Line'>
+  ma200: ISeriesApi<'Line'>
   volume: ISeriesApi<'Histogram'>
   markers: ISeriesMarkersPluginApi<Time> | null
 }
 
 type ChartTheme = ReturnType<typeof readChartTheme>
 
-export function KlineChart({ data, height = 400, wyckoffMarkers, newsMarkers, tradingRange, stage, showIndicators = false, onBarClick }: KlineChartProps) {
+export function KlineChart({ data, height = 400, wyckoffMarkers, newsMarkers, tradingRange, stage, showIndicators = false, chartPlan, onBarClick }: KlineChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRefs = useRef<ChartRefs | null>(null)
   const themeRef = useRef(readChartTheme())
   const structure = useMemo(() => buildStructureSnapshot(data, tradingRange, stage), [data, tradingRange, stage])
   const [indicators, setIndicators] = useState({ boll: false, rsi: false, macd: false })
+  const planMarkers = useMemo(() => (chartPlan ? toPlanMarkers(chartPlan) : undefined), [chartPlan])
+  const planNotes = useMemo(() => (chartPlan ? formatChartPlanNotes(chartPlan) : []), [chartPlan])
 
   useChartInit(containerRef, chartRefs, themeRef, height)
-  useChartData(chartRefs, themeRef, data, wyckoffMarkers, newsMarkers, tradingRange)
+  useChartData(chartRefs, themeRef, data, planMarkers ?? wyckoffMarkers, newsMarkers, tradingRange)
   useChartSelection(chartRefs, onBarClick)
   useBollingerOverlay(chartRefs, data, indicators.boll)
+  useChartPlanOverlay(chartRefs, data, chartPlan)
 
   const closes = useMemo(() => data.map((d) => d.close), [data])
   const dates = useMemo(() => data.map((d) => d.date), [data])
@@ -94,8 +101,23 @@ export function KlineChart({ data, height = 400, wyckoffMarkers, newsMarkers, tr
       {showIndicators && <IndicatorBar indicators={indicators} setIndicators={setIndicators} />}
       {indicators.rsi && <RSISubChart closes={closes} dates={dates} />}
       {indicators.macd && <MACDSubChart closes={closes} dates={dates} />}
-      <ChartLegend boll={indicators.boll} wyckoffMarkers={!!wyckoffMarkers} newsMarkers={!!newsMarkers?.length} />
+      <ChartLegend boll={indicators.boll} wyckoffMarkers={!!wyckoffMarkers || !!planMarkers} newsMarkers={!!newsMarkers?.length} chartPlan={!!chartPlan} />
+      {planNotes.length > 0 && <ChartPlanNotes notes={planNotes} />}
     </div>
+  )
+}
+
+/**
+ * 图上只挂术语,理由列在图下。
+ *
+ * 术语加长句一起塞进 marker,几个事件挨在一起就互相压住,谁也读不清。宁可
+ * 图上少显示一个字,也不牺牲整张图的可读性。
+ */
+function ChartPlanNotes({ notes }: { notes: string[] }) {
+  return (
+    <ul className="space-y-1 rounded-lg border border-border bg-muted/20 px-3 py-2 text-[11px] leading-5 text-muted-foreground">
+      {notes.map((note) => <li key={note}>{note}</li>)}
+    </ul>
   )
 }
 
@@ -138,9 +160,10 @@ function useChartInit(
     const ma5 = chart.addSeries(LineSeries, { ...maOpts, color: '#f59e0b', lineWidth: 1 })
     const ma20 = chart.addSeries(LineSeries, { ...maOpts, color: '#2563eb', lineWidth: 2 })
     const ma50 = chart.addSeries(LineSeries, { ...maOpts, color: '#7c3aed', lineWidth: 2, lineStyle: LineStyle.Dashed })
+    const ma200 = chart.addSeries(LineSeries, { ...maOpts, color: '#dc2626', lineWidth: 2, lineStyle: LineStyle.Dashed })
     const volume = chart.addSeries(HistogramSeries, { priceFormat: { type: 'volume' }, priceScaleId: 'volume' })
     chart.priceScale('volume').applyOptions({ scaleMargins: { top: 0.84, bottom: 0 } })
-    chartRefs.current = { chart, candle, ma5, ma20, ma50, volume, markers: null }
+    chartRefs.current = { chart, candle, ma5, ma20, ma50, ma200, volume, markers: null }
     const stopResize = watchChartResize(containerRef.current, chart)
     return () => { stopResize(); chartRefs.current?.markers?.detach(); chart.remove(); chartRefs.current = null }
   }, [containerRef, chartRefs, themeRef, height])
@@ -166,6 +189,8 @@ function useChartData(
     refs.ma5.setData(movingAverage(data, 5))
     refs.ma20.setData(movingAverage(data, 20))
     refs.ma50.setData(movingAverage(data, 50))
+    // 不足 200 根时 movingAverage 返回空数组,线自动不画 —— 不用半截数据凑一条。
+    refs.ma200.setData(movingAverage(data, 200))
     refs.volume.setData(volumes)
     const markers = [...(wyckoffMarkers ? toSeriesMarkers(wyckoffMarkers) : buildMarkers(data)), ...toNewsMarkers(newsMarkers)]
     if (refs.markers) refs.markers.setMarkers(markers)
@@ -195,6 +220,83 @@ function useBollingerOverlay(chartRefs: React.MutableRefObject<ChartRefs | null>
   }, [chartRefs, data, active])
 }
 
+/**
+ * 阶段底色、阶段分割线、30 日推演线。
+ *
+ * 每次 plan 变了整套重建 —— 这三样都是整体一致的东西,增量更新容易留下上一轮的
+ * 残留线条。重建的代价是几个 addSeries,可以接受。
+ */
+function useChartPlanOverlay(
+  chartRefs: React.MutableRefObject<ChartRefs | null>,
+  data: KlineRow[],
+  plan: WyckoffChartPlan | null | undefined,
+) {
+  useEffect(() => {
+    const refs = chartRefs.current
+    if (!refs || data.length === 0 || !plan) return
+    const added: ISeriesApi<'Line'>[] = []
+    const zones = deriveWyckoffZones(plan, data)
+    const zonePrimitive = zones.length > 0 ? new WyckoffZonePrimitive(zones) : null
+    if (zonePrimitive) refs.candle.attachPrimitive(zonePrimitive)
+
+    // 阶段分割线画成竖线:同一天两个点,一个贴顶一个贴底。用独立 series 而不是
+    // priceLine —— priceLine 只能横着画。
+    const bounds = priceBounds(data)
+    for (const phase of plan.phases) {
+      const divider = refs.chart.addSeries(LineSeries, {
+        color: '#94a3b8', lineWidth: 1, lineStyle: LineStyle.Dotted,
+        priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false,
+      })
+      divider.setData([
+        { time: phase.startDate as Time, value: bounds.low },
+        { time: phase.startDate as Time, value: bounds.high },
+      ])
+      added.push(divider)
+    }
+
+    const forecast = deriveForecastSeries(plan.forecast, data)
+    if (forecast.length > 1) {
+      const line = refs.chart.addSeries(LineSeries, {
+        color: '#f97316', lineWidth: 2, lineStyle: LineStyle.Dashed,
+        priceLineVisible: false, lastValueVisible: true, title: '推演',
+      })
+      line.setData(forecast.map((point) => ({ time: point.date as Time, value: point.value })))
+      added.push(line)
+    }
+    refs.chart.timeScale().fitContent()
+
+    return () => {
+      if (zonePrimitive) refs.candle.detachPrimitive(zonePrimitive)
+      added.forEach((series) => refs.chart.removeSeries(series))
+    }
+  }, [chartRefs, data, plan])
+}
+
+function priceBounds(data: KlineRow[]): { low: number; high: number } {
+  return {
+    low: Math.min(...data.map((row) => row.low)),
+    high: Math.max(...data.map((row) => row.high)),
+  }
+}
+
+/** 图上只挂术语原文,理由交给 ChartPlanNotes —— 长句挤在 K 线上谁也读不清。 */
+function toPlanMarkers(plan: WyckoffChartPlan): WyckoffMarkerInput[] {
+  return plan.events.map((event) => ({
+    date: event.date,
+    type: planMarkerType(event.term),
+    label: event.term,
+    position: event.side === 'above' ? 'aboveBar' : 'belowBar',
+  }))
+}
+
+function planMarkerType(term: string): WyckoffMarkerInput['type'] {
+  const normalized = term.toLowerCase()
+  if (normalized.includes('spring') || normalized.includes('sc')) return 'spring'
+  if (normalized.includes('sos') || normalized.includes('jac')) return 'sos'
+  if (normalized.includes('lps') || normalized.includes('st')) return 'lps'
+  return 'evr'
+}
+
 function StructureMetrics({ structure }: { structure: StructureSnapshot }) {
   return (
     <div className="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-4">
@@ -216,12 +318,20 @@ function IndicatorBar({ indicators, setIndicators }: { indicators: { boll: boole
   )
 }
 
-function ChartLegend({ boll, wyckoffMarkers, newsMarkers }: { boll: boolean; wyckoffMarkers: boolean; newsMarkers: boolean }) {
+function ChartLegend({ boll, wyckoffMarkers, newsMarkers, chartPlan = false }: { boll: boolean; wyckoffMarkers: boolean; newsMarkers: boolean; chartPlan?: boolean }) {
   return (
     <div className="flex flex-wrap gap-3 text-[11px] text-muted-foreground">
       <Legend color="#f59e0b" label="MA5" />
       <Legend color="#2563eb" label="MA20" />
       <Legend color="#7c3aed" label="MA50" />
+      <Legend color="#dc2626" label="MA200" />
+      {chartPlan && (
+        <>
+          <Legend color="#f97316" label="30日推演" />
+          <Legend color="#2563eb" label="吸筹区" />
+          <Legend color="#ef4444" label="派发区" />
+        </>
+      )}
       {boll && <Legend color="#94a3b8" label="BOLL" />}
       {newsMarkers && <Legend color="#0f766e" label="新闻" />}
       {wyckoffMarkers ? (

--- a/web/apps/web/src/components/wyckoff-zone-primitive.ts
+++ b/web/apps/web/src/components/wyckoff-zone-primitive.ts
@@ -1,0 +1,117 @@
+/**
+ * 吸筹/派发区底色。
+ *
+ * priceLines 只能画横线,填不出矩形,所以这里走 lightweight-charts 的 primitive
+ * 直接在画布上刷一块半透明矩形。zOrder 走 'bottom',保证 K 线永远压在底色之上 ——
+ * 底色是背景信息,不能盖住价格。
+ */
+
+import type {
+  IChartApi,
+  IPrimitivePaneRenderer,
+  IPrimitivePaneView,
+  ISeriesApi,
+  ISeriesPrimitive,
+  PrimitivePaneViewZOrder,
+  SeriesAttachedParameter,
+  Time,
+} from 'lightweight-charts'
+import type { WyckoffZone } from '@wyckoff/shared'
+
+interface ZoneBox {
+  left: number
+  right: number
+  top: number
+  bottom: number
+  color: string
+}
+
+const ACCUMULATION_FILL = 'rgba(37, 99, 235, 0.10)'
+const DISTRIBUTION_FILL = 'rgba(239, 68, 68, 0.10)'
+
+class ZoneRenderer implements IPrimitivePaneRenderer {
+  constructor(private readonly boxes: ZoneBox[]) {}
+
+  draw(target: Parameters<IPrimitivePaneRenderer['draw']>[0]) {
+    target.useMediaCoordinateSpace(({ context }) => {
+      for (const box of this.boxes) {
+        context.fillStyle = box.color
+        context.fillRect(box.left, box.top, box.right - box.left, box.bottom - box.top)
+      }
+    })
+  }
+}
+
+class ZonePaneView implements IPrimitivePaneView {
+  private boxes: ZoneBox[] = []
+
+  constructor(private readonly source: WyckoffZonePrimitive) {}
+
+  zOrder(): PrimitivePaneViewZOrder {
+    return 'bottom'
+  }
+
+  update() {
+    this.boxes = this.source.computeBoxes()
+  }
+
+  renderer(): IPrimitivePaneRenderer | null {
+    return this.boxes.length > 0 ? new ZoneRenderer(this.boxes) : null
+  }
+}
+
+export class WyckoffZonePrimitive implements ISeriesPrimitive<Time> {
+  private chart: IChartApi | null = null
+  private series: ISeriesApi<'Candlestick', Time> | null = null
+  private readonly paneView = new ZonePaneView(this)
+
+  constructor(private zones: WyckoffZone[]) {}
+
+  attached(param: SeriesAttachedParameter<Time>) {
+    this.chart = param.chart as IChartApi
+    this.series = param.series as ISeriesApi<'Candlestick', Time>
+  }
+
+  detached() {
+    this.chart = null
+    this.series = null
+  }
+
+  setZones(zones: WyckoffZone[]) {
+    this.zones = zones
+    this.paneView.update()
+  }
+
+  updateAllViews() {
+    this.paneView.update()
+  }
+
+  paneViews(): readonly IPrimitivePaneView[] {
+    return [this.paneView]
+  }
+
+  computeBoxes(): ZoneBox[] {
+    const chart = this.chart
+    const series = this.series
+    if (!chart || !series || this.zones.length === 0) return []
+    const timeScale = chart.timeScale()
+    const boxes: ZoneBox[] = []
+
+    for (const zone of this.zones) {
+      const left = timeScale.timeToCoordinate(zone.startDate as Time)
+      const right = timeScale.timeToCoordinate(zone.endDate as Time)
+      const top = series.priceToCoordinate(zone.priceHigh)
+      const bottom = series.priceToCoordinate(zone.priceLow)
+      // 区间滚出可视范围时坐标为 null,跳过 —— 不猜一个位置画上去。
+      if (left == null || right == null || top == null || bottom == null) continue
+      boxes.push({
+        left: Math.min(left, right),
+        right: Math.max(left, right),
+        top: Math.min(top, bottom),
+        bottom: Math.max(top, bottom),
+        color: zone.structure === 'accumulation' ? ACCUMULATION_FILL : DISTRIBUTION_FILL,
+      })
+    }
+    return boxes
+  }
+}

--- a/web/apps/web/src/features/reading-room/tool-structured-cards.tsx
+++ b/web/apps/web/src/features/reading-room/tool-structured-cards.tsx
@@ -5,6 +5,7 @@ import { ScreenResultCard } from '@/components/screen-result-card'
 import { asRecord, normalizeStockCode, sanitizeText } from './utils'
 import type { PinStockInput } from './types'
 import { isAnalyzeResult, isScreenResult, isStrategyResult, summarizeToolOutput } from './tool-rendering-model'
+import { WyckoffChartPanel } from './wyckoff-chart-panel'
 
 export function ToolStructuredOutput({
   toolName,
@@ -62,6 +63,7 @@ function AnalyzeResultCard({
       </div>
       {data.data_quality && <DataQualityLine quality={data.data_quality} />}
       {data.context_pack && <ContextPackLine pack={data.context_pack} />}
+      {code && data.chart_plan && <WyckoffChartPanel code={code} plan={data.chart_plan} />}
       <AnalyzeLevelBadges data={data} />
       <MarkdownContent content={data.markdown || data.summary} className="text-xs" />
     </div>

--- a/web/apps/web/src/features/reading-room/wyckoff-chart-panel.tsx
+++ b/web/apps/web/src/features/reading-room/wyckoff-chart-panel.tsx
@@ -1,0 +1,67 @@
+/**
+ * 聊天里的威科夫图。
+ *
+ * 图画在浏览器端,不走 matplotlib —— 沙箱里没网装不了包,也读不回图片字节。
+ * 顺带把中文字体那一整套约束消掉:浏览器渲染中文本来就不会 fallback 成方框。
+ *
+ * K 线不在工具返回值里(带 320 根进上下文太贵),所以这里按需自己取,并且只在
+ * 用户展开时才发请求。
+ */
+
+import { useEffect, useState } from 'react'
+import type { WyckoffChartPlan, KlineRow } from '@wyckoff/shared'
+import { KlineChart } from '@/components/kline-chart'
+import { fetchKlineWithQuality, getUserDataKeys } from '@/lib/kline'
+import { useAuthStore } from '@/stores/auth'
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; rows: KlineRow[] }
+  | { status: 'error'; message: string }
+
+export function WyckoffChartPanel({ code, plan }: { code: string; plan: WyckoffChartPlan }) {
+  const [open, setOpen] = useState(false)
+  const [state, setState] = useState<LoadState>({ status: 'idle' })
+  const userId = useAuthStore((store) => store.user?.id)
+
+  useEffect(() => {
+    if (!open || state.status !== 'idle' || !userId) return
+    let cancelled = false
+    setState({ status: 'loading' })
+    void (async () => {
+      try {
+        const keys = await getUserDataKeys(userId)
+        const result = await fetchKlineWithQuality(code, keys, userId)
+        if (!cancelled) setState({ status: 'ready', rows: result.data })
+      } catch (error) {
+        if (!cancelled) setState({ status: 'error', message: error instanceof Error ? error.message : String(error) })
+      }
+    })()
+    return () => { cancelled = true }
+  }, [open, state.status, code, userId])
+
+  return (
+    <div className="rounded-md border border-border/50 bg-muted/20 px-2 py-1.5 text-[11px]">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="w-full cursor-pointer text-left font-medium text-foreground"
+      >
+        {open ? '收起威科夫结构图' : '展开威科夫结构图'}
+      </button>
+      {open && (
+        <div className="mt-2">
+          {state.status === 'loading' && <p className="text-muted-foreground">正在取 K 线…</p>}
+          {state.status === 'error' && <p className="text-amber-700 dark:text-amber-200">取 K 线失败：{state.message}</p>}
+          {!userId && <p className="text-muted-foreground">未登录，无法取 K 线。</p>}
+          {state.status === 'ready' && (
+            state.rows.length > 0
+              ? <KlineChart data={state.rows} height={380} chartPlan={plan} showIndicators />
+              : <p className="text-muted-foreground">没有可用 K 线，不画图。</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/apps/web/src/lib/__tests__/price-basis.test.ts
+++ b/web/apps/web/src/lib/__tests__/price-basis.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { checkPriceBasis, formatPriceBasisNote } from '@wyckoff/shared'
+
+describe('checkPriceBasis', () => {
+  it('前复权收盘与实时价一致时算对齐', () => {
+    expect(checkPriceBasis(12.3, 12.32)).toMatchObject({ status: 'aligned' })
+  })
+
+  it('差出阈值就判为错开,不当作同一把尺子', () => {
+    const check = checkPriceBasis(12.3, 20.5)
+    expect(check.status).toBe('diverged')
+    expect(check.divergencePct).toBeCloseTo(0.4, 2)
+  })
+
+  it('缺任一边就是 unknown,不许拿单边数当依据', () => {
+    expect(checkPriceBasis(null, 12.3).status).toBe('unknown')
+    expect(checkPriceBasis(12.3, null).status).toBe('unknown')
+  })
+
+  it('零和负数不是有效价格', () => {
+    expect(checkPriceBasis(0, 12.3).status).toBe('unknown')
+    expect(checkPriceBasis(12.3, -1).status).toBe('unknown')
+  })
+
+  it('NaN 不能被当成数字放过去', () => {
+    expect(checkPriceBasis(Number.NaN, 12.3).status).toBe('unknown')
+  })
+})
+
+describe('formatPriceBasisNote', () => {
+  it('对齐时允许直接引用结构价位报单', () => {
+    const text = formatPriceBasisNote(checkPriceBasis(12.3, 12.3))
+    expect(text).toContain('可以直接引用结构价位')
+  })
+
+  it('错开时必须先说明,且报单价以实时价为准', () => {
+    const text = formatPriceBasisNote(checkPriceBasis(12.3, 20.5))
+    expect(text).toContain('两把尺子没对上')
+    expect(text).toContain('不要把结构价位直接当作委托价')
+    expect(text).toContain('报单价以实时价为准')
+  })
+
+  it('缺实时价时要求标明价来自前复权收盘', () => {
+    const text = formatPriceBasisNote(checkPriceBasis(12.3, null))
+    expect(text).toContain('无法核对')
+    expect(text).toContain('前复权收盘而非实时成交价')
+  })
+})

--- a/web/apps/web/src/lib/__tests__/session-clock.test.ts
+++ b/web/apps/web/src/lib/__tests__/session-clock.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assessTradingDay,
+  formatSessionClockContext,
+  resolveSessionClock,
+  toBeijingParts,
+} from '@wyckoff/shared'
+
+/** 2026-08-28 是周五。用 UTC 构造,避免测试机器时区影响结果。 */
+function utc(iso: string): Date {
+  return new Date(iso)
+}
+
+describe('toBeijingParts', () => {
+  it('不看运行环境时区,固定按 UTC+8 换算', () => {
+    // UTC 01:30 → 北京 09:30
+    expect(toBeijingParts(utc('2026-08-28T01:30:00Z'))).toMatchObject({
+      date: '2026-08-28', time: '09:30', weekday: 5,
+    })
+  })
+
+  it('跨日:UTC 傍晚已经是北京第二天', () => {
+    // UTC 周五 16:10 → 北京周六 00:10
+    expect(toBeijingParts(utc('2026-08-28T16:10:00Z'))).toMatchObject({
+      date: '2026-08-29', time: '00:10', weekday: 6,
+    })
+  })
+
+  it('周日按 ISO 记为 7,不是 0', () => {
+    expect(toBeijingParts(utc('2026-08-30T04:00:00Z')).weekday).toBe(7)
+  })
+})
+
+describe('时段判定', () => {
+  const at = (utcIso: string) => resolveSessionClock(utc(utcIso))
+
+  it('09:25 到 09:30 之间是空档,不可下单', () => {
+    // 集合竞价 09:25 结束,连续竞价 09:30 才开始
+    expect(at('2026-08-28T01:27:00Z')).toMatchObject({ phase: 'pre-open', tradableByClock: false })
+  })
+
+  it('集合竞价与连续竞价都算可交易时段', () => {
+    expect(at('2026-08-28T01:20:00Z')).toMatchObject({ phase: 'call-auction', tradableByClock: true })
+    expect(at('2026-08-28T02:00:00Z')).toMatchObject({ phase: 'continuous', tradableByClock: true })
+    expect(at('2026-08-28T06:58:00Z')).toMatchObject({ phase: 'call-auction', tradableByClock: true })
+  })
+
+  it('边界:11:30 收盘进午休,13:00 开盘回连续竞价', () => {
+    expect(at('2026-08-28T03:30:00Z').phase).toBe('lunch-break')
+    expect(at('2026-08-28T05:00:00Z').phase).toBe('continuous')
+  })
+
+  it('15:00 整已经收盘,不再可交易', () => {
+    expect(at('2026-08-28T07:00:00Z')).toMatchObject({ phase: 'post-close', tradableByClock: false })
+  })
+
+  it('周末无论几点都是休市,且不存在节假日不确定性', () => {
+    const saturday = at('2026-08-29T02:00:00Z')
+    expect(saturday).toMatchObject({ phase: 'weekend', tradableByClock: false, holidayUnknown: false })
+  })
+
+  it('工作日一律带节假日未知标记 —— 调休和节假日算不出来', () => {
+    expect(at('2026-08-28T02:00:00Z').holidayUnknown).toBe(true)
+  })
+})
+
+describe('assessTradingDay', () => {
+  const tradingHours = resolveSessionClock(utc('2026-08-28T02:00:00Z'))
+
+  it('报价时间戳落在今天 → 证实今日开市', () => {
+    expect(assessTradingDay(tradingHours, ['2026-08-28T02:00:00Z'])).toBe('confirmed-open')
+  })
+
+  it('时间戳停在前一天 → 很可能休市,不能报成开市', () => {
+    expect(assessTradingDay(tradingHours, ['2026-08-27T07:00:00Z'])).toBe('likely-closed')
+  })
+
+  it('没有可用时间戳时说 unknown,不许猜一个方向', () => {
+    expect(assessTradingDay(tradingHours, [])).toBe('unknown')
+    expect(assessTradingDay(tradingHours, [null, '  '])).toBe('unknown')
+  })
+
+  it('收盘后拿不到判据:那时行情静止,分不出收盘与没开市', () => {
+    const afterClose = resolveSessionClock(utc('2026-08-28T08:00:00Z'))
+    expect(assessTradingDay(afterClose, ['2026-08-28T07:00:00Z'])).toBe('unknown')
+  })
+
+  it('周末直接判休市,不需要行情判据', () => {
+    const weekend = resolveSessionClock(utc('2026-08-29T02:00:00Z'))
+    expect(assessTradingDay(weekend, [])).toBe('likely-closed')
+  })
+})
+
+describe('formatSessionClockContext', () => {
+  it('每种情形都带上那句固定开头,时间取实测值', () => {
+    const clock = resolveSessionClock(utc('2026-08-28T02:00:00Z'))
+    const text = formatSessionClockContext(clock, 'confirmed-open')
+    expect(text).toContain('当前北京时间:2026-08-28 10:00(UTC+8)')
+    expect(text).toContain('周五')
+  })
+
+  it('非交易时段必须给出那句禁令,并限定到复盘与次日计划', () => {
+    const clock = resolveSessionClock(utc('2026-08-28T08:00:00Z'))
+    const text = formatSessionClockContext(clock, 'unknown')
+    expect(text).toContain('当前不可盘中交易(原因:非交易时段')
+    expect(text).toContain('T+1')
+    expect(text).toContain('不要给「立刻买/立刻卖」的指令')
+  })
+
+  it('周末给的原因是非交易日,不是非交易时段', () => {
+    const clock = resolveSessionClock(utc('2026-08-29T02:00:00Z'))
+    expect(formatSessionClockContext(clock, 'likely-closed')).toContain('当前不可盘中交易(原因:非交易日)')
+  })
+
+  it('疑似节假日时按不可交易处理,而不是因为时钟对就放行', () => {
+    const clock = resolveSessionClock(utc('2026-08-28T02:00:00Z'))
+    const text = formatSessionClockContext(clock, 'likely-closed')
+    expect(text).toContain('很可能是节假日休市')
+    expect(text).toContain('按不可盘中交易处理')
+  })
+
+  it('没有判据时不假装确定,要求先确认今日开市', () => {
+    const clock = resolveSessionClock(utc('2026-08-28T02:00:00Z'))
+    const text = formatSessionClockContext(clock, 'unknown')
+    expect(text).toContain('无法离线判定')
+    expect(text).toContain('先确认今日确实开市')
+    expect(text).not.toContain('今日确认在交易')
+  })
+})

--- a/web/apps/web/src/lib/__tests__/wyckoff-chart-plan.test.ts
+++ b/web/apps/web/src/lib/__tests__/wyckoff-chart-plan.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveForecastSeries,
+  deriveWyckoffZones,
+  formatChartPlanNotes,
+  validateChartPlan,
+  type KlineRow,
+  type WyckoffChartPlan,
+} from '@wyckoff/shared'
+
+/** 2024-01-01 起连续自然日,收盘价由 closes 指定。 */
+function buildKline(closes: number[], startDay = 1): KlineRow[] {
+  return closes.map((close, index) => {
+    const day = String(startDay + index).padStart(2, '0')
+    return {
+      date: `2024-01-${day}`,
+      open: close,
+      high: close + 1,
+      low: close - 1,
+      close,
+      volume: 1000,
+    }
+  })
+}
+
+const EMPTY_PLAN: WyckoffChartPlan = { phases: [], events: [], forecast: null }
+
+describe('validateChartPlan', () => {
+  const kline = buildKline([10, 11, 12, 13, 14])
+
+  it('丢掉不存在的交易日上的事件 —— 标注没有 K 线可挂', () => {
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      events: [
+        { date: '2024-01-03', term: 'Spring', reason: '缩量下破后收回', side: 'below' },
+        { date: '2024-01-04', term: 'SOS', reason: '放量突破', side: 'below' },
+      ],
+    }
+    // 01-04 存在于 kline,01-03 也存在;换一个不存在的日期验证过滤
+    const withBogus: WyckoffChartPlan = {
+      ...plan,
+      events: [...plan.events, { date: '2024-06-15', term: 'UTAD', reason: '编的日期', side: 'above' }],
+    }
+    const result = validateChartPlan(withBogus, kline)
+    expect(result.events.map((event) => event.date)).toEqual(['2024-01-03', '2024-01-04'])
+  })
+
+  it('阶段超出数据覆盖区间就丢掉', () => {
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [
+        { phase: 'B', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-04', reason: '区间震荡' },
+        { phase: 'C', structure: 'accumulation', startDate: '2023-06-01', endDate: '2023-07-01', reason: '早于覆盖区间' },
+      ],
+    }
+    const result = validateChartPlan(plan, kline)
+    expect(result.phases).toHaveLength(1)
+    expect(result.phases[0]!.phase).toBe('B')
+  })
+
+  it('起止颠倒的阶段丢掉', () => {
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [{ phase: 'A', structure: 'accumulation', startDate: '2024-01-04', endDate: '2024-01-02', reason: '倒序' }],
+    }
+    expect(validateChartPlan(plan, kline).phases).toHaveLength(0)
+  })
+
+  it('阶段按开始日期排序', () => {
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [
+        { phase: 'C', structure: 'accumulation', startDate: '2024-01-04', endDate: '2024-01-05', reason: 'c' },
+        { phase: 'A', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-02', reason: 'a' },
+      ],
+    }
+    expect(validateChartPlan(plan, kline).phases.map((p) => p.phase)).toEqual(['A', 'C'])
+  })
+
+  it('目标价非正的推演直接丢掉', () => {
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      forecast: { direction: 'up', targetPrice: 0, horizonDays: 30, reason: '无效' },
+    }
+    expect(validateChartPlan(plan, kline).forecast).toBeNull()
+  })
+})
+
+describe('deriveWyckoffZones', () => {
+  it('纵向范围取 Phase B 的收盘价密度带,不含影线', () => {
+    // 收盘价 10..19,最高价各 +1、最低价各 -1。带子必须落在收盘价范围内。
+    const kline = buildKline([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [
+        { phase: 'A', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-02', reason: 'a' },
+        { phase: 'B', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-10', reason: 'b' },
+      ],
+    }
+    const zones = deriveWyckoffZones(plan, kline)
+    expect(zones).toHaveLength(1)
+    // 10%-90% 分位落在 10.9 与 18.1,不会碰到 low=9 或 high=20 的影线端。
+    expect(zones[0]!.priceLow).toBeGreaterThan(10)
+    expect(zones[0]!.priceHigh).toBeLessThan(19)
+    expect(zones[0]!.sampleSize).toBe(10)
+  })
+
+  it('横向铺满整个吸筹结构,不只是 Phase B', () => {
+    const kline = buildKline([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [
+        { phase: 'A', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-02', reason: 'a' },
+        { phase: 'B', structure: 'accumulation', startDate: '2024-01-03', endDate: '2024-01-08', reason: 'b' },
+        { phase: 'D', structure: 'accumulation', startDate: '2024-01-09', endDate: '2024-01-10', reason: 'd' },
+      ],
+    }
+    const zones = deriveWyckoffZones(plan, kline)
+    expect(zones[0]!.startDate).toBe('2024-01-01')
+    expect(zones[0]!.endDate).toBe('2024-01-10')
+  })
+
+  it('没有 Phase B 就不画底色 —— 密度带没有依据', () => {
+    const kline = buildKline([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [{ phase: 'A', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-10', reason: 'a' }],
+    }
+    expect(deriveWyckoffZones(plan, kline)).toHaveLength(0)
+  })
+
+  it('Phase B 样本不足 5 根就不画', () => {
+    const kline = buildKline([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [{ phase: 'B', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-03', reason: 'b' }],
+    }
+    expect(deriveWyckoffZones(plan, kline)).toHaveLength(0)
+  })
+
+  it('上涨/下跌阶段不画底色 —— 底色只标吸筹和派发', () => {
+    const kline = buildKline([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [{ phase: 'B', structure: 'markup', startDate: '2024-01-01', endDate: '2024-01-10', reason: 'e' }],
+    }
+    expect(deriveWyckoffZones(plan, kline)).toHaveLength(0)
+  })
+
+  it('吸筹后接派发拆成两块底色', () => {
+    const kline = buildKline([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29], 1)
+    const plan: WyckoffChartPlan = {
+      ...EMPTY_PLAN,
+      phases: [
+        { phase: 'B', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-08', reason: 'acc' },
+        { phase: 'B', structure: 'distribution', startDate: '2024-01-12', endDate: '2024-01-20', reason: 'dist' },
+      ],
+    }
+    const zones = deriveWyckoffZones(plan, kline)
+    expect(zones.map((zone) => zone.structure)).toEqual(['accumulation', 'distribution'])
+  })
+})
+
+describe('deriveForecastSeries', () => {
+  const kline = buildKline([10, 11, 12, 13, 14])
+
+  it('从最后一根 K 线线性推到目标价', () => {
+    const points = deriveForecastSeries(
+      { direction: 'up', targetPrice: 20, horizonDays: 10, reason: 'r' },
+      kline,
+    )
+    expect(points).toHaveLength(11)
+    expect(points[0]).toEqual({ date: '2024-01-05', value: 14 })
+    expect(points.at(-1)!.value).toBeCloseTo(20, 6)
+  })
+
+  it('跳过周末 —— 但这些日期不是真实交易日,节假日算不出来', () => {
+    // 2024-01-05 是周五,下一个点应落在 01-08(周一)。
+    const points = deriveForecastSeries(
+      { direction: 'up', targetPrice: 20, horizonDays: 2, reason: 'r' },
+      kline,
+    )
+    expect(points[1]!.date).toBe('2024-01-08')
+    expect(points[2]!.date).toBe('2024-01-09')
+  })
+
+  it('forecast 为 null 时返回空数组', () => {
+    expect(deriveForecastSeries(null, kline)).toEqual([])
+  })
+
+  it('K 线为空时返回空数组', () => {
+    expect(deriveForecastSeries({ direction: 'up', targetPrice: 20, horizonDays: 30, reason: 'r' }, [])).toEqual([])
+  })
+
+  it('horizonDays 为 0 时退回默认 30 日,不产生除零', () => {
+    const points = deriveForecastSeries(
+      { direction: 'up', targetPrice: 20, horizonDays: 0, reason: 'r' },
+      kline,
+    )
+    expect(points).toHaveLength(31)
+    expect(points.every((point) => Number.isFinite(point.value))).toBe(true)
+  })
+
+  it('horizonDays 过大时截到上限', () => {
+    const points = deriveForecastSeries(
+      { direction: 'up', targetPrice: 20, horizonDays: 9999, reason: 'r' },
+      kline,
+    )
+    expect(points).toHaveLength(121)
+  })
+})
+
+describe('formatChartPlanNotes', () => {
+  it('术语与理由成对列出,阶段用中文结构名', () => {
+    const notes = formatChartPlanNotes({
+      phases: [{ phase: 'C', structure: 'accumulation', startDate: '2024-01-01', endDate: '2024-01-10', reason: '缩量测试支撑' }],
+      events: [{ date: '2024-01-05', term: 'Spring', reason: '下破后当日收回' }],
+      forecast: { direction: 'up', targetPrice: 20.5, horizonDays: 30, reason: '结构完成待突破' },
+    } as WyckoffChartPlan)
+    expect(notes[0]).toContain('Phase C（吸筹）')
+    expect(notes[0]).toContain('缩量测试支撑')
+    expect(notes[1]).toBe('[Spring] 2024-01-05：下破后当日收回')
+    expect(notes[2]).toContain('未来 30 个交易日上行至 20.50')
+  })
+
+  it('没有推演时不产生推演行', () => {
+    expect(formatChartPlanNotes(EMPTY_PLAN)).toEqual([])
+  })
+})

--- a/web/packages/shared/src/chat-tools.ts
+++ b/web/packages/shared/src/chat-tools.ts
@@ -13,6 +13,7 @@ import {
   type ValueSnapshot,
 } from './agent-market'
 import { buildValuePrompt, buildValueScore } from './agent-value'
+import { checkPriceBasis, formatPriceBasisNote } from './price-basis'
 import {
   attributionFormalDynamicLabel,
   attributionGovernorStatusLabel,
@@ -30,6 +31,7 @@ import {
   type PatternReviewRow,
 } from './pattern-review'
 import { ANALYSIS_CONTEXT_PACK_SCHEMA, buildStockAnalysisContextPack } from './analysis-context'
+import { WYCKOFF_CHART_PLAN_SCHEMA, validateChartPlan } from './wyckoff-chart-plan'
 import { marketWatchSymbol, normalizeMarketWatchCode, readFreshMarketWatchSnapshot, type MarketWatchQuote, type MarketWatchSnapshot } from './market-watch'
 import { refreshPortfolioTotalEquity } from './portfolio-valuation'
 
@@ -108,6 +110,7 @@ export const ANALYZE_STOCK_OUTPUT_SCHEMA = z.object({
     fallbackUsed: z.boolean(),
   }).nullable().optional(),
   context_pack: ANALYSIS_CONTEXT_PACK_SCHEMA.nullable().optional(),
+  chart_plan: WYCKOFF_CHART_PLAN_SCHEMA.nullable().optional(),
 })
 
 export const STRATEGY_POLICY_OUTPUT_SCHEMA = z.object({
@@ -1325,6 +1328,18 @@ function booleanValue(value: unknown): boolean | null {
   return typeof value === 'boolean' ? value : null
 }
 
+/** 取不复权实时最新价,只用于核对复权口径。取不到就返回 null,不猜。 */
+async function fetchLivePrice(deps: ToolDeps, code: string, tickflowKey: string | null): Promise<number | null> {
+  if (!tickflowKey) return null
+  const quotes = await fetchQuotes(deps, tickflowKey, [{ code }])
+    .catch((): Record<string, Record<string, number>> => ({}))
+  const normalized = normalizePortfolioCode(code) || normalizeCode(code)
+  const row = quotes[normalized] || quotes[normalizeTickFlowSymbol(normalized)]
+  if (!row) return null
+  const price = row.last_price || row.close || row.last || row.price || row.current || 0
+  return Number.isFinite(price) && price > 0 ? price : null
+}
+
 export async function execAnalyzeStock(
   deps: ToolDeps, userId: string, _config: LLMToolConfig, model: unknown, code: string, name: string | null,
 ): Promise<AnalyzeStockResult> {
@@ -1341,10 +1356,17 @@ export async function execAnalyzeStock(
     return buildAnalyzeError(code, name, `无法获取 ${code} ${name || ''} 的K线数据。美股/港股请使用 TickFlow 标准代码（如 AAPL.US / 00700.HK）。推荐购买 TickFlow 获取实时行情：https://tickflow.org/auth/register?ref=5N4NKTCPL4`)
   }
 
+  // 结构价位来自前复权，报单价必须是不复权实时价。两把尺子悄悄错开会把
+  // 除权前的价位当成挂单价报出去，所以先核一遍。
+  const basisNote = formatPriceBasisNote(checkPriceBasis(
+    kline[kline.length - 1]?.close ?? null,
+    await fetchLivePrice(deps, code, keys.tickflow),
+  ))
   const digest = [
     `数据来源：${quality.source === 'tickflow' ? 'TickFlow' : quality.source === 'tushare' ? 'Tushare' : quality.source}`,
     `数据覆盖：${quality.coverageStart || '未知'} 至 ${quality.coverageEnd || '未知'}；最新交易日：${quality.latestTradingDate || '未知'}；返回 ${quality.returnedRows}/${quality.requestedRows} 根${quality.fallbackUsed ? '；已发生数据源回退' : ''}`,
     buildKlineDigest(kline),
+    basisNote,
   ].join('\n')
   const valueDigest = buildValueAgentDigest(valueSnapshot)
   const contextPack = buildStockAnalysisContextPack({ symbol: code, name, kline, dataQuality: quality, valueSnapshot })
@@ -1357,7 +1379,13 @@ export async function execAnalyzeStock(
 6. 主力行为判断（是否有吸筹/出货迹象）
 7. 操作建议与风险提示（含建议止损位）
 
-按结构化 schema 输出。markdown 字段保留一段简洁专业的 Markdown 诊断正文。`
+按结构化 schema 输出。markdown 字段保留一段简洁专业的 Markdown 诊断正文。
+
+chart_plan 字段用于前端作图，填写规则：
+- phases：威科夫阶段划分。判断不出来的阶段就不要填，五个阶段不必凑齐；宁可少标一段，不要硬套。structure 用 accumulation/distribution/markup/markdown，日期用 YYYY-MM-DD 且必须落在上面给出的数据覆盖区间内。
+- events：关键事件，date 必须是数据里真实存在的交易日。term 填威科夫术语原文（SC/AR/ST/Spring/SOS/LPS/UTAD/BC 等），reason 用中文一句话说明判为该术语的理由。
+- forecast：未来 30 个交易日的推演，targetPrice 是 horizon 末端目标价，与 K 线同为前复权口径。看不出方向就填 sideways，判断不了就整个填 null。
+- 不要输出价格带或逐日预测数值，这两项由程序从 K 线算出。`
   const userPrompt = `${valueDigest}\n\n${digest}`
   try {
     const result = await deps.generateText({
@@ -1366,14 +1394,14 @@ export async function execAnalyzeStock(
       prompt: userPrompt,
       output: Output.object({ schema: ANALYZE_STOCK_OUTPUT_SCHEMA }),
     })
-    return withAnalyzeQuality(normalizeAnalyzeOutput(result.output, result.text), quality, contextPack)
+    return withAnalyzeQuality(normalizeAnalyzeOutput(result.output, result.text), quality, contextPack, kline)
   } catch {
     const fallback = await deps.generateText({
       model: model as Parameters<typeof GenerateTextFn>[0]['model'],
       system: systemPrompt + '\n\n请用纯 JSON 输出，字段: summary, phase, confidence, support, resistance, action, risk, markdown。',
       prompt: userPrompt,
     })
-    return withAnalyzeQuality(parseAnalyzeFallback(fallback.text, code, name), quality, contextPack)
+    return withAnalyzeQuality(parseAnalyzeFallback(fallback.text, code, name), quality, contextPack, kline)
   }
 }
 
@@ -1393,13 +1421,20 @@ function buildAnalyzeError(code: string, name: string | null, message: string): 
   }
 }
 
-function withAnalyzeQuality(result: AnalyzeStockResult, quality: KlineDataQuality, contextPack?: AnalyzeStockResult['context_pack']): AnalyzeStockResult {
+function withAnalyzeQuality(
+  result: AnalyzeStockResult,
+  quality: KlineDataQuality,
+  contextPack?: AnalyzeStockResult['context_pack'],
+  kline?: KlineRow[],
+): AnalyzeStockResult {
   return {
     ...result,
     data_source: quality.source,
     data_asof: quality.latestTradingDate,
     data_quality: quality,
     context_pack: contextPack,
+    // 模型给的日期会编。落在 K 线之外的阶段和事件在这里就丢掉,不要带到前端去画。
+    chart_plan: result.chart_plan && kline?.length ? validateChartPlan(result.chart_plan, kline) : null,
   }
 }
 

--- a/web/packages/shared/src/index.ts
+++ b/web/packages/shared/src/index.ts
@@ -66,6 +66,32 @@ export {
 export { MARKET_WATCH_CACHE_TTL_MS } from './market-watch'
 export type { MarketWatchQuote, MarketWatchSnapshot, MarketWatchState } from './market-watch'
 export {
+  assessTradingDay,
+  formatSessionClockContext,
+  resolveSessionClock,
+  sessionPhaseLabel,
+  toBeijingParts,
+} from './session-clock'
+export type { SessionClock, SessionPhase, TradingDayEvidence } from './session-clock'
+export { checkPriceBasis, formatPriceBasisNote } from './price-basis'
+export type { PriceBasisCheck, PriceBasisStatus } from './price-basis'
+export {
+  WYCKOFF_CHART_PLAN_SCHEMA,
+  deriveForecastSeries,
+  deriveWyckoffZones,
+  formatChartPlanNotes,
+  structureLabel,
+  validateChartPlan,
+} from './wyckoff-chart-plan'
+export type {
+  WyckoffChartPlan,
+  WyckoffEvent,
+  WyckoffForecast,
+  WyckoffForecastPoint,
+  WyckoffPhase,
+  WyckoffZone,
+} from './wyckoff-chart-plan'
+export {
   buildValuePrompt,
   buildValueScore,
   evaluateValueRules,

--- a/web/packages/shared/src/price-basis.ts
+++ b/web/packages/shared/src/price-basis.ts
@@ -1,0 +1,60 @@
+/**
+ * 复权口径:结构分析用前复权,报单价用实时价,两者必须对得上。
+ *
+ * K 线取的是 `adjust: 'forward'`(前复权):历史价按今天的价格尺度还原,所以
+ * 最新一根的收盘就等于当天的真实收盘,历史上的 Spring / SOS 价位也都落在
+ * 今天这把尺子上 —— 可以直接拿来当挂单参考。
+ *
+ * 会出事的是两个尺子悄悄错开:除权后数据源还没重算、或者 K 线停在几天前。
+ * 这时候「支撑位 12.30」和盘口的 12.30 已经不是同一个价。算不出谁对,
+ * 但能测出差多少 —— 差得离谱就别报单价,先说清楚。
+ */
+
+/** 收盘价与实时价的相对偏离超过这个比例就不当作同一把尺子。 */
+const BASIS_DIVERGENCE_THRESHOLD = 0.02
+
+export type PriceBasisStatus = 'aligned' | 'diverged' | 'unknown'
+
+export interface PriceBasisCheck {
+  status: PriceBasisStatus
+  /** 前复权最新收盘。 */
+  adjustedClose: number | null
+  /** 实时最新价(不复权)。 */
+  livePrice: number | null
+  /** 相对偏离,livePrice 为基准。 */
+  divergencePct: number | null
+}
+
+export function checkPriceBasis(adjustedClose: number | null, livePrice: number | null): PriceBasisCheck {
+  const usable = typeof adjustedClose === 'number' && Number.isFinite(adjustedClose) && adjustedClose > 0
+    && typeof livePrice === 'number' && Number.isFinite(livePrice) && livePrice > 0
+  if (!usable) {
+    return { status: 'unknown', adjustedClose, livePrice, divergencePct: null }
+  }
+  const divergence = Math.abs(adjustedClose - livePrice) / livePrice
+  return {
+    status: divergence <= BASIS_DIVERGENCE_THRESHOLD ? 'aligned' : 'diverged',
+    adjustedClose,
+    livePrice,
+    divergencePct: divergence,
+  }
+}
+
+/** 给模型看的口径说明。报单价只在两把尺子对得上时才允许直接引用结构价位。 */
+export function formatPriceBasisNote(check: PriceBasisCheck): string {
+  const head = '## 复权口径'
+  const base = 'K 线为前复权(历史价已折算到当前价格尺度),结构价位与实时价可直接比较;实时最新价为不复权成交价。'
+  if (check.status === 'aligned') {
+    return [head, base, '本轮两者一致,T+1 委托价可以直接引用结构价位。'].join('\n')
+  }
+  if (check.status === 'diverged') {
+    const pct = ((check.divergencePct ?? 0) * 100).toFixed(2)
+    return [
+      head,
+      base,
+      `注意:前复权最新收盘 ${check.adjustedClose} 与实时最新价 ${check.livePrice} 相差 ${pct}%,两把尺子没对上(可能刚除权、数据源未重算,或 K 线不是最新交易日)。`,
+      '这种情况下不要把结构价位直接当作委托价报出去,先说明口径差异,报单价以实时价为准。',
+    ].join('\n')
+  }
+  return [head, base, '本轮缺少实时价,无法核对两者是否一致;若要给出 T+1 委托价,需明确说明其来自前复权收盘而非实时成交价。'].join('\n')
+}

--- a/web/packages/shared/src/session-clock.ts
+++ b/web/packages/shared/src/session-clock.ts
@@ -1,0 +1,153 @@
+/**
+ * 北京时间与 A 股交易时段:算得出的部分算,算不出的部分说清楚。
+ *
+ * 时段规则(周末、连续竞价、集合竞价)是纯计算,离线可判。节假日不是 ——
+ * 它由国务院逐年公布,没有算法能推出来,调休更是没有规律。所以这里不猜:
+ * 工作日只报到 `weekday-open`(按时段规则可交易),节假日的可能性作为已知
+ * 不确定性一并交出去,由调用方用行情时间戳这类证据去证实。
+ */
+
+export type SessionPhase =
+  | 'pre-open'      // 开盘前(09:15 之前)
+  | 'call-auction'  // 集合竞价 09:15-09:25 / 14:57-15:00
+  | 'continuous'    // 连续竞价 09:30-11:30 / 13:00-15:00
+  | 'lunch-break'   // 午间休市 11:30-13:00
+  | 'post-close'    // 收盘后
+  | 'weekend'       // 周末
+
+export interface SessionClock {
+  /** 「YYYY-MM-DD HH:MM」北京时间,用于回复开头那一行。 */
+  beijingText: string
+  beijingDate: string
+  beijingTime: string
+  /** 1=周一 … 7=周日,按北京时间算。 */
+  weekday: number
+  phase: SessionPhase
+  /** 时段规则允许下单。节假日未计入 —— 见 holidayUnknown。 */
+  tradableByClock: boolean
+  /** 落在工作日时为 true:今天可能是节假日或调休,离线无法判定。 */
+  holidayUnknown: boolean
+}
+
+const MINUTE = 60
+const CALL_AUCTION_MORNING = [9 * 60 + 15, 9 * 60 + 25] as const
+const CONTINUOUS_MORNING = [9 * 60 + 30, 11 * 60 + 30] as const
+const CONTINUOUS_AFTERNOON = [13 * 60, 14 * 60 + 57] as const
+const CALL_AUCTION_CLOSING = [14 * 60 + 57, 15 * 60] as const
+
+/**
+ * 把任意时刻换成北京时间(UTC+8)。不依赖运行环境的本地时区 ——
+ * Worker 跑在 UTC,桌面端跑在用户本地,两边必须得出同一个答案。
+ */
+export function toBeijingParts(now: Date): { date: string; time: string; weekday: number; minutes: number } {
+  const shifted = new Date(now.getTime() + 8 * 60 * MINUTE * 1000)
+  const date = shifted.toISOString().slice(0, 10)
+  const hour = shifted.getUTCHours()
+  const minute = shifted.getUTCMinutes()
+  const time = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+  // getUTCDay(): 0=周日。转成 ISO 的 1=周一 … 7=周日。
+  const weekday = shifted.getUTCDay() === 0 ? 7 : shifted.getUTCDay()
+  return { date, time, weekday, minutes: hour * 60 + minute }
+}
+
+function inRange(minutes: number, range: readonly [number, number]): boolean {
+  return minutes >= range[0] && minutes < range[1]
+}
+
+function resolvePhase(weekday: number, minutes: number): SessionPhase {
+  if (weekday >= 6) return 'weekend'
+  if (inRange(minutes, CALL_AUCTION_MORNING)) return 'call-auction'
+  if (inRange(minutes, CONTINUOUS_MORNING)) return 'continuous'
+  if (inRange(minutes, CONTINUOUS_AFTERNOON)) return 'continuous'
+  if (inRange(minutes, CALL_AUCTION_CLOSING)) return 'call-auction'
+  // 09:25-09:30 是竞价结束到开盘之间的空档,归到开盘前 —— 不能落进 post-close。
+  if (minutes < CONTINUOUS_MORNING[0]) return 'pre-open'
+  if (minutes < CONTINUOUS_AFTERNOON[0]) return 'lunch-break'
+  return 'post-close'
+}
+
+export function resolveSessionClock(now: Date): SessionClock {
+  const { date, time, weekday, minutes } = toBeijingParts(now)
+  const phase = resolvePhase(weekday, minutes)
+  const tradable = phase === 'continuous' || phase === 'call-auction'
+  return {
+    beijingText: `${date} ${time}`,
+    beijingDate: date,
+    beijingTime: time,
+    weekday,
+    phase,
+    tradableByClock: tradable,
+    holidayUnknown: weekday <= 5,
+  }
+}
+
+const PHASE_LABEL: Record<SessionPhase, string> = {
+  'pre-open': '开盘前',
+  'call-auction': '集合竞价',
+  continuous: '连续竞价',
+  'lunch-break': '午间休市',
+  'post-close': '收盘后',
+  weekend: '周末休市',
+}
+
+export function sessionPhaseLabel(phase: SessionPhase): string {
+  return PHASE_LABEL[phase]
+}
+
+export type TradingDayEvidence = 'confirmed-open' | 'likely-closed' | 'unknown'
+
+/**
+ * 用行情时间戳证实「今天到底开没开」。
+ *
+ * 节假日算不出来,但能观测:交易时段里报价时间戳落在今天 → 今天在交易。
+ * 时间戳停在往前某一天 → 大概率休市(也可能是数据源滞后,所以只说 likely)。
+ * 收盘后拿不到判据 —— 那时行情静止,分不出「今天收盘了」和「今天没开」。
+ */
+export function assessTradingDay(clock: SessionClock, quoteTimestamps: Array<string | null>): TradingDayEvidence {
+  if (clock.phase === 'weekend') return 'likely-closed'
+  if (!clock.tradableByClock) return 'unknown'
+  const dates = quoteTimestamps
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => toBeijingParts(new Date(value)))
+    .filter((parts) => !Number.isNaN(Date.parse(parts.date)))
+  if (dates.length === 0) return 'unknown'
+  if (dates.some((parts) => parts.date === clock.beijingDate)) return 'confirmed-open'
+  return 'likely-closed'
+}
+
+/**
+ * 当轮注入的时间与时段口径。走 user 消息,不进 system —— system 要保持字节
+ * 稳定给 prompt cache 用,时间每轮都变,写进去等于每轮击穿缓存。
+ */
+export function formatSessionClockContext(clock: SessionClock, evidence: TradingDayEvidence): string {
+  const lines = [
+    '## 当前时间与交易时段(本轮实测,不是推算)',
+    `当前北京时间:${clock.beijingText}(UTC+8),周${'一二三四五六日'[clock.weekday - 1]}。`,
+    `时段:${sessionPhaseLabel(clock.phase)}。`,
+    '回复开头必须先写这一行:「当前北京时间:' + clock.beijingText + '(UTC+8)」。不要自己推断或编造时间。',
+  ]
+
+  if (clock.phase === 'weekend') {
+    lines.push('周末休市,当前不可盘中交易(原因:非交易日)。只做盘后复盘、次日计划与 T+1 委托策略,不要给「立刻买/立刻卖」的指令。')
+    return lines.join('\n')
+  }
+
+  if (!clock.tradableByClock) {
+    lines.push(`当前不可盘中交易(原因:非交易时段,${sessionPhaseLabel(clock.phase)})。只做盘后复盘、次日计划与 T+1 委托策略,不要给「立刻买/立刻卖」的指令。`)
+    lines.push('连续竞价 09:30-11:30 / 13:00-15:00,集合竞价 09:15-09:25 与 14:57-15:00。')
+    return lines.join('\n')
+  }
+
+  if (evidence === 'confirmed-open') {
+    lines.push('本轮行情时间戳落在今天,今日确认在交易,处于可盘中交易时段。')
+    return lines.join('\n')
+  }
+
+  if (evidence === 'likely-closed') {
+    lines.push('注意:时段规则上属于交易时间,但本轮行情时间戳不是今天 —— 今天很可能是节假日休市(也可能是数据源滞后)。按不可盘中交易处理,除非另有证据表明今日开市。')
+    return lines.join('\n')
+  }
+
+  lines.push('时段规则上属于交易时间。节假日与调休无法离线判定,本轮也没有取到可用行情时间戳作为判据;如果要给盘中交易指令,先确认今日确实开市。')
+  return lines.join('\n')
+}

--- a/web/packages/shared/src/wyckoff-chart-plan.ts
+++ b/web/packages/shared/src/wyckoff-chart-plan.ts
@@ -1,0 +1,203 @@
+/**
+ * 威科夫图的结构化作图计划:模型只出判断,数字由代码算。
+ *
+ * 分界线落在哪一天、某根 K 线该叫 Spring 还是 LPS、为什么这么叫 —— 这些是读盘
+ * 判断,只有模型能给。但吸筹区的价格带、预测线的每日取值是机械推导,交给模型
+ * 等于让它编价格。所以这里的分工是硬的:模型给 phases / events / forecast 的
+ * 锚点,代码从 K 线里算出 zones 和 forecast 序列。
+ */
+
+import { z } from 'zod'
+import type { KlineRow } from './chat-tools'
+
+export const WYCKOFF_PHASE_SCHEMA = z.object({
+  /** Phase A-E。判断不出来就别硬凑,少标一个阶段好过标错。 */
+  phase: z.enum(['A', 'B', 'C', 'D', 'E']),
+  /** 大结构:吸筹 / 派发 / 上涨 / 下跌。zone 底色只画前两种。 */
+  structure: z.enum(['accumulation', 'distribution', 'markup', 'markdown']),
+  startDate: z.string(),
+  endDate: z.string(),
+  /** 这一段为什么这么定,中文一句话。 */
+  reason: z.string(),
+})
+
+export const WYCKOFF_EVENT_SCHEMA = z.object({
+  date: z.string(),
+  /** 威科夫术语原文:SC / AR / ST / Spring / SOS / LPS / UTAD / BC…… */
+  term: z.string(),
+  /** 判为这个术语的理由,中文一句话。图上只显示术语,理由列在图下。 */
+  reason: z.string(),
+  side: z.enum(['above', 'below']),
+})
+
+export const WYCKOFF_FORECAST_SCHEMA = z.object({
+  direction: z.enum(['up', 'down', 'sideways']),
+  /** horizon 末端的目标价。前复权口径,与 K 线同一把尺子。 */
+  targetPrice: z.number(),
+  /** 交易日数。默认 30。 */
+  horizonDays: z.number(),
+  reason: z.string(),
+})
+
+export const WYCKOFF_CHART_PLAN_SCHEMA = z.object({
+  phases: z.array(WYCKOFF_PHASE_SCHEMA),
+  events: z.array(WYCKOFF_EVENT_SCHEMA),
+  forecast: WYCKOFF_FORECAST_SCHEMA.nullable(),
+})
+
+export type WyckoffPhase = z.infer<typeof WYCKOFF_PHASE_SCHEMA>
+export type WyckoffEvent = z.infer<typeof WYCKOFF_EVENT_SCHEMA>
+export type WyckoffForecast = z.infer<typeof WYCKOFF_FORECAST_SCHEMA>
+export type WyckoffChartPlan = z.infer<typeof WYCKOFF_CHART_PLAN_SCHEMA>
+
+export interface WyckoffZone {
+  structure: 'accumulation' | 'distribution'
+  startDate: string
+  endDate: string
+  priceLow: number
+  priceHigh: number
+  /** 算价格带用到的收盘价根数,少于 5 根就别当回事。 */
+  sampleSize: number
+}
+
+export interface WyckoffForecastPoint {
+  date: string
+  value: number
+}
+
+/** 密度带取 10%-90% 分位,不取极值 —— 极值一根异常 K 线就能把带子撑开。 */
+const DENSITY_LOW_QUANTILE = 0.1
+const DENSITY_HIGH_QUANTILE = 0.9
+const MIN_ZONE_SAMPLE = 5
+const DEFAULT_HORIZON_DAYS = 30
+const MAX_HORIZON_DAYS = 120
+
+function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return 0
+  const pos = q * (sorted.length - 1)
+  const lo = Math.floor(pos)
+  const hi = Math.ceil(pos)
+  return sorted[lo]! + (sorted[hi]! - sorted[lo]!) * (pos - lo)
+}
+
+/**
+ * 丢掉日期落在 K 线之外的阶段与事件。
+ *
+ * 模型给的日期会编 —— 编一个不存在的交易日,画出来就是一条飘在空处的竖线。
+ * 宁可少画一条,不画错一条。
+ */
+export function validateChartPlan(plan: WyckoffChartPlan, kline: KlineRow[]): WyckoffChartPlan {
+  const dates = new Set(kline.map((row) => row.date))
+  const first = kline[0]?.date ?? ''
+  const last = kline.at(-1)?.date ?? ''
+  const inCoverage = (date: string) => date >= first && date <= last
+
+  return {
+    // 阶段边界允许不精确落在交易日上(模型常给月初月末),只要求落在覆盖区间内且顺序正确。
+    phases: plan.phases
+      .filter((phase) => inCoverage(phase.startDate) && inCoverage(phase.endDate) && phase.startDate <= phase.endDate)
+      .sort((a, b) => a.startDate.localeCompare(b.startDate)),
+    // 事件必须钉在真实交易日上 —— 标注要挂在某一根 K 线上,没有这根就没处挂。
+    events: plan.events
+      .filter((event) => dates.has(event.date))
+      .sort((a, b) => a.date.localeCompare(b.date)),
+    forecast: plan.forecast && plan.forecast.targetPrice > 0 ? plan.forecast : null,
+  }
+}
+
+/**
+ * 把同一个结构的连续阶段并成一段,取其中 Phase B 的收盘价密度带做纵向范围。
+ *
+ * 纵向用**收盘价**而不是最高/最低价,这正好满足「排除 SC 的下影线与 AR 的上影线」——
+ * 收盘价本身就不含影线,不需要再去识别哪根是 SC、哪根是 AR 然后特殊处理。
+ * 横向铺满整个吸筹/派发结构(A 到 D),因为底色标的是这个区间,不只是 Phase B。
+ */
+export function deriveWyckoffZones(plan: WyckoffChartPlan, kline: KlineRow[]): WyckoffZone[] {
+  const zones: WyckoffZone[] = []
+  let run: WyckoffPhase[] = []
+
+  const flush = () => {
+    if (run.length === 0) return
+    const structure = run[0]!.structure
+    if (structure === 'accumulation' || structure === 'distribution') {
+      const phaseB = run.find((phase) => phase.phase === 'B')
+      const band = phaseB ? closeDensityBand(kline, phaseB.startDate, phaseB.endDate) : null
+      if (band) {
+        zones.push({
+          structure,
+          startDate: run[0]!.startDate,
+          endDate: run.at(-1)!.endDate,
+          priceLow: band.low,
+          priceHigh: band.high,
+          sampleSize: band.sampleSize,
+        })
+      }
+    }
+    run = []
+  }
+
+  for (const phase of plan.phases) {
+    if (run.length > 0 && run[0]!.structure !== phase.structure) flush()
+    run.push(phase)
+  }
+  flush()
+  return zones
+}
+
+function closeDensityBand(kline: KlineRow[], startDate: string, endDate: string): { low: number; high: number; sampleSize: number } | null {
+  const closes = kline
+    .filter((row) => row.date >= startDate && row.date <= endDate)
+    .map((row) => row.close)
+    .sort((a, b) => a - b)
+  // 样本太少算不出密度,直接不画 —— 一条假的价格带比没有底色更误导。
+  if (closes.length < MIN_ZONE_SAMPLE) return null
+  const low = quantile(closes, DENSITY_LOW_QUANTILE)
+  const high = quantile(closes, DENSITY_HIGH_QUANTILE)
+  return high > low ? { low, high, sampleSize: closes.length } : null
+}
+
+/**
+ * 从最后一根 K 线线性推到目标价,生成预测序列。
+ *
+ * 未来的交易日期算不出来 —— 节假日不可推导(见 session-clock)。这里只跳周末,
+ * 遇到节假日日期会偏几天。对一条 30 日的推演线,横轴偏几天无关紧要,但别把
+ * 这些日期当成真实交易日引用。
+ */
+export function deriveForecastSeries(forecast: WyckoffForecast | null, kline: KlineRow[]): WyckoffForecastPoint[] {
+  const last = kline.at(-1)
+  if (!forecast || !last || forecast.targetPrice <= 0) return []
+  const horizon = Math.min(
+    Math.max(Math.round(forecast.horizonDays) || DEFAULT_HORIZON_DAYS, 1),
+    MAX_HORIZON_DAYS,
+  )
+  const points: WyckoffForecastPoint[] = [{ date: last.date, value: last.close }]
+  const step = (forecast.targetPrice - last.close) / horizon
+  const cursor = new Date(`${last.date}T00:00:00Z`)
+  if (Number.isNaN(cursor.getTime())) return []
+
+  for (let i = 1; i <= horizon; i++) {
+    do {
+      cursor.setUTCDate(cursor.getUTCDate() + 1)
+    } while (cursor.getUTCDay() === 0 || cursor.getUTCDay() === 6)
+    points.push({ date: cursor.toISOString().slice(0, 10), value: last.close + step * i })
+  }
+  return points
+}
+
+/** 图下方的中文说明:术语配理由,一行一个。图上只挂术语,长句放这里。 */
+export function formatChartPlanNotes(plan: WyckoffChartPlan): string[] {
+  const notes = plan.phases.map((phase) => `Phase ${phase.phase}（${structureLabel(phase.structure)}） ${phase.startDate} 至 ${phase.endDate}：${phase.reason}`)
+  notes.push(...plan.events.map((event) => `[${event.term}] ${event.date}：${event.reason}`))
+  if (plan.forecast) {
+    notes.push(`[推演] 未来 ${plan.forecast.horizonDays} 个交易日${directionLabel(plan.forecast.direction)}至 ${plan.forecast.targetPrice.toFixed(2)}：${plan.forecast.reason}`)
+  }
+  return notes
+}
+
+export function structureLabel(structure: WyckoffPhase['structure']): string {
+  return structure === 'accumulation' ? '吸筹' : structure === 'distribution' ? '派发' : structure === 'markup' ? '上涨' : '下跌'
+}
+
+function directionLabel(direction: WyckoffForecast['direction']): string {
+  return direction === 'up' ? '上行' : direction === 'down' ? '下行' : '横向震荡'
+}


### PR DESCRIPTION
## 问题

模型在三个能算的地方靠猜。

**时间**：自己推算当前时间必然编，非交易时段照样给「立刻买/立刻卖」的指令。

**复权口径**：K 线取前复权，历史 Spring / SOS 价位折算到今天的价格尺度上，可以直接当挂单参考。
但两把尺子会悄悄错开 —— 除权后数据源还没重算，或者 K 线停在几天前。这时候「支撑位 12.30」
和盘口的 12.30 已经不是同一个价，模型照样把它当委托价报出去。

**威科夫结构**：吸筹区的价格带、预测线的每日取值是机械推导，让模型出等于让它编价格。

## 改动

### 时间与交易时段 `shared/session-clock.ts`

算得出的算，算不出的说清楚。时段规则（周末、连续竞价 09:30-11:30 / 13:00-15:00、
集合竞价 09:15-09:25 与 14:57-15:00）是纯计算，离线可判。**节假日不是** —— 由国务院逐年公布、
调休无规律，没有算法能推出来。所以不猜：工作日只报到 `weekday-open`（按时段规则可交易），
把节假日的可能性作为**已知的不确定性**一并交出去，由调用方用证据去证实。

`assessTradingDay` 用行情时间戳证实「今天到底开没开」：

| 观测 | 判定 |
|---|---|
| 交易时段内，报价时间戳落在今天 | `confirmed-open` |
| 交易时段内，时间戳停在往前某天 | `likely-closed`（也可能是数据源滞后，所以只说 likely） |
| 收盘后 / 拿不到时间戳 | `unknown` —— 那时行情静止，分不出「今天收盘了」和「今天没开」 |

`toBeijingParts` 不依赖运行环境的本地时区：Worker 跑在 UTC、桌面端跑在用户本地，两边必须
得出同一个答案。

### 复权口径 `shared/price-basis.ts`

算不出谁对，但能测出差多少。收盘价与实时价相对偏离 > 2% 判 `diverged`，此时明确禁止把结构
价位直接当委托价，先说明口径差异、报单价以实时价为准。取不到实时价就报 `unknown`，不猜。

`execAnalyzeStock` 里加了 `fetchLivePrice`（不复权实时最新价，取不到返回 null）来做这个核对。

### 威科夫作图计划 `shared/wyckoff-chart-plan.ts`

分工是硬的：

- **模型给判断** —— `phases`（A–E + 吸筹/派发/上涨/下跌 + 起止日 + 中文理由）、
  `events`（日期 + 威科夫术语原文 + 理由）、`forecast`（方向 + 目标价 + horizon）
- **代码算数字** —— `validateChartPlan` 把日期对齐到 K 线里的真实交易日，
  `deriveWyckoffZones` 从 K 线算出区间价格带，`deriveForecastSeries` 生成预测序列

判断不出的阶段留空，少标一个阶段好过标错。`chart_plan` 挂在 `ANALYZE_STOCK_OUTPUT_SCHEMA` 上
（nullable），前端 `tool-structured-cards.tsx:66` → `WyckoffChartPanel` 消费，
`kline-chart.tsx` 用 `WyckoffZonePrimitive` 画底色。

### 注入位置：当轮 user 消息，不进 system

system prompt 要保持字节稳定才能用上 prompt cache，**时间每轮都变，写进 system 等于每轮
击穿缓存**。所以时间和复权口径都跟行情一样挂在当轮消息末尾。

system prompt 加了三条约束：

- 第 8 条 —— 时间以注入的那一行为准，不得自行推算；非交易日/非交易时段只做盘后复盘、次日计划
  与 T+1 委托策略
- 第 9 条 —— 复权口径以注入为准，判定错开时先说明差异
- 第 10 条 —— `chart_plan` 日期必须取自工具返回的真实交易日；**盘中已有持仓时不填**（置 null），
  直接给结论与操作口径 —— 盘中持仓看的是当下怎么办，不是回顾结构

### 顺带

`runChatAttempt` 加第四个参数后 91 行，超了 `web/apps` 的 90 行层级上限。消息准备那一段抽成
`buildTurnModelMessages`。

## 验证

新增 46 个断言：`price-basis` 三态、`session-clock` 六个时段与三种证据（含 09:25-09:30 空档
必须归 `pre-open` 而不能落进 `post-close`）、`chart-plan` 的校验与推导。

CI 的 web-check 按原样跑了一遍：

- 递归 `tsc --noEmit` 干净
- `@wyckoff/web` 42 files / 258 tests passed
- `@wyckoff/api` 19 files / 128 tests passed（2 skipped）
- `quality_gate.py --ci` OK（0 active legacy functions over limit）
