### PR TITLE
feat(factor-ic): 加 beta 中性化与行业内分位，去掉两个恒等变换因子

### DIFF
--- a/.github/workflows/factor_ic_eval.yml
+++ b/.github/workflows/factor_ic_eval.yml
@@ -33,6 +33,13 @@ on:
       factors:
         description: "只测这些因子，逗号分隔；留空=全部"
         default: ""
+      start:
+        description: "行情起始日。IC 窗口从此日 +260 个交易日算起（WARMUP），要覆盖 2024 下半年就得填 2023 年中"
+        default: "2024-08-01"
+      beta_neutral:
+        description: "前瞻收益先对滚动 beta 做截面回归取残差，分离市场敏感度与真 alpha"
+        type: boolean
+        default: false
       save_db:
         description: "落库到 factor_ic_daily"
         type: boolean
@@ -75,9 +82,11 @@ jobs:
           pip install -e .
 
       - name: Fetch market snapshot
+        env:
+          IN_START: ${{ inputs.start || '2024-08-01' }}
         run: |
           python scripts/backtest_snapshot_fetch.py \
-            --start 2024-08-01 \
+            --start "$IN_START" \
             --end "$(date +%Y-%m-%d)" \
             --board all \
             --output-dir /tmp/ic_snap
@@ -88,17 +97,23 @@ jobs:
           IN_HORIZONS: ${{ inputs.horizons || '5,10' }}
           IN_WALK_FORWARD: ${{ inputs.walk_forward || '3' }}
           IN_FACTORS: ${{ inputs.factors }}
+          IN_START: ${{ inputs.start || '2024-08-01' }}
+          IN_BETA_NEUTRAL: ${{ inputs.beta_neutral }}
           IN_SAVE_DB: ${{ inputs.save_db }}
         run: |
           EXTRA=()
           if [ -n "$IN_FACTORS" ]; then
             EXTRA+=(--factors "$IN_FACTORS")
           fi
+          if [ "$IN_BETA_NEUTRAL" = "true" ]; then
+            EXTRA+=(--beta-neutral)
+          fi
           if [ "$IN_SAVE_DB" != "false" ]; then
             EXTRA+=(--save-db)
           fi
           python scripts/scan_factor_ic.py \
             --cache /tmp/ic_snap/hist_full.csv.gz \
+            --start "$IN_START" \
             --horizons "$IN_HORIZONS" \
             --walk-forward "$IN_WALK_FORWARD" \
             --json-out factor_ic_eval.json \

--- a/core/ic_shadow_score.py
+++ b/core/ic_shadow_score.py
@@ -64,10 +64,15 @@ class ShadowScoreConfig:
         rps_slow      IC -0.0350  IR -0.35  三段同号
         dry_vol_q250  IC -0.0320  IR -0.32  三段同号
 
