### PR TITLE
feat(reading-room): 个股消息检索改用东财接口，补上 Step 1.5 核证

### DIFF
--- a/web/apps/api/src/routes/chat.ts
+++ b/web/apps/api/src/routes/chat.ts
@@ -13,6 +13,7 @@ import {
   execQueryRecommendations,
   execScreenStocks,
   execSearchStock,
+  execStockNews,
   execStrategyDecision,
   execViewPortfolio,
   fetchMarketWatchSnapshot,
@@ -135,11 +136,13 @@ const WYCKOFF_CHAT_SYSTEM_PROMPT = `# 角色设定
 7. 只有用户明确要求进行 Python 计算、回测或统计时，才可调用 run_python_research。先说明计算目的；该工具必须等待用户确认，脚本只处理已知、有限的数据，不能把猜测当作数据来源。
 8. 时间与交易时段以本轮注入的「当前时间与交易时段」为准，不得自行推算或编造。涉及盘面的回复先写出那一行北京时间；处于非交易日/非交易时段时，只做盘后复盘、次日计划与 T+1 委托策略，不给「立刻买/立刻卖」的指令。
 9. 复权口径以本轮注入的「复权口径」为准：结构价位来自前复权，委托价须是不复权实时价。两者被判定错开时，先说明差异，不得把结构价位直接当作委托价。
-10. analyze_stock 的 chart_plan 用于前端作图：日期必须取自工具返回的真实交易日，判断不出的阶段就留空，不要为了凑齐五个阶段而编。若处于可盘中交易时段且该股已有持仓，则不填 chart_plan（置为 null），直接给结论与操作口径 —— 盘中持仓看的是当下怎么办，不是回顾结构。`
+10. analyze_stock 的 chart_plan 用于前端作图：日期必须取自工具返回的真实交易日，判断不出的阶段就留空，不要为了凑齐五个阶段而编。若处于可盘中交易时段且该股已有持仓，则不填 chart_plan（置为 null），直接给结论与操作口径 —— 盘中持仓看的是当下怎么办，不是回顾结构。
+11. 消息只用于核证，顺序不可颠倒：先用 analyze_stock 得出量价结构结论，再调用 stock_news 看消息能否对上。消息与结构冲突时说明冲突，不要用消息改写结构判断，也不要把消息当作买卖依据。stock_news 返回空只说明检索没命中，不等于无事发生，不得据此断言「没有利空」。`
 
 const WEB_SEARCH_GUIDANCE = `# 联网搜索
 
-公开网页信息、未上市/IPO、舆情、公告或本地库查不到时，优先调用 web_search 做服务端联网检索。
+公开网页信息、未上市/IPO、舆情、宏观或本地库查不到时，优先调用 web_search 做服务端联网检索。
+A股个股消息优先用 stock_news（覆盖更稳、字段结构化）；web_search 用于它覆盖不到的场景。
 行情、持仓、形态复盘和归因仍必须用对应本地工具，不得用网页搜索替代 K 线事实。
 搜索结果仅当轮有效；跨轮追问时如需最新网页证据应再次搜索。`
 
@@ -680,6 +683,7 @@ function buildReadTools(deps: ToolDeps, userId: string, model: unknown) {
     view_portfolio: tool({ description: '查看用户当前持仓列表和可用资金。', inputSchema: z.object({}), execute: () => execViewPortfolio(deps, userId) }),
     market_overview: tool({ description: '查看当前/最新大盘行情信号。', inputSchema: z.object({}), execute: () => execMarketOverview(deps) }),
     market_history: tool({ description: '回看大盘指数过去N个交易日K线，分析量价关系和威科夫阶段。', inputSchema: z.object({ days: z.number().nullable(), index: z.enum(['sse', 'csi300', 'szse', 'chinext']).nullable() }), execute: ({ days, index }) => execMarketHistory(deps, userId, model, days ?? 100, index ?? 'sse') }),
+    stock_news: tool({ description: 'A股个股近期消息（东方财富），用于核证量价结构判断。两条模型通道都可用，不依赖服务端联网检索。', inputSchema: z.object({ code: z.string(), name: z.string().nullable(), limit: z.number().nullable() }), execute: ({ code, name, limit }) => execStockNews(deps, code, name, limit ?? 12) }),
     query_recommendations: tool({ description: '查询形态复盘记录。', inputSchema: z.object({ limit: z.number() }), execute: ({ limit }) => execQueryRecommendations(deps, limit) }),
     query_attribution: tool({ description: '查询远端策略归因治理器、operator_summary、latest_policy_display、latest_execution_summary、promotion_checklist 和 latest_operations；本地 --no-write 报告需走 CLI/MCP。', inputSchema: z.object({ limit: z.number() }), execute: ({ limit }) => execQueryAttribution(deps, limit) }),
   }

--- a/web/apps/web/src/lib/__tests__/stock-news.test.ts
+++ b/web/apps/web/src/lib/__tests__/stock-news.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { execStockNews, selectStockNewsHeadlines, type ToolDeps } from '@wyckoff/shared'
+
+/** execStockNews 只用到 deps.fetch,其余字段给个空壳即可。 */
+function depsWith(fetchImpl: typeof globalThis.fetch): ToolDeps {
+  return { supabase: null as never, fetch: fetchImpl, generateText: null as never }
+}
+
+function eastMoneyResponse(articles: Array<Record<string, string>>): Response {
+  return new Response(`jQuery3510(${JSON.stringify({ result: { cmsArticleWebOld: articles } })})`)
+}
+
+describe('selectStockNewsHeadlines', () => {
+  it('保留归不了类的条目 —— 核证不该只看那五类事件', () => {
+    const rows = selectStockNewsHeadlines([
+      { title: '中石科技中标某车企年度采购项目', published_at: '2026-08-20 09:00:00' },
+      { title: '中石科技完成董事会换届', published_at: '2026-08-19 09:00:00' },
+    ], 12, '', '中石科技')
+    expect(rows.map((row) => row.kind)).toEqual(['deal', null])
+    expect(rows).toHaveLength(2)
+  })
+
+  it('过滤涨停板与盘后集锦这类没有事件内核的标题', () => {
+    const rows = selectStockNewsHeadlines([
+      { title: '300684，20cm三连板！', published_at: '2026-08-20 09:00:00' },
+      { title: '净利同比增长10.92倍！盘后公告集锦', published_at: '2026-08-19 09:00:00' },
+      { title: '公司收到证监会立案调查通知', published_at: '2026-08-18 09:00:00' },
+    ], 12)
+    expect(rows.map((row) => row.title)).toEqual(['公司收到证监会立案调查通知'])
+  })
+
+  it('按发布日倒序,同标题只留一条', () => {
+    const rows = selectStockNewsHeadlines([
+      { title: '公司披露业绩预增公告', published_at: '2026-08-10 09:00:00' },
+      { title: '公司披露业绩预增公告', published_at: '2026-08-10 15:00:00' },
+      { title: '大股东拟减持不超过2%', published_at: '2026-08-21 09:00:00' },
+    ], 12)
+    expect(rows.map((row) => row.date)).toEqual(['2026-08-21', '2026-08-10'])
+  })
+
+  it('同一天可以留两条 —— 与作图的一天一个不同', () => {
+    const rows = selectStockNewsHeadlines([
+      { title: '公司收到证监会问询函', published_at: '2026-08-20 09:00:00' },
+      { title: '控股股东增持公司股份', published_at: '2026-08-20 15:00:00' },
+    ], 12)
+    expect(rows).toHaveLength(2)
+    expect(new Set(rows.map((row) => row.date))).toEqual(new Set(['2026-08-20']))
+  })
+
+  it('保留原始发布日,不贴到交易日', () => {
+    const rows = selectStockNewsHeadlines([
+      { title: '公司披露中报,净利扭亏', published_at: '2026-08-15 22:38:00' },
+    ], 12)
+    expect(rows[0]?.date).toBe('2026-08-15')
+  })
+
+  it('limit 为 0 时返回空数组', () => {
+    const rows = selectStockNewsHeadlines([
+      { title: '公司收到证监会立案调查通知', published_at: '2026-08-18 09:00:00' },
+    ], 0)
+    expect(rows).toEqual([])
+  })
+})
+
+describe('execStockNews', () => {
+  it('拒绝非 A 股代码,不打上游', async () => {
+    const text = await execStockNews(depsWith(() => { throw new Error('should not fetch') }), 'AAPL.US', null, 12)
+    expect(text).toContain('不是 A 股 6 位代码')
+  })
+
+  it('不足 6 位的代码先补零再判定', async () => {
+    const text = await execStockNews(depsWith(async () => eastMoneyResponse([
+      { date: '2026-08-20 09:00:00', title: '平安银行披露业绩预增公告', content: '预增', mediaName: '财联社', code: 'abc' },
+    ])), '1', '平安银行', 12)
+    expect(text).toContain('000001')
+    expect(text).toContain('业绩预增')
+  })
+
+  it('输出带核证口径,并说明发布日未贴交易日', async () => {
+    const text = await execStockNews(depsWith(async () => eastMoneyResponse([
+      { date: '2026-08-20 09:00:00', title: '中石科技收到证监会立案调查通知', content: '立案', mediaName: '财联社', code: 'abc' },
+    ])), '300684', '中石科技', 12)
+    expect(text).toContain('用途：核证量价结构判断')
+    expect(text).toContain('不要反过来用消息推结构')
+    expect(text).toContain('未贴到交易日')
+    expect(text).toContain('[监管/偏空]')
+  })
+
+  it('检索为空时说清「没命中 ≠ 无事发生」', async () => {
+    const text = await execStockNews(depsWith(async () => eastMoneyResponse([])), '300684', '中石科技', 12)
+    expect(text).toContain('不等于确实无事发生')
+  })
+
+  it('上游报错时不谎称没有消息', async () => {
+    const text = await execStockNews(depsWith(async () => { throw new Error('upstream down') }), '300684', '中石科技', 12)
+    expect(text).toContain('消息源暂时不可用')
+    expect(text).toContain('不要据此断定')
+  })
+
+  it('limit 收敛到 20 上限', async () => {
+    const articles = Array.from({ length: 20 }, (_, index) => ({
+      date: `2026-08-${String(index + 1).padStart(2, '0')} 09:00:00`,
+      title: `中石科技第${index + 1}次披露业绩预增公告`,
+      content: '预增',
+      mediaName: '财联社',
+      code: 'abc',
+    }))
+    const text = await execStockNews(depsWith(async () => eastMoneyResponse(articles)), '300684', '中石科技', 999)
+    expect(text).toContain('近期消息 20 条')
+  })
+})

--- a/web/packages/shared/src/chat-tools.ts
+++ b/web/packages/shared/src/chat-tools.ts
@@ -31,6 +31,13 @@ import {
   type PatternReviewRow,
 } from './pattern-review'
 import { ANALYSIS_CONTEXT_PACK_SCHEMA, buildStockAnalysisContextPack } from './analysis-context'
+import {
+  fetchEastMoneyStockNews,
+  selectStockNewsHeadlines,
+  type NewsEventKind,
+  type NewsSentiment,
+  type StockNewsHeadline,
+} from './news-chart-events'
 import { WYCKOFF_CHART_PLAN_SCHEMA, validateChartPlan } from './wyckoff-chart-plan'
 import { marketWatchSymbol, normalizeMarketWatchCode, readFreshMarketWatchSnapshot, type MarketWatchQuote, type MarketWatchSnapshot } from './market-watch'
 import { refreshPortfolioTotalEquity } from './portfolio-valuation'
@@ -709,6 +716,56 @@ function buildMarketHistoryDigest(name: string, rows: KlineRow[]): string {
     ...recent,
     '```',
   ].join('\n')
