### PR TITLE
test(momentum): 动量体检加随机负控制与机械项分解

### DIFF
--- a/core/momentum_regime_eval.py
+++ b/core/momentum_regime_eval.py
@@ -29,6 +29,31 @@ IC 自身也不可预测：非重叠窗口 lag-1 rho 仅 +0.12/+0.21（重叠窗
 所以首轮**没有改任何参数**。这个体检保留下来，是为了持续确认「闸门期望为零、
 振幅按季度摆动」这个结论，以及在它真的转为持续为负时能被看见。
 
+第二轮（2026-09-01，1079 个交易日 2022..2026 回测快照，H=10）把样本从 402 天拉到
+1079 天后，结论从「平的」变成「方向反了」，又有两条发现——
+
+**四、beta 中性化后动量还在，所以「跟着市场动态迭代」不是对冲 beta 的事。**
+ret60 中性化后保留 82% 的 Rank IC（IR -0.41 → -0.39，三段符号一致），
+dry_vol_q250 保留 94%。顺带露出两个被 beta 盖住的因子：amplitude60 IR
+-0.20 → **-0.72**（t=-22.0）、price_from_low250 -0.35 → **-0.59**（t=-18.2）。
+但它们的单调性只有 -0.141/-0.054，和 ret60 一样不可线性化，仍只能做负筛。
+
+**五、动量唯一可用的内容是顶部负筛，不是「越低越好」，更不是「退到中动量档」。**
+按 10 分位逐带扫描，RPS50 与 RPS120 两条腿各自独立地给出同一梯度：0~60 带为正、
+70~100 带为负、交叉点落在 60~70，90~100 带 -0.860（0/5 年为正）。生产的 65/70
+正好压在交叉点上并向负区延伸。两个方向的阈值微调都被否掉——收紧 75/80 是 -0.687
+（t=-6.27），放松 55/60 是 -0.389（t=-5.46）；闸门相对全域的超额在 5/5 个年份为负
+或为零，所以这不是水温故事。**但「退到中动量档」同样不成立**：随机负控制里，只要
+每天从「两条腿都 < NON_TOP_CAP 分位」随机抽同样只数，5 个种子给出 +0.164~+0.210，
+与中动量档的 +0.197 无法区分；而从全域随机抽是 ~0.00。中动量档的全部边缘来自避开
+顶部，不含任何选择信息——这就是本模块把随机负控制固化进每次体检的原因。
+
+据此，当前有三处机制押在梯度的负端，第二轮**同样没有改动它们**：闸门本身
+（``FunnelConfig`` 65/70）、弱市收紧（``tools/market_regime.py`` 抬到 80/75，
+在它针对的弱市子样本里实测 -0.200、t=-4.80、0/5 年为正）、以及
+``_boost_bias_for_strong_rps``（rps_slow>=90 放宽 bias 上限，正是 -0.860 那一带）。
+按下面「走前测试的必要性」一节，动手前必须先过 ``walk_forward_switch``。
+
 口径约定
 --------
 - 前向收益：T+1 开盘买、T+1+H 收盘卖，扣单次往返成本 0.202%
@@ -42,6 +67,20 @@ IC 自身也不可预测：非重叠窗口 lag-1 rho 仅 +0.12/+0.21（重叠窗
 首轮四种设计里有两种在全样本回看下 t 值超过 2，走前测试才把它们否掉。任何
 新的阈值或权重改动都必须按 ``walk_forward_switch`` 的同一口径验证——那个测试
 是唯一能区分「真信号」和「事后挑期」的环节。