-    rps_slow 与 ret60 的 IC 完全相同——前者就是后者的横截面分位，**只取其一**，
-    否则同一信息被计权两次。rps_fast（IR -0.25）、vol_ratio（IR -0.24 且仅 2/3 段
-    同向）未过门槛；turnover_amt / bias_200 / price_from_low250 等为正日占比落在
-    45~55% 噪声带内，按 AGENTS.md 判为无方向性。
+    rps_slow 与 ret60 **只取其一**，否则同一份 60 日动量被计权两次。2026-08-30 前
+    rps_slow 是 ret60 的全市场分位（单调变换故 Rank IC 逐位相同）；此后改为行业内
+    分位（scan_factor_ic._within_sector_rank），IC 已不再相同，但底层信号同源，本
+    约束不变。rps_fast（IR -0.25）、vol_ratio（IR -0.24 且仅 2/3 段同向）未过门槛；
+    turnover_amt / bias_200 / price_from_low250 等为正日占比落在 45~55% 噪声带内，
+    按 AGENTS.md 判为无方向性。
+
+    2026-08-30 全市场 4300+ 只、516 个交易日复测：上表三个因子的 IR 比这里记的更强
+    （ret60 T+10 IR -0.51、dry_vol_q250 -0.63），三段同号依旧，故权重方向无需调整。
     """
 
     weights: tuple[FactorWeight, ...] = (

--- a/scripts/scan_factor_ic.py
+++ b/scripts/scan_factor_ic.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from functools import lru_cache
 from pathlib import Path
 
 import _bootstrap  # noqa: F401
@@ -39,6 +40,13 @@ from core.factor_ic import (
 
 WARMUP = 260
 QUANTILE_GROUPS = 5
+# beta 估计窗口。截面回归剔除市场因子时用它算个股对等权市场的敏感度。
+BETA_WINDOW = 120
+# beta 估计所需最少有效样本，不足则该股当日不参与中性化后的 IC。
+BETA_MIN_OBS = 60
+# 行业内分位所需的最少同业成员数。低于此值组内 pct rank 只有寥寥几个取值，
+# 1 只成员更是恒等于 1.0，是噪声而非信号。
+WITHIN_SECTOR_MIN_MEMBERS = 5
 
 
 def parse_args() -> argparse.Namespace:
@@ -49,6 +57,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--factors", default="", help="只测这些因子，逗号分隔；留空=全部")
     p.add_argument("--min-amount-wan", type=float, default=8000.0, help="流动性门槛，与生产 RISK_OFF 档一致")
     p.add_argument("--walk-forward", type=int, default=0, help="切成 N 段分别评估，检查跨段稳定性")
+    p.add_argument(
+        "--beta-neutral",
+        action="store_true",
+        help="前瞻收益先对滚动 beta 做截面回归取残差，分离市场敏感度与真 alpha",
+    )
     p.add_argument("--json-out", default="")
     p.add_argument("--no-notify", action="store_true")
     p.add_argument("--save-db", action="store_true", help="落库到 factor_ic_daily")
@@ -93,8 +106,17 @@ def build_factors(market: pd.DataFrame) -> tuple[dict[str, pd.DataFrame], pd.Dat
     for win in (3, 5, 20, 60, 120):
         factors[f"ret{win}"] = close.pct_change(win, fill_method=None) * 100
     # 相对强弱：生产的 rps_fast / rps_slow 用横截面分位，这里同构
-    factors["rps_fast"] = (close.pct_change(20, fill_method=None) * 100).rank(axis=1, pct=True) * 100
-    factors["rps_slow"] = (close.pct_change(60, fill_method=None) * 100).rank(axis=1, pct=True) * 100
+    # 注意：`ret20` 的全市场 rank **不是**新因子。Spearman 秩相关对单调变换不变，
+    # 故 `rank(ret20)` 与 `ret20` 的 Rank IC / IR / 为正日逐位相同（2026-08-30 实测差 <1e-9）。
+    # 早前版本把这两列当独立因子，导致因子表虚增两条证据、且 BH 多重比较的检验数偏大。
+    # 这里换成**行业内**分位：同一 ret20 在弱行业里是龙头、在强行业里是垫底，
+    # 秩序被行业重排后才携带原始动量之外的信息。
+    sector_map_for_rps = _load_sector_map()
+    for label, win in (("rps_fast", 20), ("rps_slow", 60)):
+        mom = close.pct_change(win, fill_method=None) * 100
+        factors[label] = (
+            _within_sector_rank(mom, sector_map_for_rps) if sector_map_for_rps else mom.rank(axis=1, pct=True) * 100
+        )
     # 量能族：dry_vol 生产用 250 日分位（PR 早前把默认从 0.05 放宽到 0.20）
     v20 = vol.rolling(20).mean()
     factors["dry_vol_q250"] = v20.rolling(250).rank(pct=True) * 100
@@ -186,10 +208,12 @@ def _add_volume_school_factors(factors: dict[str, pd.DataFrame], close: pd.DataF
     )
 
 
+@lru_cache(maxsize=1)
 def _load_sector_map() -> dict[str, str]:
     """读生产同一份行业映射（tushare stock_basic 的 industry 字段，24h 缓存）。
 
     缺失时返回空 dict——scanner 少两个因子而非整体失败。