+}
+
+/**
+ * 拉个股近期消息,供 Step 1.5 核证结构判断。
+ *
+ * 为什么不用 web_search:那个是 provider 侧工具,只在 DeepSeek Responses 通道
+ * 挂得上(见 chat-language-model 的 providerTools)。走 chat 通道时它整个不存在,
+ * 核证一步就断了。这个走东财接口,两条通道都在。
+ *
+ * 定位是核证,不是选股依据 —— 先有量价结构结论,再看消息能不能对上。所以输出
+ * 里明写这一句,不让模型倒过来用。
+ */
+export async function execStockNews(deps: ToolDeps, code: string, name: string | null, limit: number): Promise<string> {
+  const normalized = normalizeCode(code)
+  if (!isCnSymbol(normalized)) {
+    return `${code} 不是 A 股 6 位代码。个股消息检索目前只覆盖 A 股（数据源为东方财富），港股/美股请用其它工具或公开信息。`
+  }
+  const rows = await fetchEastMoneyStockNews(normalized, deps.fetch).catch(() => null)
+  if (rows === null) return `消息源暂时不可用，未能取到 ${normalized} ${name || ''} 的消息。不要据此断定「没有消息」。`
+  const headlines = selectStockNewsHeadlines(rows, Math.min(Math.max(limit, 1), 20), normalized, name || '')
+  if (headlines.length === 0) {
+    return `未检索到 ${normalized} ${name || ''} 的相关消息（已过滤涨停板、龙虎榜、盘后集锦这类无事件内核的标题）。这说明检索没有命中，不等于确实无事发生。`
+  }
+  return [
+    `${normalized} ${name || ''} 近期消息 ${headlines.length} 条（来源：东方财富，按发布日倒序）`,
+    '用途：核证量价结构判断。先有结构结论，再看消息能否对上；不要反过来用消息推结构。',
+    '注意：发布日是自然日，未贴到交易日；周末与盘后消息通常反映在下一交易日。',
+    '',
+    ...headlines.map(formatNewsHeadlineLine),
+  ].join('\n')
+}
+
+function formatNewsHeadlineLine(row: StockNewsHeadline): string {
+  const tags = [row.kind ? NEWS_KIND_LABEL[row.kind] : '未归类', NEWS_SENTIMENT_LABEL[row.sentiment]].join('/')
+  return [`- ${row.date} [${tags}] ${row.title}`, row.summary ? `  摘要：${row.summary}` : ''].filter(Boolean).join('\n')
+}
+
+const NEWS_KIND_LABEL: Record<NewsEventKind, string> = {
+  regulatory: '监管',
+  risk: '风险',
+  earnings: '业绩',
+  holder: '股东',
+  deal: '交易',
+}
+
+const NEWS_SENTIMENT_LABEL: Record<NewsSentiment, string> = {
+  bullish: '偏多',
+  bearish: '偏空',
+  mixed: '多空混杂',
+  unknown: '中性',
 }
 
 export async function execQueryRecommendations(deps: ToolDeps, limit: number): Promise<string> {

--- a/web/packages/shared/src/index.ts
+++ b/web/packages/shared/src/index.ts
@@ -161,7 +161,10 @@ export {
   classifyHeadline,
   fetchEastMoneyStockNews,
   handleNewsEventsRequest,
+  headlineSentiment,
+  isNoiseHeadline,
   selectNewsChartEvents,
+  selectStockNewsHeadlines,
   snapToSession,
 } from './news-chart-events'
-export type { NewsChartEvent, NewsEventKind, NewsSentiment, RawNewsItem } from './news-chart-events'
+export type { NewsChartEvent, NewsEventKind, NewsSentiment, RawNewsItem, StockNewsHeadline } from './news-chart-events'

--- a/web/packages/shared/src/news-chart-events.ts
+++ b/web/packages/shared/src/news-chart-events.ts
@@ -68,20 +68,72 @@ export function selectNewsChartEvents(
 
 export function classifyHeadline(title: string, content = ''): { kind: NewsEventKind; sentiment: NewsSentiment; score: number } | null {
   const text = `${title} ${content}`
-  if ([...ROUNDUP_TITLES, ...NOISE_ONLY].some((word) => title.includes(word))) return null
+  if (isNoiseHeadline(title)) return null
   const kind = (Object.keys(KIND_KEYWORDS) as NewsEventKind[]).find((name) => KIND_KEYWORDS[name].some((word) => text.includes(word)))
   if (!kind) return null
+  const extra = [...BULLISH_KEYWORDS, ...BEARISH_KEYWORDS].filter((word) => text.includes(word)).length
+  return { kind, sentiment: headlineSentiment(text), score: KIND_WEIGHTS[kind] + extra }
+}
+
+/** 涨停板、龙虎榜、盘后集锦这类没有事件内核的标题。 */
+export function isNoiseHeadline(title: string): boolean {
+  return [...ROUNDUP_TITLES, ...NOISE_ONLY].some((word) => title.includes(word))
+}
+
+export function headlineSentiment(text: string): NewsSentiment {
   const bullish = BULLISH_KEYWORDS.some((word) => text.includes(word))
   const bearish = BEARISH_KEYWORDS.some((word) => text.includes(word))
-  const sentiment: NewsSentiment = bullish && bearish ? 'mixed' : bullish ? 'bullish' : bearish ? 'bearish' : 'unknown'
-  const extra = [...BULLISH_KEYWORDS, ...BEARISH_KEYWORDS].filter((word) => text.includes(word)).length
-  return { kind, sentiment, score: KIND_WEIGHTS[kind] + extra }
+  return bullish && bearish ? 'mixed' : bullish ? 'bullish' : bearish ? 'bearish' : 'unknown'
 }
 
 export function snapToSession(rawDate: string, sessionDates: string[]): string {
   const day = parseDay(rawDate)
   if (!day) return ''
   return sessionDates.find((session) => session >= day) || sessionDates.at(-1) || ''
+}
+
+export interface StockNewsHeadline {
+  date: string
+  title: string
+  summary: string
+  source: string
+  url: string
+  /** 命中已知事件类型时给出;命中不了仍保留条目 —— 核证消息不该只看这五类。 */
+  kind: NewsEventKind | null
+  sentiment: NewsSentiment
+}
+
+/**
+ * 给模型核证用的消息流,与作图用的 selectNewsChartEvents 不是一回事。
+ *
+ * 作图那条要求「一天一个、必须归到已知事件类型、必须贴到交易日」,因为图上一天只
+ * 挂得下一个标记。核证不受这些约束:同一天可以有两条,归不了类的公告照样是证据。
+ * 所以这里只做三件事 —— 去噪、去重、按时间倒序,保留原始日期不贴任何交易日。
+ */
+export function selectStockNewsHeadlines(items: RawNewsItem[], limit = 12, symbol = '', name = ''): StockNewsHeadline[] {
+  const seen = new Set<string>()
+  const rows: StockNewsHeadline[] = []
+  for (const item of items) {
+    const title = item.title.trim()
+    const published = parseDay(item.published_at || item.date || '')
+    if (!title || !published) continue
+    if (isNoiseHeadline(title)) continue
+    if (!mentionsSymbol(title, item.content || '', symbol, name)) continue
+    const key = titleKey(title)
+    if (seen.has(key)) continue
+    seen.add(key)
+    rows.push({
+      date: published,
+      title,
+      summary: (item.content || '').replace(/\s+/g, ' ').trim().slice(0, 100),
+      source: item.source || 'eastmoney',
+      url: item.url || '',
+      kind: classifyHeadline(title, item.content || '')?.kind ?? null,
+      sentiment: headlineSentiment(`${title} ${item.content || ''}`),
+    })
+  }
+  rows.sort((a, b) => b.date.localeCompare(a.date) || a.title.localeCompare(b.title))
+  return rows.slice(0, Math.max(limit, 0))
 }
 
 export async function fetchEastMoneyStockNews(code: string, fetcher: typeof fetch = fetch): Promise<RawNewsItem[]> {


### PR DESCRIPTION
## 问题

Step 1.5「搜索消息做核证」原本指望 `web_search`,但它是 provider 侧工具。
`chat-language-model.ts` 只在官方 DeepSeek Responses 通道返回非空 `providerTools`,
其余配置一律 `{}` + `transport: 'chat'`。走 chat 通道时这个工具**根本不存在**,
核证一步是断的。`chat.ts` 里那道 `transport === 'responses'` 判断只压住了提示
文案,并没有补上能力——所以这不是「文档没写清」,是功能缺失。

## 改法

复用 `news-chart-events.ts` 里已有的东财检索(纯 `fetch`,已作为 Pages function
部署,两条通道行为一致),新增 `stock_news` 工具,不挂在 responses 闸门后面。

作图那条 `selectNewsChartEvents` 不能直接拿来核证。它强制三件事:一天一个、
必须归入五类事件、必须贴到交易日——因为图上一天只挂得下一个标记。这三条对核证
都是在毁证据:同一天两条消息是正常的,归不了类的公告照样是证据。所以另写
`selectStockNewsHeadlines`,只做去噪、去重、按发布日倒序,保留原始自然日。
函数注释里写明了这个分工,免得日后被「简化」合并回去。

顺手把 `classifyHeadline` 拆出 `isNoiseHeadline` / `headlineSentiment`,两条路径共用。

## 核证纪律

方向单向锁死:先 `analyze_stock` 得结构结论,再 `stock_news` 看消息能否对上。
消息不得改写结构判断,也不得当买卖依据。这条同时写进工具返回文案和系统提示词
第 11 条——重复是有意的,「消息驱动结构」正是原始 prompt 用「仅用于验证」防的
那个失效模式。

检索为空与上游失败各给一套措辞,都明写「没命中 ≠ 无事发生」,避免一次失败的
检索被读成「没有利空」。

`WEB_SEARCH_GUIDANCE` 相应调整:A 股个股优先 `stock_news`,`web_search` 留给它
覆盖不到的场景(未上市/IPO、舆情、宏观)。

## 验证

- `tsc --noEmit`:`packages/shared`、`apps/api`、`apps/web` 三处均 0 错
- `apps/web` vitest:43 文件 / 270 通过(新增 12 条)
- `apps/api` vitest:19 文件 / 128 通过 + 2 skipped
- 新测试特意覆盖「同一天两条都保留」——这正是它与作图路径的分界

## 范围说明

**本 PR 只做 Step 1.5 消息核证。**图片与 CSV 上传没动:`composer.tsx` 目前仍
只有一个文本 `<input>`,没有 file input、没有附件状态、没有 multipart 通路,
原始 prompt 里的图片模态还honor不了。分支名带 `-and-upload` 是当时预留的,要不要
把上传并进来还是单独一个 PR,由你定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)