+
+**但走前本身也不够——``diff_t`` 单独看不是有效检验。**基线是固定放行闸门，而中
+动量档全期高出闸门 0.671pct，于是任何关闭约 51% 天数的开关表都会机械地换来
+~0.345pct。实测同关闭率的**随机**开关表给 +0.313~+0.419、t=+3.70~+5.17：抛硬币
+就能过 t>=2 的线。所以 ``SwitchStat`` 把差值拆成机械项与择时项，判定改看条件价差
+``spread_t``（关闭日与开启日的 mid-gate 之差），并且：
+
+1. ``spread_t`` 只能用**不重叠**日算。相邻交易日的 H 日前向收益共用 H-1 天，全样本
+   口径把按市场宽度切换算成 t=+3.57，而不重叠口径只有 +1.38。
+2. 单个抽样相位的 t 自己就是噪声，故取遍 H+1 个相位报中位数与区间。该设计的 11 个
+   相位落在 +0.08~+1.92，**0/11 个到 2**；按截面离散度切换是 -2.43~-0.86。
+
+两种动态切换设计都不含可用的水温信息，第二轮**没有**上线任何一种。这与配对随机
+控制给出的 +1.61~+2.85 是同一结论，三条独立路径互相印证。
 """
 
 from __future__ import annotations
@@ -76,6 +115,12 @@ THRESHOLD_GRID: tuple[tuple[float, float], ...] = (
 # 中动量档，用于回答「退到中间档是不是更好」。走前测试的对照必须是漏斗真能
 # 输出的另一档，不能是空仓——漏斗每天都要出票。
 MID_BAND = (40.0, 65.0, 40.0, 70.0)
+
+# 顶部上限：随机负控制只从「两条腿都低于此分位」的票里抽。
+# 取 80 是因为逐带扫描里 70~80 已转负、80~90 为 0/5 年正（详见模块 docstring 第五条）。
+NON_TOP_CAP = 80.0
+# 随机负控制的种子。多种子是为了看边缘是否稳定，单种子的一次抽样不足以判定。
+CONTROL_SEEDS: tuple[int, ...] = (11, 29, 47, 83, 101)
 
 
 def tstat(values: list[float]) -> float | None:
@@ -139,7 +184,15 @@ class BandStat:
 
 @dataclass
 class SwitchStat:
-    """一种动态切换设计的走前结果。"""
+    """一种动态切换设计的走前结果，含机械项/择时项分解。
+
+    ``diff_t`` 单独看**不是有效检验**。基线是固定放行闸门，而中动量档全期高出闸门
+    0.671pct，于是任何关闭率约 51% 的开关表都会机械地换来 ~0.345pct；实测同关闭率
+    的随机开关表给 +0.313~+0.419（t=+3.70~+5.17）。抛硬币就能过 t>=2 的线。
+
+    所以要判断设计是否真在识别水温，得看 ``spread_t``：它关闭的那些天，中动量档相对
+    闸门的优势是不是真的更大（两样本 Welch t，不含随机成分）。
+    """
 
     label: str
     days: int
@@ -149,6 +202,18 @@ class SwitchStat:
     diff_t: float | None
     on_rate: float | None
     on_rate_by_quarter: dict[int, float] = field(default_factory=dict)
+    # 机械项：关闭率 × 全期 (mid - gate)。与开关表是否含信息无关，任何同关闭率的
+    # 表都拿得到。择时项 = diff - 机械项。
+    mechanical: float | None = None
+    # 条件价差：关闭日与开启日的 (mid - gate) 均值（用全部日子），及其两样本 Welch t。
+    spread_off: float | None = None
+    spread_on: float | None = None
+    # t 只用不重叠日算（天数远少于 days），且取遍 H+1 个相位后的**中位数**——
+    # 单个相位自己就是噪声：实测 breadth 的 11 个相位给 +0.08~+1.92。
+    spread_t: float | None = None
+    spread_t_min: float | None = None
+    spread_t_max: float | None = None
+    spread_days: int | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -160,8 +225,23 @@ class SwitchStat:
             "diff_t": _round(self.diff_t, 2),
             "on_rate": _round(self.on_rate, 3),
             "on_rate_by_quarter": {str(k): _round(v, 3) for k, v in sorted(self.on_rate_by_quarter.items())},
+            "mechanical": _round(self.mechanical),
+            "timing": _round(self.timing),
+            "spread_off": _round(self.spread_off),
+            "spread_on": _round(self.spread_on),
+            "spread_t": _round(self.spread_t, 2),
+            "spread_t_min": _round(self.spread_t_min, 2),
+            "spread_t_max": _round(self.spread_t_max, 2),
+            "spread_days": self.spread_days,
             "verdict": self.verdict,
         }
+
+    @property
+    def timing(self) -> float | None:
+        """择时项：diff 里扣掉任何同关闭率开关表都能拿到的机械部分。"""
+        if self.diff is None or self.mechanical is None:
+            return None
+        return self.diff - self.mechanical
 
     @property
     def verdict(self) -> str:
@@ -169,6 +249,13 @@ class SwitchStat:
             return "样本不足"
         if self.diff_t < 2.0:
             return "走前不显著：不可上线"
+        if self.spread_t is None:
+            return "机械项未分解：不可判定"
+        if self.spread_t < 2.0:
+            return "机械项主导：换档收益而非水温信息"
+        # 中位数过线还不够：相位间波动大意味着结论取决于抽哪一相,那不是稳定的证据。
+        if self.spread_t_min is not None and self.spread_t_min < 2.0:
+            return "价差t 依赖抽样相位：证据不稳"
         return "走前显著：值得进一步验证"
 
 
@@ -181,6 +268,9 @@ class MomentumReport:
     thresholds: list[BandStat] = field(default_factory=list)
     mid_band: BandStat | None = None
     domain: BandStat | None = None
+    # 随机负控制，每个种子一档。中动量档要证明自己不只是「避开了顶部」，
+    # 就必须比这几档更好；第二轮的结论正是它比不过。
+    controls: list[BandStat] = field(default_factory=list)
     switches: list[SwitchStat] = field(default_factory=list)
     ic_persistence: dict[str, Any] = field(default_factory=dict)
 
@@ -189,6 +279,8 @@ class MomentumReport:
             "thresholds": [s.as_dict() for s in self.thresholds],
             "mid_band": None if self.mid_band is None else self.mid_band.as_dict(),
             "domain": None if self.domain is None else self.domain.as_dict(),
+            "controls": [s.as_dict() for s in self.controls],
+            "control_gap": control_gap(self.mid_band, self.controls),
             "switches": [s.as_dict() for s in self.switches],
             "ic_persistence": self.ic_persistence,
             "production": {
@@ -200,7 +292,11 @@ class MomentumReport:
             "reading": (
                 "excess 为相对同日流动性域内全体的超额。闸门要证明自己有价值，"
                 "需要 excess_t 显著为正**且**绝对收益的 t 值高于域内基准——"
-                "首轮两条都不成立。switches 的 diff_t 是走前口径，样本内回看不算。"
+                "首轮两条都不成立。controls 是每天从「两条腿都低于 "
+                f"{NON_TOP_CAP:.0f} 分位」随机抽同样只数的负控制：中动量档只有明显"
+                "跑赢它才算含选择信息，否则它的边缘只是「避开了顶部」。"
+                "switches 的 diff_t 是走前口径，但它单独看不是有效检验——机械项那部分"
+                "任何同关闭率的随机开关表都拿得到，判断择时能力要看 spread_t。"
             ),
         }
 
@@ -234,6 +330,40 @@ def summarize_band(
     )
 
 
+def control_gap(mid: BandStat | None, controls: list[BandStat]) -> dict[str, Any]:
+    """中动量档相对随机负控制的差距。
+
+    这是第二轮唯一能否掉「退到中动量档」的环节。控制组每天从「两条腿都低于
+    ``NON_TOP_CAP`` 分位」里随机抽同样只数，因此它只带「避开顶部」这一条信息、
+    不带任何选择信息。中动量档若落在控制组的区间内，说明它的边缘同样只是避开
+    顶部——**这种情况下不能把它当成一个可选档位提案**。
+
+    差距按各种子超额的均值算；``seed_spread`` 给出控制组自身的抽样边缘宽度，
+    差距小于这个宽度就谈不上「跑赢」。
+    """
+    usable = [c.excess for c in controls if c.excess is not None]
+    if mid is None or mid.excess is None or len(usable) < 2:
+        return {"verdict": "样本不足", "seeds": len(usable)}
+    avg = sum(usable) / len(usable)
+    spread = max(usable) - min(usable)
+    gap = mid.excess - avg
+    inside = min(usable) <= mid.excess <= max(usable)
+    return {
+        "seeds": len(usable),
+        "mid_excess": _round(mid.excess),
+        "control_excess_avg": _round(avg),
+        "control_excess_min": _round(min(usable)),
+        "control_excess_max": _round(max(usable)),
+        "seed_spread": _round(spread),
+        "gap": _round(gap),
+        "verdict": (
+            "中动量档落在随机负控制区间内：边缘仅来自避开顶部，不含选择信息"
+            if inside or gap <= spread
+            else "中动量档跑赢随机负控制：含独立选择信息，值得按走前口径复验"
+        ),
+    }
+
+
 def walk_forward_switch(
     label: str,
     rows: list[dict[str, float]],
@@ -241,10 +371,20 @@ def walk_forward_switch(
     state_key: str,
     warmup: int = 120,
     high_is_on: bool = True,
+    horizon: int = 1,
 ) -> SwitchStat:
     """走前切换：T 日只用 T 之前的历史定阈值，关闭时退到中动量档而非空仓。
 
     这是唯一能否掉「样本内回看显著」的环节。首轮四种设计全部在这里失效。