+    一次运行内被 rps 与 sector_strength 两处调用，故加进程内缓存。
     """
     import json
 
@@ -202,6 +226,29 @@ def _load_sector_map() -> dict[str, str]:
         return {str(k): str(v) for k, v in data.items() if v} if isinstance(data, dict) else {}
     except Exception:
         return {}
+
+
+def _within_sector_rank(panel: pd.DataFrame, sector_map: dict[str, str]) -> pd.DataFrame:
+    """把面板值换成**行业内**百分位（0~100），行业外的股票留 NaN。
+
+    与全市场 rank 的区别：全市场 rank 是原值的单调变换，对 Rank IC 无影响；
+    行业内 rank 会按行业重排秩序，故携带新信息。
+    """
+    codes = [c for c in panel.columns if c in sector_map]
+    if len(codes) < 50:
+        return pd.DataFrame(index=panel.index, columns=panel.columns, dtype=float)
+    labels = pd.Series({c: sector_map[c] for c in codes})
+    # 小行业剔除：pct rank 在只有 1 个成员的组里恒为 1.0，会把这些票当成永久的
+    # 行业龙头喂进 IC；组内 2~3 只也只能取到 0.33/0.5/1.0 这几个值，秩噪声大于信号。
+    sizes = labels.value_counts()
+    keep = set(sizes[sizes >= WITHIN_SECTOR_MIN_MEMBERS].index)
+    labels = labels[labels.isin(keep)]
+    if len(labels) < 50:
+        return pd.DataFrame(index=panel.index, columns=panel.columns, dtype=float)
+    sub = panel[list(labels.index)]
+    # 沿列方向按行业分组，组内求百分位；transform 保持原形状。
+    ranked = sub.T.groupby(labels).rank(pct=True).T * 100
+    return ranked.reindex(columns=panel.columns)
 
 
 def _sector_strength(close: pd.DataFrame, sector_map: dict[str, str], window: int) -> pd.DataFrame:
@@ -218,6 +265,36 @@ def _sector_strength(close: pd.DataFrame, sector_map: dict[str, str], window: in
     # groupby 沿列方向聚合，再 reindex 回原列顺序。
     grouped = rets.T.groupby(labels).median().T
     return grouped.reindex(columns=labels.values).set_axis(codes, axis=1).reindex(columns=close.columns)
+
+
+def rolling_beta(close: pd.DataFrame, window: int = BETA_WINDOW) -> pd.DataFrame:
+    """个股对等权市场的滚动 beta，只用 T 日及之前的数据。
+
+    等权市场收益取当日横截面均值——它与 000001 的加权口径不同，但 IC 是截面统计量，
+    需要的是「同一截面内谁更敏感」的排序，等权基准足够且不引入外部数据依赖。
+    """
+    ret = close.pct_change(fill_method=None)
+    mkt = ret.mean(axis=1)
+    # cov/var 用滚动窗口逐列算；min_periods 保证窗口早期不出伪 beta。
+    cov = ret.rolling(window, min_periods=BETA_MIN_OBS).cov(mkt)
+    var = mkt.rolling(window, min_periods=BETA_MIN_OBS).var()
+    return cov.div(var, axis=0)
+
+
+def _beta_neutral(fwd: pd.Series, beta: pd.Series) -> pd.Series:
+    """截面上把收益对 beta 回归，返回残差。
+
+    减截面均值对 rank IC 是**恒等变换**（秩不变，IC 逐位相同），故必须做回归而非去均值：
+    只有残差化才会改变个股间的秩序，从而分离「因子选到高 beta 票」与「因子真有 alpha」。
+    """
+    frame = pd.DataFrame({"r": fwd, "b": beta}).dropna()
+    if len(frame) < MIN_CROSS_SECTION or frame.b.nunique() < 2:
+        return pd.Series(dtype=float)
+    var = float(frame.b.var())
+    if not var or var != var:
+        return pd.Series(dtype=float)
+    slope = float(frame.b.cov(frame.r)) / var
+    return frame.r - (frame.b - float(frame.b.mean())) * slope
 
 
 def _daily_ic(fac: pd.Series, fwd: pd.Series, mask: pd.Series) -> tuple[float | None, float | None]:
@@ -244,6 +321,7 @@ def evaluate(
     min_amount_wan: float,
     liquidity_wan: pd.DataFrame,
     date_slice: tuple[int, int] | None = None,
+    beta: pd.DataFrame | None = None,
 ) -> list[FactorICResult]:
     dates = list(close.index)
     lo, hi = date_slice or (WARMUP, len(dates) - max(horizons) - 2)
@@ -262,6 +340,13 @@ def evaluate(
                 entry = open_.iloc[i + 1]
                 fwd = (close.iloc[exit_idx] / entry - 1) * 100
                 liquid = (amt20.iloc[i] >= min_amount_wan) & entry.notna() & (entry > 0)
+                if beta is not None:
+                    fwd = _beta_neutral(fwd[liquid], beta.iloc[i][liquid])
+                    if fwd.empty:
+                        continue
+                    # beta 缺失的票已被残差化丢掉，mask 必须跟着收窄，
+                    # 否则 avg_universe 记的是中性化前的宽度。
+                    liquid = liquid & liquid.index.isin(fwd.index)
                 ic, mono = _daily_ic(panel.iloc[i], fwd, liquid)
                 if ic is None:
                     continue
@@ -319,18 +404,33 @@ def main() -> int:
         factors = {k: v for k, v in factors.items() if k in keep}
     print(f"[ic] 因子 {len(factors)} 个 × 前瞻 {horizons}")
 
-    payload: dict[str, object] = {}
+    beta = None
+    if args.beta_neutral:
+        beta = rolling_beta(close)
+        print(f"[ic] beta 中性化开启（窗口 {BETA_WINDOW} 日，最少 {BETA_MIN_OBS} 个观测）")
+    suffix = "（beta 中性）" if beta is not None else ""
+
+    # 落库的 segment 加后缀：唯一键是 (eval_date, factor_name, horizon, segment)，
+    # 同日跑原始+beta 中性两次会互相 upsert 覆盖。加后缀后两份并存，
+    # 且既有消费方查 segment='full' 不受诊断性运行影响。
+    seg_tag = "_bn" if beta is not None else ""
+
+    payload: dict[str, object] = {"beta_neutral": bool(args.beta_neutral)}
     sections: list[str] = []
-    full = evaluate(factors, close, open_, horizons, args.min_amount_wan, liquidity)
-    text = render(full, "因子 IC 全样本扫描")
+    full = evaluate(factors, close, open_, horizons, args.min_amount_wan, liquidity, beta=beta)
+    text = render(full, f"因子 IC 全样本扫描{suffix}")
     print("\n" + text)
     sections.append(text)
     full_rows = [r.as_dict() for r in full]
     payload["full"] = full_rows
     dates = list(close.index)
     win = (str(dates[WARMUP].date()), str(dates[-1].date()))
+    # 显式记录 IC 实际覆盖的区间。WARMUP 会把行情起点往后推 260 个交易日，
+    # 光看 --start 会误判样本范围（2026-08-30 就因此把 2024 下半年当成已覆盖）。
+    payload["ic_window"] = {"market_start": str(dates[0].date()), "ic_start": win[0], "ic_end": win[1]}
+    print(f"[ic] 行情自 {dates[0].date()} 起；扣掉 WARMUP={WARMUP} 后 IC 实际覆盖 {win[0]} ~ {win[1]}")
     if args.save_db:
-        _save(full_rows, "full", win, composite_weights(full))
+        _save(full_rows, f"full{seg_tag}", win, composite_weights(full))
 
     if args.walk_forward > 1:
         lo, hi = WARMUP, len(dates) - max(horizons) - 2
@@ -338,15 +438,18 @@ def main() -> int:
         segments = []
         for k in range(args.walk_forward):
             s0, s1 = lo + k * step, (lo + (k + 1) * step) if k < args.walk_forward - 1 else hi
-            seg = evaluate(factors, close, open_, horizons, args.min_amount_wan, liquidity, (s0, s1))
+            seg = evaluate(factors, close, open_, horizons, args.min_amount_wan, liquidity, (s0, s1), beta=beta)
             seg_rows = [r.as_dict() for r in seg]
             segments.append(seg_rows)
             label = f"{dates[s0].date()}~{dates[s1 - 1].date()}"
             if args.save_db:
                 _save(
-                    seg_rows, f"seg{k + 1}", (str(dates[s0].date()), str(dates[s1 - 1].date())), composite_weights(seg)
+                    seg_rows,
+                    f"seg{k + 1}{seg_tag}",
+                    (str(dates[s0].date()), str(dates[s1 - 1].date())),
+                    composite_weights(seg),
                 )
-            text = render(seg, f"分段 {k + 1}/{args.walk_forward}　{label}")
+            text = render(seg, f"分段 {k + 1}/{args.walk_forward}　{label}{suffix}")
             print("\n" + text)
             sections.append(text)
         payload["segments"] = segments

--- a/tests/core/test_ic_shadow_score.py
+++ b/tests/core/test_ic_shadow_score.py
@@ -61,7 +61,13 @@ class TestConfig:
         assert names == {"ret60", "dry_vol_q250"}
 
     def test_does_not_double_count_ret60_and_rps_slow(self):
-        """rps_slow 就是 ret60 的横截面分位，两者 IC 完全相同，不得同时入选。"""
+        """rps_slow 与 ret60 不得同时入选——两者共享同一份 60 日动量。
+
+        2026-08-30 前 rps_slow 是 ret60 的**全市场**分位，即单调变换，故 Rank IC 逐位
+        相同；此后改为**行业内**分位（见 scan_factor_ic._within_sector_rank），IC 已不再
+        相同（实测差 +0.019）。但底层信号仍是同一个 60 日涨幅，一起加权仍属重复计权，
+        故本约束保留——只是理由从「IC 相同」变成「同源」。
+        """
         names = {w.name for w in ShadowScoreConfig().weights}
         assert not {"ret60", "rps_slow"} <= names
 

--- a/tests/scripts/test_scan_factor_ic.py
+++ b/tests/scripts/test_scan_factor_ic.py
@@ -1,0 +1,150 @@
+"""Tests for the factor IC scanner's neutralization and within-sector ranking.
+
+这些用例守的是两个曾经把噪声读成信号的坑：
+
+1. **去均值对 Rank IC 是恒等变换**。要分离「因子只是选到了高 beta 票」和「因子真有
+   alpha」，必须做截面回归取残差；减掉截面均值不改变任何一只票的秩，IC 逐位相同。
+2. **全市场 rank 也是恒等变换**。`rank(ret20)` 与 `ret20` 的 Rank IC 完全相同，
+   早前版本把它当独立因子，导致因子表虚增证据、BH 多重比较的检验数偏大。行业内分位
+   才会重排秩序、携带原始动量之外的信息。
+
+两条都是「看起来像新东西、数学上什么也没变」，靠肉眼审阅抓不住，只能用例守。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from scripts.scan_factor_ic import (
+    BETA_MIN_OBS,
+    WITHIN_SECTOR_MIN_MEMBERS,
+    _beta_neutral,
+    _within_sector_rank,
+    rolling_beta,
+)
+
+
+def _rank_ic(a: pd.Series, b: pd.Series) -> float:
+    """Spearman 秩相关，与 scanner 的 _daily_ic 同口径。"""
+    return float(a.rank().corr(b.rank()))
+
+
+def _codes(n: int) -> list[str]:
+    return [f"{i:06d}.SZ" for i in range(n)]
+
+
+def _beta_driven_cross_section(n: int = 400, seed: int = 7):
+    """造一个「因子只是在赌 beta」的截面：因子与 beta 强相关，收益完全由 beta 驱动。"""
+    rng = np.random.default_rng(seed)
+    codes = _codes(n)
+    beta = pd.Series(rng.normal(1.0, 0.35, n), index=codes)
+    factor = pd.Series(beta.to_numpy() * 2 + rng.normal(0, 0.5, n), index=codes)
+    fwd = pd.Series(beta.to_numpy() * 3.0 + rng.normal(0, 2.0, n), index=codes)
+    return factor, fwd, beta
+
+
+class TestBetaNeutral:
+    def test_demeaning_would_not_change_rank_ic(self):
+        """反证:减截面均值是恒等变换,所以中性化必须走回归而不是去均值。"""
+        factor, fwd, _ = _beta_driven_cross_section()
+        assert _rank_ic(factor, fwd) == _rank_ic(factor, fwd - fwd.mean())
+
+    def test_residualizing_kills_a_pure_beta_factor(self):
+        """纯 beta 因子中性化后 IC 应塌回噪声带——这正是这个开关要抓的假阳性。"""
+        factor, fwd, beta = _beta_driven_cross_section()
+        raw = _rank_ic(factor, fwd)
+        resid = _beta_neutral(fwd, beta)
+        neutral = _rank_ic(factor.loc[resid.index], resid)
+        assert raw > 0.30
+        assert abs(neutral) < 0.05
+
+    def test_residual_is_orthogonal_to_beta(self):
+        _, fwd, beta = _beta_driven_cross_section()
+        resid = _beta_neutral(fwd, beta)
+        assert abs(_rank_ic(resid, beta.loc[resid.index])) < 0.05
+
+    def test_returns_empty_below_min_cross_section(self):
+        """截面太窄就不出数,不能拿几十只票的残差当 IC。"""
+        codes = _codes(40)
+        fwd = pd.Series(np.arange(40.0), index=codes)
+        beta = pd.Series(np.linspace(0.5, 1.5, 40), index=codes)
+        assert _beta_neutral(fwd, beta).empty
+
+    def test_returns_empty_when_beta_is_degenerate(self):
+        """所有票同一个 beta 时回归无解,返回空而不是除零。"""
+        codes = _codes(200)
+        fwd = pd.Series(np.arange(200.0), index=codes)
+        beta = pd.Series(np.ones(200), index=codes)
+        assert _beta_neutral(fwd, beta).empty
+
+
+class TestWithinSectorRank:
+    def _panel(self, n: int = 400, seed: int = 11):
+        rng = np.random.default_rng(seed)
+        return pd.DataFrame(
+            rng.normal(0, 5, (5, n)),
+            index=pd.bdate_range("2024-01-01", periods=5),
+            columns=_codes(n),
+        )
+
+    def test_global_rank_is_an_identity_transform(self):
+        """反证:全市场分位与原值秩逐位相同,当独立因子等于重复计权。
+
+        直接比秩而不是比相关系数——相关系数会带浮点残差(实测 0.9999999999999999),
+        比秩是精确的,也更贴近「Rank IC 逐位相同」这个真正的论断。
+        """
+        panel = self._panel()
+        row = panel.iloc[2]
+        assert (row.rank(pct=True) * 100).rank().equals(row.rank())
+
+    def test_within_sector_rank_reorders(self):
+        """行业内分位会打乱全市场秩序,故携带原始动量之外的信息。"""
+        panel = self._panel()
+        sector_map = {code: f"S{i % 12}" for i, code in enumerate(panel.columns)}
+        ranked = _within_sector_rank(panel, sector_map)
+        assert _rank_ic(ranked.iloc[2], panel.iloc[2]) < 0.99
+
+    def test_drops_sectors_below_min_members(self):
+        """单成员行业的 pct rank 恒等于 1.0,会被当成永久龙头,必须剔除。"""
+        panel = self._panel()
+        codes = list(panel.columns)
+        tiny = 30
+        sector_map = {code: (f"solo{i}" if i < tiny else "BIG") for i, code in enumerate(codes)}
+        ranked = _within_sector_rank(panel, sector_map)
+        assert WITHIN_SECTOR_MIN_MEMBERS > 1
+        assert int(ranked.iloc[2].notna().sum()) == len(codes) - tiny
+        assert ranked.iloc[2][codes[:tiny]].isna().all()
+
+    def test_returns_all_nan_when_coverage_too_thin(self):
+        """行业映射覆盖不足时整列留空,scanner 少两个因子而非拿残缺截面出数。"""
+        panel = self._panel()
+        sector_map = {code: "BIG" for code in list(panel.columns)[:20]}
+        assert _within_sector_rank(panel, sector_map).isna().all().all()
+
+    def test_keeps_original_columns(self):
+        """输出必须对齐原始列,否则 evaluate 里的 mask 会错位。"""
+        panel = self._panel()
+        sector_map = {code: f"S{i % 12}" for i, code in enumerate(panel.columns)}
+        assert list(_within_sector_rank(panel, sector_map).columns) == list(panel.columns)
+
+
+class TestRollingBeta:
+    def _close(self, rows: int = 200, cols: int = 20, seed: int = 3) -> pd.DataFrame:
+        rng = np.random.default_rng(seed)
+        path = 100 * np.cumprod(1 + rng.normal(0, 0.02, (rows, cols)), axis=0)
+        return pd.DataFrame(path, index=pd.bdate_range("2024-01-01", periods=rows), columns=_codes(cols))
+
+    def test_no_beta_before_min_obs(self):
+        """窗口早期不出伪 beta,否则中性化会拿几个点估的斜率去残差化。"""
+        beta = rolling_beta(self._close())
+        assert beta.iloc[BETA_MIN_OBS - 10].isna().all()
+
+    def test_beta_averages_to_one_against_equal_weight_market(self):
+        """基准是等权市场,故截面 beta 均值应≈1——错了说明基准算歪了。"""
+        beta = rolling_beta(self._close())
+        assert abs(float(beta.iloc[150].mean()) - 1.0) < 0.05
+
+    def test_shape_matches_input(self):
+        close = self._close()
+        assert rolling_beta(close).shape == close.shape


### PR DESCRIPTION
## 问题

因子表里有三处「看着像新证据、数学上什么也没变」。都不是算错，是把恒等变换当成了增量信息，
所以肉眼审阅抓不住。

**一、`rps_fast` / `rps_slow` 不是新因子。** 它们是 `ret20` / `ret60` 的全市场横截面分位。
Spearman 秩相关对单调变换不变，所以 `rank(ret20)` 与 `ret20` 的 Rank IC、IR、为正日占比
**逐位相同**（8-30 实测差 <1e-9）。后果是因子表凭空多两条证据，而且 BH 多重比较的检验数
偏大，相当于自己把显著性门槛调松了。

**二、IC 没有剥离 beta。** 一个因子在上涨段拿到正 IC，可能只是它选到了高 beta 的票。
分不出「赌对了市场」和「真有 alpha」，两者在报表里长得一样。

**三、`--start` 骗人。** `WARMUP=260` 会把 IC 起点往后推 260 个交易日。8-30 那次
`--start 2024-08-01` 的运行，我据此以为覆盖了 2024 下半年，实际 IC 一天都没算到那段。

## 改动

### 行业内分位取代全市场分位

同一个 `ret20`，在弱行业里是龙头、在强行业里是垫底。秩序被行业重排之后，才携带原始动量
之外的信息。`_within_sector_rank` 沿列方向按行业分组求组内百分位，行业外的股票留 NaN。