+
+    ``horizon`` 是前向收益天数。传了它，``spread_t`` 会按 H+1 步长取不重叠日再算——
+    相邻交易日的 H 日前向收益共用 H-1 天，直接算两样本 t 会像 ``ic_persistence``
+    里那个 +0.906 的假象一样把 t 夸大。而单个相位（只取 offset=0）本身又是噪声，
+    所以取遍 H+1 个相位后报中位数，并把最小/最大值一起带出来。
+
+    1080 天 H=10 实测：按市场宽度切换的重叠口径 t=+3.57，11 个相位给 +0.08~+1.92
+    （中位 +1.38），**0/11 个相位到 2**；按截面离散度切换 -2.43~-0.86。所以两种设计
+    都不含可用的水温信息，与配对随机控制给出的 +1.61~+2.85 是同一结论。
     """
     usable = [r for r in rows if r.get("gate") is not None and r.get("mid") is not None]
     if len(usable) <= warmup + MIN_DAYS:
@@ -264,6 +404,15 @@ def walk_forward_switch(
     on_by_quarter: dict[int, list[bool]] = {}
     for date, flag in zip(dates, on_flags, strict=True):
         on_by_quarter.setdefault(quarter_of(date), []).append(flag)
+    off_rate = 1.0 - sum(on_flags) / len(on_flags)
+    spread = [float(r["mid"]) - float(r["gate"]) for r in usable[warmup:]]
+    paired = list(zip(spread, on_flags, strict=True))
+    # 均值用全部日子（无偏且更精），只有 t 值需要独立样本：按 H+1 步长抽不重叠日，
+    # 与 ic_persistence 同一约定。单个相位的 t 自己就是噪声，故取遍相位再取中位数。
+    step = max(int(horizon) + 1, 1)
+    phase_ts = [t for off in range(step) if (t := _phase_welch_t(paired[off::step])) is not None]
+    spread_off = [v for v, on in paired if not on]
+    spread_on = [v for v, on in paired if on]
     return SwitchStat(
         label=label,
         days=len(switched),
@@ -273,7 +422,42 @@ def walk_forward_switch(
         diff_t=tstat(diffs),
         on_rate=sum(on_flags) / len(on_flags),
         on_rate_by_quarter={q: sum(v) / len(v) for q, v in on_by_quarter.items()},
+        mechanical=off_rate * (sum(spread) / len(spread)),
+        spread_off=_mean_or_none(spread_off),
+        spread_on=_mean_or_none(spread_on),
+        spread_t=_median_or_none(phase_ts),
+        spread_t_min=min(phase_ts) if phase_ts else None,
+        spread_t_max=max(phase_ts) if phase_ts else None,
+        spread_days=len(paired[::step]),
     )
+
+
+def _phase_welch_t(rows: list[tuple[float, bool]]) -> float | None:
+    """一个抽样相位内的两样本 Welch t。"""
+    return welch_t([v for v, on in rows if not on], [v for v, on in rows if on])
+
+
+def _median_or_none(values: list[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    return ordered[mid] if len(ordered) % 2 else (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def _mean_or_none(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def welch_t(a: list[float], b: list[float]) -> float | None:
+    """两样本 Welch t。关闭日与开启日天数不等、方差也不必相等，故不能用合并方差。"""
+    if len(a) < 3 or len(b) < 3:
+        return None
+    ma, mb = sum(a) / len(a), sum(b) / len(b)
+    va = sum((x - ma) ** 2 for x in a) / (len(a) - 1)
+    vb = sum((x - mb) ** 2 for x in b) / (len(b) - 1)
+    se = math.sqrt(va / len(a) + vb / len(b))
+    return (ma - mb) / se if se > 0 else None
 
 
 def ic_persistence(daily_ic: list[float], horizon: int) -> dict[str, Any]:
@@ -327,18 +511,30 @@ def render(report: MomentumReport, horizon: int) -> str:
         lines.append(_band_row(stat, quarters))
     if report.mid_band is not None:
         lines.append(_band_row(report.mid_band, quarters))
+    for stat in report.controls:
+        lines.append(_band_row(stat, quarters))
     if report.domain is not None:
         lines.append(_band_row(report.domain, quarters))
     lines += [
         "",
-        "| 动态切换设计 | 天数 | 切换后 | 固定放行 | 差值 | 差值t | 开启率 | 判定 |",
-        "| --- | --: | --: | --: | --: | --: | --: | --- |",
+        "| 动态切换设计 | 天数 | 切换后 | 固定放行 | 差值 | 差值t | 机械项 | 择时项 | 价差t | 开启率 | 判定 |",
+        "| --- | --: | --: | --: | --: | --: | --: | --: | --: | --: | --- |",
     ]
     for stat in report.switches:
         lines.append(
             f"| {stat.label} | {stat.days} | {_signed(stat.switched_ret)} | {_signed(stat.baseline_ret)} | "
-            f"{_num(stat.diff)} | {_num(stat.diff_t, 2)} | {_pct(stat.on_rate)} | {stat.verdict} |"
+            f"{_num(stat.diff)} | {_num(stat.diff_t, 2)} | {_num(stat.mechanical)} | {_num(stat.timing)} | "
+            f"{_spread_t_cell(stat)} | {_pct(stat.on_rate)} | {stat.verdict} |"
         )
+    lines.append(
+        "　注：差值t 单独看不是有效检验——基线是固定放行闸门，中动量档全期高出闸门，"
+        "任何同关闭率的**随机**开关表都会机械地拿到「机械项」那部分（实测 t=+3.7~+5.2）。"
+        "判断设计是否真在识别水温看 **价差t**：它关闭的那些天，中动量档的优势是否真的更大。"
+        "价差t 报的是 **H+1 个抽样相位的中位数**，方括号是相位间区间、括号是每相位的"
+        "**不重叠**天数——相邻日的 H 日前向收益共用 H-1 天，按全部日子算会把 t 夸大"
+        "一倍以上（实测 +3.57 vs 相位区间 +0.08~+1.92）；均值仍用全部日子。"
+        "区间下界不到 2 就判「证据不稳」：结论取决于抽哪一相位，不算站得住。"
+    )
     lines += ["", _ic_line(report.ic_persistence), "", "**接下来做什么**", *_actions(report)]
     return "\n".join(lines)
 
@@ -351,6 +547,22 @@ def _band_row(stat: BandStat, quarters: list[int]) -> str:
         f"| {name} | {stat.days} | {size} | {_signed(stat.inside_ret)} | {_num(stat.inside_t, 2)} | "
         f"{_num(stat.excess)} | {_num(stat.excess_t, 2)} | {cells} |"
     )
+
+
+def _spread_t_cell(stat: SwitchStat) -> str:
+    """价差 t 的中位数 + 相位区间 + 不重叠天数。
+
+    三样都得写出来：不写天数,读者会以为它和 days 一样多；不写区间,读者看不出
+    结论有多依赖抽哪一相位。
+    """
+    if stat.spread_t is None:
+        return "—"
+    cell = f"{stat.spread_t:+.2f}"
+    if stat.spread_t_min is not None and stat.spread_t_max is not None:
+        cell += f" [{stat.spread_t_min:+.2f}, {stat.spread_t_max:+.2f}]"
+    if stat.spread_days is not None:
+        cell += f"（{stat.spread_days}天）"
+    return cell
 
 
 def _signed(value: float | None) -> str:
@@ -390,13 +602,67 @@ def _actions(report: MomentumReport) -> list[str]:
         direction = "正" if prod.excess > 0 else "负"
         out.append(f"- ① 生产档超额显著为{direction}（t={prod.excess_t:+.2f}），与首轮「期望为零」不同，需复核。")
     out.append(_domain_action(report))
-    survived = [s.label for s in report.switches if s.diff_t is not None and s.diff_t >= 2.0]
-    if survived:
-        out.append(f"- ③ 这些切换设计走前显著：{'、'.join(survived)}——值得进一步验证再考虑上线。")
-    else:
-        out.append("- ③ 所有动态切换设计走前均不显著，维持固定放行。样本内回看显著不算数。")
-    out.append("- ④ 任何参数改动落地前，须按本脚本 walk_forward_switch 的走前口径复验，且增益需大于成本 0.202%。")
+    out.append(_control_action(report))
+    out.append(_switch_action(report))
+    out.append("- ⑤ 任何参数改动落地前，须按本脚本 walk_forward_switch 的走前口径复验，且增益需大于成本 0.202%。")
     return out
+
+
+def _switch_action(report: MomentumReport) -> str:
+    """切换设计的读法。差值显著但价差不显著,说明赚的是换档而非择时。"""
+    passed = [s for s in report.switches if s.verdict == "走前显著：值得进一步验证"]
+    if passed:
+        names = "、".join(
+            f"{s.label}（择时项 {s.timing:+.3f}pct、价差 t={s.spread_t:+.2f} 于 {s.spread_days or '—'} 个不重叠日）"
+            for s in passed
+            if s.timing is not None and s.spread_t is not None
+        )
+        return f"- ④ 这些切换设计的择时项在扣掉机械项后仍显著：{names or '见上表'}——值得进一步验证再考虑上线。"
+    mechanical = [s for s in report.switches if s.verdict == "机械项主导：换档收益而非水温信息"]
+    if mechanical:
+        names = "、".join(s.label for s in mechanical)
+        return (
+            f"- ④ {names} 的差值显著但**价差 t 不足 2**，赚的是「中动量档比闸门好」这个换档收益、"
+            "不是水温信息——同关闭率的随机开关表拿得到同样的钱。这不构成上线理由。"
+        )
+    unstable = [s for s in report.switches if s.verdict == "价差t 依赖抽样相位：证据不稳"]
+    if unstable:
+        names = "、".join(
+            f"{s.label}（中位 {s.spread_t:+.2f}，相位区间 [{s.spread_t_min:+.2f}, {s.spread_t_max:+.2f}]）"
+            for s in unstable
+            if s.spread_t is not None and s.spread_t_min is not None and s.spread_t_max is not None
+        )
+        return (
+            f"- ④ {names or '见上表'} 的价差 t 中位数过线但**相位区间下界不到 2**——换个不重叠"
+            "抽样相位结论就翻，这不算站得住的证据。要么把样本拉长到相位区间整体过线，要么放弃。"
+        )
+    undecided = [s for s in report.switches if s.verdict == "机械项未分解：不可判定"]
+    if undecided:
+        names = "、".join(s.label for s in undecided)
+        return (
+            f"- ④ {names} 的差值显著，但开关表几乎全程只落在一侧、没有对照日，价差无法检验。"
+            "这种情形下差值全是机械项，**不能读成走前通过**——先确认水温字段本身是否退化成了常量。"
+        )
+    return "- ④ 所有动态切换设计走前均不显著，维持固定放行。样本内回看显著不算数。"
+
+
+def _control_action(report: MomentumReport) -> str:
+    """随机负控制的读法。中动量档跑不赢它，就不能当成一个可选档位提案。"""
+    gap = control_gap(report.mid_band, report.controls)
+    if gap.get("gap") is None:
+        return "- ③ 随机负控制样本不足，无法判断中动量档是否含选择信息。"
+    if "落在" in str(gap.get("verdict")):
+        return (
+            f"- ③ 中动量档超额 {gap['mid_excess']:+.3f}pct 落在随机负控制区间 "
+            f"[{gap['control_excess_min']:+.3f}, {gap['control_excess_max']:+.3f}] 内（{gap['seeds']} 个种子），"
+            "说明它的边缘只来自避开顶部、不含选择信息。**动量可用的内容是「顶部要躲开」，"
+            "不是「越低越好」，也不是「退到中动量档」**——不要把中动量档当成档位提案。"
+        )
+    return (
+        f"- ③ 中动量档超额比随机负控制均值高 {gap['gap']:+.3f}pct，超过控制组自身的抽样宽度 "
+        f"{gap['seed_spread']:+.3f}pct（{gap['seeds']} 个种子），与第二轮结论不同，"
+        "需按 walk_forward_switch 的走前口径复核后再谈上线。"
+    )
 
 
 def _domain_action(report: MomentumReport) -> str:

--- a/scripts/evaluate_momentum_regime.py
+++ b/scripts/evaluate_momentum_regime.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import time
 from pathlib import Path
 
@@ -29,10 +30,12 @@ import _bootstrap  # noqa: F401
 import pandas as pd
 
 from core.momentum_regime_eval import (
+    CONTROL_SEEDS,
     MID_BAND,
     MIN_AMOUNT_RAW,
     MIN_DOMAIN_SIZE,
     MIN_GROUP,
+    NON_TOP_CAP,
     PROD_RPS_FAST_MIN,
     PROD_RPS_SLOW_MIN,
     PROD_RPS_WINDOW_FAST,
@@ -157,6 +160,7 @@ def _collect_day(snap, date: int, sink, switch_rows, daily_ic) -> None:
         sink.setdefault("中动量档", []).append(
             {"date": date, "inside": float(forward[mid].mean()), "domain": domain_ret, "size": float(mid.sum())}
         )
+        _collect_non_top_control(pct_fast, pct_slow, forward, date, int(mid.sum()), domain_ret, sink)
         if int(gate.sum()) >= MIN_GROUP:
             switch_rows.append(
                 {
@@ -169,6 +173,25 @@ def _collect_day(snap, date: int, sink, switch_rows, daily_ic) -> None:
             )
 
 
+def _collect_non_top_control(pct_fast, pct_slow, forward, date: int, size: int, domain_ret: float, sink) -> None:
+    """随机负控制：每天从「两条腿都低于 NON_TOP_CAP 分位」里随机抽 size 只。
+
+    只数与中动量档当日相同，域也只砍掉顶部，因此这一档除了「避开顶部」不含任何
+    选择信息。中动量档比不过它，就说明它的边缘同样只是避开顶部。
+
+    随机数按 (seed, 交易日) 定种，同一天同一种子在多次运行、多个 horizon 之间
+    都取到同一批票，否则各档之间的差值会掺进抽样噪声。
+    """
+    eligible = list(forward.index[(pct_fast < NON_TOP_CAP) & (pct_slow < NON_TOP_CAP)])
+    if len(eligible) < size:
+        return
+    for seed in CONTROL_SEEDS:
+        picks = random.Random(seed * 1_000_003 + date).sample(eligible, size)
+        sink.setdefault(f"__control_{seed}__", []).append(
+            {"date": date, "inside": float(forward[picks].mean()), "domain": domain_ret, "size": float(size)}
+        )
+
+
 def build_report(sink: dict[str, list[dict[str, float]]], daily_ic: list[float], horizon: int) -> MomentumReport:
     report = MomentumReport()
     for fast_min, slow_min in THRESHOLD_GRID:
@@ -177,10 +200,15 @@ def build_report(sink: dict[str, list[dict[str, float]]], daily_ic: list[float],
         report.thresholds.append(summarize_band(label, sink.get(label, []), is_production=is_prod))
     report.mid_band = summarize_band("中动量档 40-65/40-70", sink.get("中动量档", []))
     report.domain = summarize_band("域内基准（对照）", sink.get("__domain__", []))
+    report.controls = [
+        summarize_band(f"随机负控制 <{NON_TOP_CAP:.0f} 分位 seed={seed}", sink.get(f"__control_{seed}__", []))
+        for seed in CONTROL_SEEDS
+    ]
     rows = sink.get("__switch__", [])
+    # horizon 传进去,价差 t 才会按不重叠日算——相邻日的 H 日前向收益共用 H-1 天。
     report.switches = [
-        walk_forward_switch("按市场宽度切换", rows, state_key="breadth", high_is_on=True),
-        walk_forward_switch("按截面离散度切换", rows, state_key="dispersion", high_is_on=False),
+        walk_forward_switch("按市场宽度切换", rows, state_key="breadth", high_is_on=True, horizon=horizon),
+        walk_forward_switch("按截面离散度切换", rows, state_key="dispersion", high_is_on=False, horizon=horizon),
     ]
     report.ic_persistence = ic_persistence(daily_ic, horizon)
     return report

--- a/tests/core/test_momentum_regime_eval.py
+++ b/tests/core/test_momentum_regime_eval.py
@@ -9,12 +9,15 @@ import random
 import pytest
 
 from core.momentum_regime_eval import (
+    CONTROL_SEEDS,
     MIN_DAYS,
+    NON_TOP_CAP,
     PROD_RPS_FAST_MIN,
     PROD_RPS_SLOW_MIN,
     BandStat,
     MomentumReport,
     SwitchStat,
+    control_gap,
     ic_persistence,
     quarter_of,
     render,
@@ -199,7 +202,12 @@ class TestWalkForwardSwitch:
         assert abs(stat.diff_t) < 2.0
         assert stat.verdict == "走前不显著：不可上线"
 
-    def test_significant_diff_is_flagged_for_further_work(self):
+    def test_significant_diff_alone_is_not_enough(self):
+        """全程关闭时 diff 一定显著,但那是纯机械收益,不该判为「走前显著」。
+
+        实测：基线是固定放行闸门,而中动量档全期高出闸门 0.671pct,同关闭率的**随机**
+        开关表就能拿到 t=+3.70~+5.17。所以 diff_t 过线不构成上线理由。
+        """
         n = 200
         # state 恒定 -> current > threshold 为假 -> 全程关闭 -> 全部取 mid,稳定高于 gate。
         rows = _switch_rows(
@@ -210,7 +218,121 @@ class TestWalkForwardSwitch:
         stat = walk_forward_switch("x", rows, state_key="state", warmup=60)
         assert stat.diff == pytest.approx(1.0, abs=0.02)
         assert stat.diff_t is not None and stat.diff_t > 2.0
+        # 全程关闭 -> 没有开启日可比 -> 价差无法检验 -> 不可判定,而非「显著」。
+        assert stat.spread_t is None
+        assert stat.verdict == "机械项未分解：不可判定"
+        assert stat.mechanical == pytest.approx(1.0, abs=0.02)
+        assert stat.timing == pytest.approx(0.0, abs=0.02)
+
+    def test_mechanical_gain_without_timing_is_called_out(self):
+        """开关表与 (mid-gate) 无关时,择时项应归零、价差 t 不显著。"""
+        n = 400
+        rng = random.Random(5)
+        # state 独立于价差 -> 开关表不含水温信息;mid 稳定高于 gate -> diff 仍显著。
+        rows = _switch_rows(
+            [rng.gauss(0.0, 1.0) for _ in range(n)],
+            gates=[0.0] * n,
+            mids=[1.0 + rng.gauss(0.0, 1.0) for _ in range(n)],
+        )
+        stat = walk_forward_switch("x", rows, state_key="state", warmup=60)
+        assert stat.diff_t is not None and stat.diff_t > 2.0
+        assert stat.spread_t is not None and abs(stat.spread_t) < 2.0
+        assert stat.timing == pytest.approx(0.0, abs=0.15)
+        assert stat.verdict == "机械项主导：换档收益而非水温信息"
+
+    def test_real_timing_survives_the_decomposition(self):
+        """开关表真的挑中「价差大」的日子时,价差 t 显著、择时项为正。
+
+        这是「识别水温」的理想情形:把价差做成 state 低时更大,走前中位数切换就会在
+        低 state 关闭,正好落在价差大的日子上。两侧都掺噪声,否则方差为零、Welch t 无解。
+        """
+        n = 400
+        rng = random.Random(3)
+        states = [float(i % 40) for i in range(n)]
+        rows = _switch_rows(
+            states,
+            gates=[0.0] * n,
+            mids=[(2.0 if s < 20 else 0.1) + rng.gauss(0.0, 0.3) for s in states],
+        )
+        stat = walk_forward_switch("x", rows, state_key="state", warmup=60, high_is_on=True)
+        assert stat.spread_t is not None and stat.spread_t > 2.0
+        assert stat.spread_off is not None and stat.spread_on is not None
+        assert stat.spread_off > stat.spread_on
+        assert stat.timing is not None and stat.timing > 0
         assert stat.verdict == "走前显著：值得进一步验证"
+
+    def test_spread_t_uses_non_overlapping_days_only(self):
+        """价差 t 必须按 H+1 步长抽样,否则重叠窗口会把它夸大。
+
+        与 ic_persistence 同一个理由:相邻交易日的 H 日前向收益共用 H-1 天,
+        直接拿全部日子算两样本 t 等于把样本量当成了 H 倍。
+        """
+        n = 600
+        rng = random.Random(9)
+        states = [float(i % 40) for i in range(n)]
+        rows = _switch_rows(
+            states,
+            gates=[0.0] * n,
+            mids=[(2.0 if s < 20 else 0.1) + rng.gauss(0.0, 0.3) for s in states],
+        )
+        daily = walk_forward_switch("x", rows, state_key="state", warmup=60, horizon=1)
+        thinned = walk_forward_switch("x", rows, state_key="state", warmup=60, horizon=10)
+        # 步长 H+1:H=10 用 1/11 的天数,H=1 用 1/2。
+        assert daily.spread_days == pytest.approx((n - 60) // 2, abs=1)
+        assert thinned.spread_days == pytest.approx((n - 60) // 11, abs=1)
+        # 天数变少 -> t 变小,但均值不该变:均值仍用全部日子。
+        assert abs(thinned.spread_t) < abs(daily.spread_t)
+        assert thinned.spread_off == pytest.approx(daily.spread_off)
+        assert thinned.spread_on == pytest.approx(daily.spread_on)
+        # 机械项也用全部日子,不受抽样影响。
+        assert thinned.mechanical == pytest.approx(daily.mechanical)
+        assert thinned.diff == pytest.approx(daily.diff)
+
+    def test_spread_t_reports_the_phase_range(self):
+        """扫遍 H+1 个相位,报中位数并带出区间。单相位的 t 自己就是噪声。"""
+        n = 600
+        rng = random.Random(9)
+        states = [float(i % 40) for i in range(n)]
+        rows = _switch_rows(
+            states,
+            gates=[0.0] * n,
+            mids=[(2.0 if s < 20 else 0.1) + rng.gauss(0.0, 0.3) for s in states],
+        )
+        stat = walk_forward_switch("x", rows, state_key="state", warmup=60, horizon=10)
+        assert stat.spread_t_min is not None and stat.spread_t_max is not None
+        assert stat.spread_t_min <= stat.spread_t <= stat.spread_t_max
+        # 效应够强时,区间下界也该过线——这正是「证据稳」的定义。
+        assert stat.spread_t_min > 2.0
+        assert stat.verdict == "走前显著：值得进一步验证"
+
+    def test_phase_fragile_effect_does_not_pass(self):
+        """效应弱到只有部分相位过线时,判定必须落在「证据不稳」。"""
+        n = 600
+        rng = random.Random(4)
+        states = [float(i % 40) for i in range(n)]
+        # 噪声放大到与信号同量级 -> 相位之间 t 拉开 -> 下界掉到 2 以下。
+        rows = _switch_rows(
+            states,
+            gates=[0.0] * n,
+            mids=[(1.2 if s < 20 else 0.1) + rng.gauss(0.0, 1.6) for s in states],
+        )
+        stat = walk_forward_switch("x", rows, state_key="state", warmup=60, horizon=10)
+        assert stat.spread_t_min is not None and stat.spread_t_min < 2.0
+        assert stat.verdict != "走前显著：值得进一步验证"
+
+    def test_mechanical_plus_timing_equals_diff(self):
+        """分解必须是恒等式,否则表里三列会互相矛盾。"""
+        n = 400
+        rng = random.Random(3)
+        states = [float(i % 40) for i in range(n)]
+        rows = _switch_rows(
+            states,
+            gates=[0.0] * n,
+            mids=[(2.0 if s < 20 else 0.1) + rng.gauss(0.0, 0.3) for s in states],
+        )
+        stat = walk_forward_switch("x", rows, state_key="state", warmup=60)
+        assert stat.mechanical is not None and stat.timing is not None
+        assert stat.mechanical + stat.timing == pytest.approx(stat.diff)
 
     def test_on_rate_by_quarter_is_reported(self):
         """坏季度的开启率是否真的更低,是判断切换设计能不能识别水温的关键。"""
@@ -219,6 +341,44 @@ class TestWalkForwardSwitch:
         stat = walk_forward_switch("x", rows, state_key="state", warmup=60)
         assert stat.on_rate_by_quarter[20251] == pytest.approx(1.0)
         assert stat.on_rate_by_quarter[20252] == pytest.approx(0.0)
+
+
+class TestControlGap:
+    """随机负控制:中动量档的边缘到底是选择信息,还是只是「避开了顶部」。
+
+    第二轮实测中动量档 +0.197,而只避开顶部的随机抽样 5 个种子给出
+    +0.164~+0.210——落在区间内。缺了这个对照就会把 t=5.86 读成选择价值。
+    """
+
+    def _stat(self, excess: float | None) -> BandStat:
+        return BandStat("x", 1079, 255.0, None, None, excess, 5.5)
+
+    def test_mid_inside_control_range_has_no_selection_value(self):
+        gap = control_gap(self._stat(0.197), [self._stat(e) for e in (0.210, 0.164, 0.199)])
+        assert "落在" in gap["verdict"]
+        assert gap["control_excess_min"] == pytest.approx(0.164)
+        assert gap["control_excess_max"] == pytest.approx(0.210)
+
+    def test_gap_within_seed_spread_is_not_a_win(self):
+        """哪怕中动量档在所有种子之上,只要差距不超过种子间宽度就算不上跑赢。"""
+        controls = [self._stat(e) for e in (0.10, 0.30)]
+        gap = control_gap(self._stat(0.35), controls)
+        assert gap["gap"] == pytest.approx(0.15)
+        assert gap["seed_spread"] == pytest.approx(0.20)
+        assert "落在" in gap["verdict"]
+
+    def test_clear_outperformance_is_flagged_for_walk_forward(self):
+        controls = [self._stat(e) for e in (0.10, 0.12)]
+        gap = control_gap(self._stat(1.00), controls)
+        assert "跑赢" in gap["verdict"]
+
+    def test_single_seed_is_insufficient(self):
+        """单种子的一次抽样量不出边缘宽度,不能拿来判定。"""
+        assert control_gap(self._stat(0.197), [self._stat(0.164)])["verdict"] == "样本不足"
+
+    def test_missing_mid_is_insufficient(self):
+        assert control_gap(None, [self._stat(0.1), self._stat(0.2)])["verdict"] == "样本不足"
+        assert control_gap(self._stat(None), [self._stat(0.1), self._stat(0.2)])["verdict"] == "样本不足"
 
 
 class TestIcPersistence:
@@ -268,7 +428,17 @@ def _band(
     )
 
 
-def _report(*, prod_inside_t: float = 0.96, domain_inside_t: float = 1.27, switch_t: float = 0.27) -> MomentumReport:
+def _report(
+    *,
+    prod_inside_t: float = 0.96,
+    domain_inside_t: float = 1.27,
+    switch_t: float = 0.27,
+    spread_t: float = 0.30,
+    spread_t_min: float = 0.08,
+    spread_t_max: float = 1.92,
+    mid_excess: float = 0.197,
+    control_excesses: tuple[float, ...] = (0.210, 0.183, 0.164, 0.199, 0.174),
+) -> MomentumReport:
     report = MomentumReport()
     report.thresholds = [
         _band("75/80", inside=0.51, inside_t=0.88, excess=0.15, excess_t=0.55),
@@ -281,11 +451,39 @@ def _report(*, prod_inside_t: float = 0.96, domain_inside_t: float = 1.27, switc
             is_production=True,
         ),
     ]
-    report.mid_band = _band("中动量档", inside=0.458, inside_t=1.10, excess=0.096, excess_t=1.10)
+    report.mid_band = _band("中动量档", inside=0.559, inside_t=1.10, excess=mid_excess, excess_t=5.86)
     report.domain = _band("流动性域内基准", inside=0.362, inside_t=domain_inside_t, excess=0.0, excess_t=0.0)
     report.domain.by_quarter = {}
+    report.controls = [
+        _band(
+            f"随机负控制 <{NON_TOP_CAP:.0f} 分位 seed={seed}",
+            inside=0.362 + excess,
+            inside_t=1.20,
+            excess=excess,
+            excess_t=5.5,
+        )
+        for seed, excess in zip(CONTROL_SEEDS, control_excesses, strict=True)
+    ]
     report.switches = [
-        SwitchStat("按市场宽度切换", 282, 0.472, 0.432, 0.040, switch_t, 0.38, {20262: 0.35, 20263: 0.43}),
+        SwitchStat(
+            "按市场宽度切换",
+            282,
+            0.472,
+            0.432,
+            0.040,
+            switch_t,
+            0.38,
+            {20262: 0.35, 20263: 0.43},
+            # 机械项占掉大部分差值,是实测形态:1080 天上 diff +0.543 里 +0.345 是机械的。
+            mechanical=0.025,
+            spread_off=0.85,
+            spread_on=0.60,
+            spread_t=spread_t,
+            spread_t_min=spread_t_min,
+            spread_t_max=spread_t_max,
+            # 实测形态:960 天按 H+1=11 步长抽样,每相位 88 天。
+            spread_days=88,
+        ),
     ]
     report.ic_persistence = ic_persistence(_overlapping_ic(horizon=5), horizon=5)
     return report
@@ -316,15 +514,79 @@ class TestRender:
         text = render(_report(), 10)
         assert "不要为了改善均值去调阈值" in text
 
+    def test_control_rows_are_in_the_table(self):
+        text = render(_report(), 10)
+        assert "随机负控制" in text
+        assert f"<{NON_TOP_CAP:.0f} 分位" in text
+
+    def test_mid_matching_control_is_not_proposed_as_a_tier(self):
+        """默认数据就是第二轮实测:中动量档落在控制区间内,不可当档位提案。"""
+        text = render(_report(), 10)
+        assert "只来自避开顶部" in text
+        assert "顶部要躲开" in text
+        assert "不是「越低越好」" in text
+
+    def test_mid_beating_control_asks_for_walk_forward(self):
+        text = render(_report(mid_excess=1.20), 10)
+        assert "需按 walk_forward_switch 的走前口径复核" in text
+        assert "只来自避开顶部" not in text
+
     def test_no_switch_survives_means_keep_fixed(self):
         text = render(_report(switch_t=0.27), 10)
         assert "维持固定放行" in text
         assert "样本内回看显著不算数" in text
 
+    def test_significant_diff_without_spread_is_called_mechanical(self):
+        """差值显著但价差不显著,必须说清赚的是换档、不是水温——否则会被当成上线依据。
+
+        1080 天实测就是这个形态:按市场宽度切换 diff_t=+6.03,但同关闭率的随机开关表
+        给 t=+3.70~+5.17,差值 t 过线本身没有区分力。
+        """
+        text = render(_report(switch_t=2.40, spread_t=0.30), 10)
+        assert "按市场宽度切换" in text
+        assert "赚的是「中动量档比闸门好」这个换档收益" in text
+        assert "同关闭率的随机开关表拿得到同样的钱" in text
+        assert "走前显著" not in text
+
     def test_surviving_switch_is_named(self):
-        text = render(_report(switch_t=2.40), 10)
+        """差值与价差都过线才算幸存,此时才报出择时项。"""
+        text = render(_report(switch_t=2.40, spread_t=3.57, spread_t_min=2.30), 10)
         assert "走前显著" in text
         assert "按市场宽度切换" in text
+        assert "择时项" in text
+
+    def test_phase_dependent_spread_is_flagged_as_unstable(self):
+        """中位数过线但相位区间下界不到 2,必须说清换个相位结论就翻。
+
+        1080 天实测:breadth 的 11 个相位给 +0.08~+1.92,0/11 到 2。中位数单独看
+        会掩盖这一点。
+        """
+        text = render(_report(switch_t=2.40, spread_t=2.10, spread_t_min=0.08, spread_t_max=2.60), 10)
+        assert "相位区间下界不到 2" in text
+        assert "换个不重叠抽样相位结论就翻" in text
+        assert "走前显著" not in text
+
+    def test_spread_t_cell_shows_range_and_day_count(self):
+        """表格里 t 必须带相位区间和不重叠天数,否则读者会当成 days 那么多样本。"""
+        text = render(_report(switch_t=2.40, spread_t=1.38, spread_t_min=0.08, spread_t_max=1.92), 10)
+        assert "+1.38 [+0.08, +1.92]" in text
+        assert "（88天）" in text
+
+    def test_undecidable_switch_is_not_read_as_passing(self):
+        """没有对照日时差值全是机械项,不能落进「均不显著」那句话里蒙混过去。"""
+        report = _report(switch_t=2.40)
+        report.switches[0].spread_t = None
+        report.switches[0].spread_on = None
+        text = render(report, 10)
+        assert "没有对照日" in text
+        assert "不能读成走前通过" in text
+        assert "均不显著" not in text
+
+    def test_switch_table_warns_that_diff_t_is_not_a_test(self):
+        """表下的注必须常驻,否则读者会拿差值 t 当结论。"""
+        text = render(_report(), 10)
+        assert "任何同关闭率的**随机**开关表" in text
+        assert "价差t" in text
 
     def test_cost_threshold_and_walk_forward_are_always_stated(self):
         """任何改动建议都必须带上成本门槛和走前复验要求。"""
@@ -366,8 +628,22 @@ class TestReportSerialization:
         assert "excess_t" in reading
         assert "绝对收益的 t 值" in reading
 
+    def test_reading_note_explains_the_control(self):
+        reading = _report().as_dict()["reading"]
+        assert "避开了顶部" in reading
+        assert f"{NON_TOP_CAP:.0f} 分位" in reading
+
+    def test_control_gap_is_serialized(self):
+        payload = json.loads(json.dumps(_report().as_dict(), ensure_ascii=False))
+        gap = payload["control_gap"]
+        assert gap["seeds"] == len(CONTROL_SEEDS)
+        assert "落在" in gap["verdict"]
+        assert len(payload["controls"]) == len(CONTROL_SEEDS)
+
     def test_empty_report_is_safe(self):
         payload = MomentumReport().as_dict()
         assert payload["thresholds"] == []
         assert payload["mid_band"] is None
+        assert payload["controls"] == []
+        assert payload["control_gap"]["verdict"] == "样本不足"
         assert math.isclose(payload["production"]["rps_slow_min"], PROD_RPS_SLOW_MIN)

--- a/tests/scripts/test_evaluate_momentum_regime.py
+++ b/tests/scripts/test_evaluate_momentum_regime.py
@@ -1,0 +1,93 @@
+"""Tests for the momentum checkup's random negative control sampler.
+
+这个对照组是第二轮唯一能否掉「退到中动量档」的环节：中动量档超额 +0.197（t=5.86）
+看着很硬，但每天从「两条腿都低于 NON_TOP_CAP 分位」随机抽同样只数，5 个种子给出
++0.164~+0.210——无法区分。它的全部边缘来自避开顶部，不含选择信息。
+
+所以采样器有三件事必须守住，否则对照会失效或掺进噪声：
+
+1. **只砍顶部**，域的其余部分不能动，否则比较的就不是同一件事。
+2. **只数与中动量档当日相同**，只数不同会把规模效应读成选择价值。
+3. **同一天同一种子必须取到同一批票**，跨 horizon、跨运行都一致，否则各档之间的
+   差值里会掺进抽样噪声。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.momentum_regime_eval import CONTROL_SEEDS, NON_TOP_CAP
+from scripts.evaluate_momentum_regime import _collect_non_top_control
+
+
+def _cross_section(n: int = 200):
+    """构造截面：两条腿的分位都等于 0..100 的均匀刻度，前向收益等于分位本身。
+
+    forward 与分位同增，因此「避开顶部」必然降低组内均值——这让「域被正确裁剪」
+    这件事可以直接从数值上读出来。
+    """
+    codes = [f"{i:06d}.SZ" for i in range(n)]
+    pct = pd.Series([i * 100.0 / (n - 1) for i in range(n)], index=codes)
+    return pct, pct.copy(), pct.copy()
+
+
+def _run(size: int = 30, date: int = 20260415, domain_ret: float = 0.5, n: int = 200):
+    pct_fast, pct_slow, forward = _cross_section(n)
+    sink: dict[str, list[dict[str, float]]] = {}
+    _collect_non_top_control(pct_fast, pct_slow, forward, date, size, domain_ret, sink)
+    return sink
+
+
+class TestControlSampler:
+    def test_one_row_per_seed(self):
+        sink = _run()
+        assert sorted(sink) == sorted(f"__control_{seed}__" for seed in CONTROL_SEEDS)
+        assert all(len(rows) == 1 for rows in sink.values())
+
+    def test_size_matches_the_mid_band(self):
+        """只数不同会把规模效应读成选择价值。"""
+        sink = _run(size=37)
+        assert all(rows[0]["size"] == pytest.approx(37.0) for rows in sink.values())
+
+    def test_only_the_top_is_removed(self):
+        """抽样域是「两条腿都 < NON_TOP_CAP 分位」，其余部分不能动。
+
+        forward 与分位同增，所以组内均值必须落在裁剪后域的均值附近、明显低于全域。
+        """
+        pct_fast, pct_slow, forward = _cross_section(n=400)
+        eligible = forward[(pct_fast < NON_TOP_CAP) & (pct_slow < NON_TOP_CAP)]
+        sink = _run(size=120, n=400)
+        insides = [rows[0]["inside"] for rows in sink.values()]
+        assert max(insides) < float(forward.mean())
+        # 每个种子都是同一域内的无偏抽样，均值应在域均值附近而非贴着上下界。
+        assert all(abs(v - float(eligible.mean())) < 8.0 for v in insides)
+        assert max(insides) <= float(eligible.max())
+
+    def test_domain_ret_is_passed_through_untouched(self):
+        """对照必须与其它档共用同一个域内基准，否则 excess 不可比。"""
+        sink = _run(domain_ret=-1.25)
+        assert all(rows[0]["domain"] == pytest.approx(-1.25) for rows in sink.values())
+
+    def test_same_seed_and_date_is_reproducible(self):
+        """跨运行、跨 horizon 取到同一批票，否则各档差值里会掺进抽样噪声。"""
+        first = _run()
+        second = _run()
+        for key, rows in first.items():
+            assert rows[0]["inside"] == pytest.approx(second[key][0]["inside"])
+
+    def test_seeds_differ_from_each_other(self):
+        """多种子的意义是量出抽样边缘的宽度，全都相同就白搭了。"""
+        insides = {round(rows[0]["inside"], 6) for rows in _run().values()}
+        assert len(insides) == len(CONTROL_SEEDS)
+
+    def test_dates_differ_from_each_other(self):
+        """同一种子在不同交易日必须换一批票，否则对照会锁死在一次抽样上。"""
+        one = _run(date=20260415)
+        two = _run(date=20260416)
+        assert any(one[k][0]["inside"] != pytest.approx(two[k][0]["inside"]) for k in one)
+
+    def test_too_few_eligible_names_records_nothing(self):
+        """裁剪后不够抽满时整天跳过，不能悄悄抽少了充数。"""
+        sink = _run(size=500)
+        assert sink == {}


### PR DESCRIPTION
## 变更摘要

给动量体检脚本加两道纪律,把两个此前站不住的结论钉死。两个都是同一个统计错误的不同层级:把「机械上必然为正的部分」读成了「信号」。

**本次没有改动任何生产阈值**,只加检验手段与测试。

### 一、中动量档的边缘只是「避开顶部」,不含选择信息

新增随机负控制:每天从「两条腿都低于 80 分位」里随机抽与中动量档**同样只数**,因此它只带「避开顶部」这一条信息。种子按 `(seed, 交易日)` 定住,同一天在多次运行、多个 horizon 之间取到同一批票。

1080 天(2022..2026,H=10)实测:

| | 超额 | t |
| --- | --: | --: |
| 中动量档 | +0.198 | +5.88 |
| 随机负控制 5 个种子 | +0.169 ~ +0.217 | ~+5.5 |

`gap=+0.006`,远小于控制组自身的抽样宽度 `+0.049` → 判定「落在区间内」。

结论:动量可用的内容是**「顶部要躲开」,不是「越低越好」,更不是「退到中动量档」**。中动量档不构成档位提案。这条纪律固化进每次体检,以后不用靠记性。

### 二、`walk_forward_switch` 的 `diff_t` 单独看不是有效检验

基线是固定放行闸门,而中动量档全期高出闸门 0.671pct。于是**任何**关闭约 51% 天数的开关表都会机械地换来 ~0.345pct。实测同关闭率的**随机**开关表给 +0.313~+0.419、**t=+3.70~+5.17** —— 抛硬币就能过 t≥2 的线。