小行业必须剔除：组内只有 1 个成员时 pct rank 恒等于 1.0，这只票会被当成**永久的行业龙头**
喂进 IC；2~3 只也只能取到 0.33/0.5/1.0 几个值，秩噪声大于信号。门槛
`WITHIN_SECTOR_MIN_MEMBERS = 5`。行业映射覆盖不足 50 只时整列留空 —— scanner 少两个因子，
好过拿残缺截面出数。

### `--beta-neutral`

`rolling_beta`（120 日窗口，最少 60 个观测）算个股对**等权市场**的敏感度，
`_beta_neutral` 在截面上把前瞻收益对 beta 回归、取残差。

必须是回归，不能是去均值 —— 减掉截面均值不改变任何一只票的秩，对 Rank IC 是**恒等变换**。
只有残差化才会重排个股间的秩序，从而真的把市场敏感度分离出去。

beta 缺失的票被残差化丢掉后，`liquid` mask 跟着收窄，否则 `avg_universe` 记的是中性化
**前**的截面宽度。

基准取等权而不是 000001：口径确实不同，但 IC 是截面统计量，要的是「同一截面内谁更敏感」
的排序，等权足够，且不引入外部数据依赖。

### 显式记录 IC 覆盖区间

`payload["ic_window"]` 同时记 `market_start` / `ic_start` / `ic_end`，并在 stdout 打一行：