原先按市场宽度切换报 `diff_t=+6.03`,照旧口径读就是一条可上线建议。拆开后:

- 机械项 +0.345(占 64%)、择时项 +0.197
- 判定改看条件价差 `spread_t`(关闭日与开启日的 mid−gate 之差)

`spread_t` 又要过两道:

1. **只用不重叠日**。相邻交易日的 H 日前向收益共用 H−1 天,与 `ic_persistence` 里那个 +0.906 假象同一个病。全样本口径 t=+3.57,不重叠口径 +1.38。
2. **取遍 H+1 个相位报中位数与区间**,单相位自己就是噪声。

| 设计 | 差值t | 机械项 | 择时项 | 价差t(中位 [区间],每相位天数) | 判定 |
| --- | --: | --: | --: | --- | --- |
| 按市场宽度切换 | +6.03 | +0.345 | +0.197 | +1.38 [+0.08, +1.92](88天) | 机械项主导 |
| 按截面离散度切换 | +0.72 | +0.345 | −0.271 | −1.48 [−2.43, −0.86](88天) | 走前不显著 |

**0/11 个相位到 2**。两种动态切换设计都不含可用的水温信息,本次没有上线任何一种。这与配对随机控制独立给出的 +1.61~+2.85 是同一结论,三条路径互相印证。

新增判定档「价差t 依赖抽样相位:证据不稳」——中位数过线但区间下界不到 2 时,换个相位结论就翻,不算站得住。

## 验证

- `tests/core/test_momentum_regime_eval.py` + `tests/scripts/test_evaluate_momentum_regime.py`:**71 passed**。覆盖相位扫描、机械项+择时项恒等式、以及三个判定档各自的正反例(真择时/纯机械/相位不稳/无对照日)。
- `tests/core` + `tests/scripts` 全量:**1250 passed**。
- **接线用生产代码路径复算**(直接调 `_day_snapshot` / `_collect_day` / `build_report`,不重写算法),在 2022..2026 快照上跑出的价差 t 与独立写的相位扫描脚本逐位一致:`+1.38 [+0.08, +1.92]`(88天)。接线若有偏差(域裁剪、只数、种子)会对不上。
- `ruff check` + `ruff format --check` 通过。
- `quality_gate.py --ci` 与 `--check-no-sql` 通过。

## 遗留

CI 里这个 job 默认 `--start 2025-01`(402 天),给出的是「平的」读数;负方向结论只在 1079 天长样本上出现。是否把默认区间拉长,单独议。