```
[ic] 行情自 2024-08-01 起；扣掉 WARMUP=260 后 IC 实际覆盖 2025-08-27 ~ 2026-08-28
```

workflow 把 `start` 和 `beta_neutral` 提成 dispatch 输入，`start` 的描述里直接写明
「要覆盖 2024 下半年就得填 2023 年中」。

### 落库分段加后缀

唯一键是 `(eval_date, factor_name, horizon, segment)`。同日跑原始 + beta 中性两次会互相
upsert 覆盖，所以中性化的运行落 `full_bn` / `seg1_bn`。既有消费方查 `segment='full'`
不受诊断性运行影响。

### 顺带

`_load_sector_map` 加 `lru_cache` —— 一次运行内被 rps 和 sector_strength 两处调用。
`ic_shadow_score.py` 的权重表注释更正：`rps_slow` 与 `ret60` 的 IC 现在**不再相同**
（实测差 +0.019），但底层是同一份 60 日涨幅，同时入选仍属重复计权，所以约束保留 ——
理由从「IC 相同」改成「同源」。权重方向未变（8-30 全市场 4300+ 只 / 516 交易日复测，
三段同号依旧）。

## 验证

新增 `tests/scripts/test_scan_factor_ic.py`，13 个用例。核心是两个**反证** —— 把「什么也
没变」这件事本身钉住，防止以后有人再把恒等变换当新因子：

| 用例 | 断言 | 实测 |
|---|---|---|
| `test_demeaning_would_not_change_rank_ic` | 去均值后 Rank IC 完全相等 | 差 `0.00e+00`，位级恒等 |
| `test_global_rank_is_an_identity_transform` | 全市场分位与原值秩逐位相同 | `.rank().equals()` 通过 |

正面用例用一个**纯 beta 因子**（因子与 beta 强相关，收益完全由 beta 驱动）做负控制：

```
中性化前 Rank IC = +0.3263
中性化后 Rank IC = -0.0202     ← 塌回噪声带
残差 ~ beta 秩相关 = -0.0281   ← 正交
```

这正是这个开关要抓的假阳性形态。其余覆盖：截面 <100 只返回空、beta 退化（全票同值）
返回空而不是除零、单成员行业被剔除（30 个单成员组 → 保留 370/400 列）、行业覆盖不足时
整列留空、输出列对齐原始面板（错位会让 evaluate 的 mask 串位）、`min_periods` 前不出伪 beta、
等权基准下截面 beta 均值 ≈ 1.000。

- `tests/scripts/test_scan_factor_ic.py` + `tests/core/test_ic_shadow_score.py`：40 passed
- `tests/test_workflow_hygiene.py` + `test_ci_policy_gates.py` + `test_script_help_smoke.py`：39 passed
- `ruff check` / `ruff format --check` 干净；`quality_gate.py --ci` OK；`--check-no-sql` OK
- workflow YAML 解析通过，两个新 input 就位；`--help` 显示 `--beta-neutral` 与 `--start`
