### PR TITLE
fix(web): 前端执行闸门与 Python 下单侧对齐，60/60 组合一致

### DIFF
--- a/web/apps/web/src/lib/__tests__/market-regime-gate.test.ts
+++ b/web/apps/web/src/lib/__tests__/market-regime-gate.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BENCHMARK_BUY_BLOCK_REGIMES,
+  mergePremarketRegime,
+  normalizeRegime,
+  PREMARKET_ESCALATION_REGIMES,
+  resolveExecutionGate,
+} from '@wyckoff/shared'
+
+// 下面这张表是从 Python 侧实跑出来的，命令：
+//   STEP4_BUY_BLOCK_REGIMES="UNKNOWN,NEUTRAL,PANIC_REPAIR,RISK_OFF,CRASH,BLACK_SWAN" \
+//   STEP4_BUY_ALLOW_REGIMES="BEAR_REBOUND" \
+//   .venv/bin/python -c "from core.market_trade_mode import merge_premarket_regime as m; ..."
+// 改 Python 侧后要重跑并同步这张表。
+describe('mergePremarketRegime 与 Python 逐例一致', () => {
+  const cases: Array<[string | null, string | null, string]> = [
+    // 盘前 BLACK_SWAN 是唯一还能收紧的档位。
+    ['NEUTRAL', 'BLACK_SWAN', 'BLACK_SWAN'],
+    ['CAUTION', 'BLACK_SWAN', 'BLACK_SWAN'],
+    // 盘前 RISK_OFF 不再降级：只由单条「VIX 涨幅 >= 8%」触发，而 VIX 是隔夜美股收盘，滞后一天。
+    ['NEUTRAL', 'RISK_OFF', 'NEUTRAL'],
+    // 盘前 UNKNOWN 不再降级：实测 3 天全是外部取数失败，不是「看不清」。
+    ['NEUTRAL', 'UNKNOWN', 'NEUTRAL'],
+    // DATA_GAP / 缺失 / 拼错 / CAUTION 一律回落到收盘态。
+    ['NEUTRAL', 'DATA_GAP', 'NEUTRAL'],
+    ['NEUTRAL', '', 'NEUTRAL'],
+    ['NEUTRAL', null, 'NEUTRAL'],
+    ['NEUTRAL', 'risk_of', 'NEUTRAL'],
+    ['NEUTRAL', 'CAUTION', 'NEUTRAL'],
+    // 大小写与空白不影响判定。
+    [' neutral ', ' black_swan ', 'BLACK_SWAN'],
+    // 收盘态缺失或不在 KNOWN_MARKET_REGIMES 里，一律归 UNKNOWN。
+    [null, 'NORMAL', 'UNKNOWN'],
+    ['NORMAL', 'NORMAL', 'UNKNOWN'],
+    ['typo', 'NORMAL', 'UNKNOWN'],
+  ]
+
+  for (const [benchmark, premarket, expected] of cases) {
+    it(`${JSON.stringify(benchmark)} + ${JSON.stringify(premarket)} -> ${expected}`, () => {
+      expect(mergePremarketRegime(benchmark, premarket)).toBe(expected)
+    })
+  }
+
+  it('盘前只有 BLACK_SWAN 一档能收紧', () => {
+    expect([...PREMARKET_ESCALATION_REGIMES]).toEqual(['BLACK_SWAN'])
+  })
+})
+
+describe('normalizeRegime', () => {
+  it('NORMAL 不是合法收盘态 —— 它只是盘前标签', () => {
+    expect(normalizeRegime('NORMAL')).toBe('UNKNOWN')
+    expect(resolveExecutionGate('NORMAL', 'NORMAL').level).toBe('blocked')
+  })
+
+  it('10 个合法收盘态原样返回', () => {
+    for (const regime of [
+      'RISK_ON', 'NEUTRAL', 'CAUTION', 'BEAR_REBOUND', 'PANIC_REPAIR',
+      'PANIC_REPAIR_CONFIRMED', 'PANIC_REPAIR_INTRADAY', 'RISK_OFF', 'CRASH', 'BLACK_SWAN',
+    ]) {
+      expect(normalizeRegime(regime)).toBe(regime)
+    }
+  })
+})
+
+describe('BENCHMARK_BUY_BLOCK_REGIMES 与生产 env 同口径', () => {
+  // 实跑 oms_buy_block_regimes() 得到:
+  // ['BLACK_SWAN','CRASH','NEUTRAL','PANIC_REPAIR','RISK_OFF','RISK_ON','UNKNOWN']
+  it('名单与 Python oms_buy_block_regimes() 逐项一致', () => {
+    expect([...BENCHMARK_BUY_BLOCK_REGIMES].sort()).toEqual([
+      'BLACK_SWAN', 'CRASH', 'NEUTRAL', 'PANIC_REPAIR', 'RISK_OFF', 'RISK_ON', 'UNKNOWN',
+    ])
+  })
+
+  it('NEUTRAL 禁买 —— 生产 STEP4_BUY_BLOCK_REGIMES 明确加了它', () => {
+    expect(resolveExecutionGate('NEUTRAL', 'NORMAL').level).toBe('blocked')
+  })
+
+  it('BEAR_REBOUND 被 STEP4_BUY_ALLOW_REGIMES 豁免,不禁买', () => {
+    expect(BENCHMARK_BUY_BLOCK_REGIMES.has('BEAR_REBOUND')).toBe(false)
+    expect(resolveExecutionGate('BEAR_REBOUND', 'NORMAL').level).toBe('allowed')
+  })
+})
+
+describe('resolveExecutionGate', () => {
+  it('CAUTION 只放二次确认后的 PROBE', () => {
+    const gate = resolveExecutionGate('CAUTION', 'NORMAL')
+    expect(gate.level).toBe('probe_only')
+    expect(gate.text).toContain('PROBE')
+  })
+
+  it('盘前 CAUTION 不再单独触发 PROBE 档 —— 收盘态说了算', () => {
+    expect(resolveExecutionGate('BEAR_REBOUND', 'CAUTION').level).toBe('allowed')
+  })
+
+  it('禁买优先于 PROBE —— 盘前 BLACK_SWAN 压过收盘 CAUTION', () => {
+    const gate = resolveExecutionGate('CAUTION', 'BLACK_SWAN')
+    expect(gate.effectiveRegime).toBe('BLACK_SWAN')
+    expect(gate.level).toBe('blocked')
+  })
+
+  it('PANIC_REPAIR_CONFIRMED 走 PROBE,不是禁买', () => {
+    expect(resolveExecutionGate('PANIC_REPAIR_CONFIRMED', 'NORMAL').level).toBe('probe_only')
+  })
+})

--- a/web/packages/shared/src/chat-tools.ts
+++ b/web/packages/shared/src/chat-tools.ts
@@ -13,6 +13,7 @@ import {
   type ValueSnapshot,
 } from './agent-market'
 import { buildValuePrompt, buildValueScore } from './agent-value'
+import { resolveExecutionGate } from './market-regime-gate'
 import { checkPriceBasis, formatPriceBasisNote } from './price-basis'
 import {
   attributionFormalDynamicLabel,
@@ -626,14 +627,7 @@ export async function execMarketOverview(deps: ToolDeps): Promise<string> {
   }
   const regime = String(merged.benchmark_regime || 'UNKNOWN').toUpperCase()
   const premarket = String(merged.premarket_regime || 'UNKNOWN').toUpperCase()
-  const blockedRegimes = new Set(['UNKNOWN', 'RISK_ON', 'BEAR_REBOUND', 'PANIC_REPAIR', 'RISK_OFF', 'CRASH', 'BLACK_SWAN'])
-  const hardPremarket = new Set(['UNKNOWN', 'RISK_OFF', 'BLACK_SWAN'])
-  const blocked = blockedRegimes.has(regime) || hardPremarket.has(premarket)
-  const executionGate = blocked
-    ? '执行闸门：禁止新开仓，只管理已有仓位'
-    : premarket === 'CAUTION' || regime === 'CAUTION'
-      ? '执行闸门：仅允许二次确认后的 PROBE，禁止 ATTACK'
-      : '执行闸门：允许 confirmed 候选进入 OMS 复核'
+  const executionGate = resolveExecutionGate(regime, premarket).text
   const close = Number(merged.main_index_close || 0)
   const pct = Number(merged.main_index_today_pct || 0)
   const a50Close = Number(merged.a50_close || 0)

--- a/web/packages/shared/src/index.ts
+++ b/web/packages/shared/src/index.ts
@@ -66,6 +66,16 @@ export {
 export { MARKET_WATCH_CACHE_TTL_MS } from './market-watch'
 export type { MarketWatchQuote, MarketWatchSnapshot, MarketWatchState } from './market-watch'
 export {
+  BENCHMARK_BUY_BLOCK_REGIMES,
+  KNOWN_MARKET_REGIMES,
+  mergePremarketRegime,
+  normalizeRegime,
+  PREMARKET_ESCALATION_REGIMES,
+  PROBE_ONLY_REGIMES,
+  resolveExecutionGate,
+} from './market-regime-gate'
+export type { ExecutionGate, ExecutionGateLevel } from './market-regime-gate'
+export {
   assessTradingDay,
   formatSessionClockContext,
   resolveSessionClock,

--- a/web/packages/shared/src/market-regime-gate.ts
+++ b/web/packages/shared/src/market-regime-gate.ts
@@ -1,0 +1,127 @@
+/**
+ * 前端展示用的执行闸门判定 —— 必须与 Python 执行侧同口径。
+ *
+ * 为什么单独成文件：`chat-tools.ts` 里原先内联了一份自算闸门，与真正下单的
+ * Python 侧三处不一致，于是 chat 报的「执行闸门」和系统实际行为对不上：
+ *
+ * 1. 盘前 `UNKNOWN` / `RISK_OFF` 被当成硬禁买。这两条路径 Python 侧已按实测
+ *    裁掉（见 `core/market_trade_mode.py` 的 `merge_premarket_regime`）：3 个
+ *    盘前 UNKNOWN 日全部是外部取数失败而非「看不清」，08-17 一天就白扔了 71 只
+ *    formal_l4 / 168 只候选；3 个 RISK_OFF 日全由单条「VIX 涨幅 >= 8%」触发，
+ *    而 VIX 取的是隔夜美股收盘，天然滞后一天。
+ * 2. 收盘态漏了 `NEUTRAL`。生产 `STEP4_BUY_BLOCK_REGIMES` 含 NEUTRAL，实际禁买，
+ *    前端却报「允许进入 OMS 复核」。
+ * 3. 收盘态多了 `BEAR_REBOUND`。生产 `STEP4_BUY_ALLOW_REGIMES=BEAR_REBOUND`
+ *    显式豁免，实际放行，前端却报禁止新开仓。
+ *
+ * `integrations/supabase_market_signal.py` 已经因为同款自算翻过两次车（生产实测
+ * 06-18 / 08-07 / 08-17 三天横幅与 trade mode 直接相反），修法都是「不自算，改调
+ * merge_premarket_regime + resolve_market_trade_mode」。前端读不到 env、也读不到
+ * 那两个函数（`action_phrase` 那组结构化列在写失败时会被整组剥掉，不能当作稳定
+ * 数据源），只能重算一份；那就把它收敂到这里，用测试锁住与 Python 的一致性。
+ *
+ * 改这里之前先改 Python 侧：本文件是镜像，不是真源。
+ */
+
+/**
+ * 盘前态唯一还能收紧执行权限的档位。
+ * 镜像 `core/market_trade_mode.py` 的 `PREMARKET_ESCALATION_REGIMES`。
+ */
+export const PREMARKET_ESCALATION_REGIMES: ReadonlySet<string> = new Set(['BLACK_SWAN'])
+
+/**
+ * 合法收盘态。镜像 `core/market_trade_mode.py` 的 `KNOWN_MARKET_REGIMES`。
+ *
+ * 注意不含 `NORMAL`：那是盘前态专用标签（「隔夜外部冲击相对平稳」），
+ * 收盘态只由 `tools/market_regime.py` 产出这 10 个值。收盘态拿到表外的值
+ * （含 NORMAL）按 `normalize_regime` 一律归成 UNKNOWN，即禁买。
+ */
+export const KNOWN_MARKET_REGIMES: ReadonlySet<string> = new Set([
+  'RISK_ON',
+  'NEUTRAL',
+  'CAUTION',
+  'BEAR_REBOUND',
+  'PANIC_REPAIR',
+  'PANIC_REPAIR_CONFIRMED',
+  'PANIC_REPAIR_INTRADAY',
+  'RISK_OFF',
+  'CRASH',
+  'BLACK_SWAN',
+])
+
+/** 镜像 `core/market_trade_mode.py` 的 `normalize_regime`。 */
+export function normalizeRegime(regime: string | null | undefined): string {
+  const normalized = String(regime || '').trim().toUpperCase()
+  return KNOWN_MARKET_REGIMES.has(normalized) ? normalized : 'UNKNOWN'
+}
+
+/**
+ * 收盘态禁止新开仓的水温。
+ *
+ * 镜像 `core/market_trade_mode.py` 的 `oms_buy_block_regimes()` 在生产 env 下的取值：
+ * `EXECUTE_BLOCK_NEW_BUY_REGIMES`（UNKNOWN/RISK_OFF/CRASH/BLACK_SWAN/RISK_ON/
+ * BEAR_REBOUND/PANIC_REPAIR）并上 `STEP4_BUY_BLOCK_REGIMES`（额外加 NEUTRAL）,
+ * 再减去 `STEP4_BUY_ALLOW_REGIMES`（BEAR_REBOUND）。
+ *
+ * env 由 `.github/workflows/wyckoff_funnel.yml` 与 `step4_from_supabase.yml` 提供。
+ * 运维改动那两个变量时，这里要跟着改——`web/packages/shared/src/market-regime-gate.test.ts`
+ * 会把当前口径钉住，不同步就会红。
+ */
+export const BENCHMARK_BUY_BLOCK_REGIMES: ReadonlySet<string> = new Set([
+  'UNKNOWN',
+  'NEUTRAL',
+  'RISK_ON',
+  'PANIC_REPAIR',
+  'RISK_OFF',
+  'CRASH',
+  'BLACK_SWAN',
+])
+
+/**
+ * 只允许二次确认后小额 PROBE 的水温。
+ * 镜像 `core/market_trade_mode.py` 的 `PROBE_ONLY_REGIMES`。
+ */
+export const PROBE_ONLY_REGIMES: ReadonlySet<string> = new Set([
+  'CAUTION',
+  'PANIC_REPAIR_CONFIRMED',
+  'PANIC_REPAIR_INTRADAY',
+])
+
+/**
+ * 合并收盘态与盘前态，得出实际生效的水温。
+ * 镜像 `core/market_trade_mode.py` 的 `merge_premarket_regime`：盘前态只有落在
+ * `PREMARKET_ESCALATION_REGIMES` 时才生效，其余（RISK_OFF / UNKNOWN / CAUTION /
+ * DATA_GAP / 缺失 / 拼错）一律回落到收盘态。
+ */
+export function mergePremarketRegime(benchmark: string | null | undefined, premarket: string | null | undefined): string {
+  const benchmarkNorm = normalizeRegime(benchmark)
+  const premarketNorm = String(premarket || '').trim().toUpperCase()
+  if (!PREMARKET_ESCALATION_REGIMES.has(premarketNorm)) return benchmarkNorm
+  // BLACK_SWAN 是 MARKET_EXECUTION_PRIORITY 里最严的一档（优先级 0），收紧即取它。
+  return 'BLACK_SWAN'
+}
+
+export type ExecutionGateLevel = 'blocked' | 'probe_only' | 'allowed'
+
+export interface ExecutionGate {
+  /** 合并后实际生效的水温。 */
+  effectiveRegime: string
+  level: ExecutionGateLevel
+  /** 给用户看的一行说明。 */
+  text: string
+}
+
+/** 按收盘态 + 盘前态算出执行闸门。 */
+export function resolveExecutionGate(
+  benchmark: string | null | undefined,
+  premarket: string | null | undefined,
+): ExecutionGate {
+  const effectiveRegime = mergePremarketRegime(benchmark, premarket)
+  if (BENCHMARK_BUY_BLOCK_REGIMES.has(effectiveRegime)) {
+    return { effectiveRegime, level: 'blocked', text: '执行闸门：禁止新开仓，只管理已有仓位' }
+  }
+  if (PROBE_ONLY_REGIMES.has(effectiveRegime)) {
+    return { effectiveRegime, level: 'probe_only', text: '执行闸门：仅允许二次确认后的 PROBE，禁止 ATTACK' }
+  }
+  return { effectiveRegime, level: 'allowed', text: '执行闸门：允许 confirmed 候选进入 OMS 复核' }
+}


### PR DESCRIPTION
## 变更摘要

chat 的 `market_overview` 里内联了一份自算执行闸门，与真正决定能不能买的 Python 侧不一致，用户看到的「执行闸门」和系统实际行为对不上。把判定收敂到 `web/packages/shared/src/market-regime-gate.ts`，并用测试钉住与 Python 的一致性。

**10 个收盘态 × 6 个盘前态共 60 种组合，改前 18 格判定错误，改后 60/60 与 Python 完全一致。**

## 错在哪

`web/packages/shared/src/chat-tools.ts` 原先这两行自己算：

```ts
const blockedRegimes = new Set(['UNKNOWN','RISK_ON','BEAR_REBOUND','PANIC_REPAIR','RISK_OFF','CRASH','BLACK_SWAN'])
const hardPremarket = new Set(['UNKNOWN','RISK_OFF','BLACK_SWAN'])
```

四处偏差：

1. **盘前 `UNKNOWN` / `RISK_OFF` 被当成硬禁买。** 这两条路径 Python 侧已按实测裁掉（`core/market_trade_mode.py` 的 `merge_premarket_regime`）：3 个盘前 UNKNOWN 日全部是外部取数失败而非「看不清」，08-17 一天就白扔了 71 只 formal_l4 / 168 只候选；3 个 RISK_OFF 日全由单条「VIX 涨幅 >= 8%」触发，而 VIX 取的是隔夜美股收盘，天然滞后一天。
2. **收盘态漏了 `NEUTRAL`。** 生产 `STEP4_BUY_BLOCK_REGIMES` 含 NEUTRAL，实际禁买，前端却报「允许进入 OMS 复核」。
3. **收盘态多了 `BEAR_REBOUND`。** 生产 `STEP4_BUY_ALLOW_REGIMES=BEAR_REBOUND` 显式豁免，实际放行，前端却报禁止新开仓。
4. **漏了 `normalize_regime`。** `NORMAL` 不是合法收盘态（只是盘前标签），Python 会归成 `UNKNOWN` 即禁买，前端直接放行。

这与 memory 里记的 `two-gates-must-share-one-source` 是同一类缺陷，也是同款自算第三次翻车——`integrations/supabase_market_signal.py:360-370` 的注释记着前两轮（生产实测 06-18 / 08-07 / 08-17 三天横幅与 trade mode 直接相反），两次修法都是「不自算，改调 `merge_premarket_regime` + `resolve_market_trade_mode`」。

## 为什么还是重算，而不是读结论

- 前端读不到 `STEP4_BUY_BLOCK_REGIMES` / `STEP4_BUY_ALLOW_REGIMES`：`@wyckoff/shared` 全包不碰 `process.env`（会被打进 bundle）。
- 也不能读库里 Python 已算好的 `action_phrase`：那组结构化列在 `_write_merged_row` 写失败时会被整组剥掉（`STRUCTURED_MARKET_SIGNAL_FIELDS` fallback），不是稳定数据源。

所以只能在 TS 侧镜像一份。新文件开头写明「本文件是镜像不是真源，改这里之前先改 Python」，硬编码值逐条标注对应的 Python 常量与生产 env 来源，运维改那两个变量时测试会红。

## 判定改变的 18 格

| 收盘态 | 盘前态 | 旧 | 新 |
|---|---|---|---|
| NEUTRAL | NORMAL / DATA_GAP | allowed | **blocked** |
| NEUTRAL | CAUTION | probe_only | **blocked** |
| CAUTION | RISK_OFF / UNKNOWN | blocked | **probe_only** |
| BEAR_REBOUND | NORMAL / CAUTION / RISK_OFF / UNKNOWN / DATA_GAP | blocked | **allowed** |
| PANIC_REPAIR_CONFIRMED | NORMAL / DATA_GAP | allowed | **probe_only** |
| PANIC_REPAIR_CONFIRMED | RISK_OFF / UNKNOWN | blocked | **probe_only** |
| PANIC_REPAIR_INTRADAY | NORMAL / DATA_GAP | allowed | **probe_only** |
| PANIC_REPAIR_INTRADAY | RISK_OFF / UNKNOWN | blocked | **probe_only** |

两个方向都有：NEUTRAL 那三格是**旧版漏报禁买**（用户以为能买，实际买不到，正是 `two-gates` 那 16 行的同款体验），BEAR_REBOUND 那五格是**旧版误报禁买**（用户以为空仓，实际系统在放行）。

## 影响面

只改展示文案，不碰任何执行路径——`resolveExecutionGate` 唯一消费者是 `market_overview` 返回给用户的那行字。Python 的下单与写入闸门一行未动。

## 验证

- 逐格对照：60 种组合各自跑 Python `merge_premarket_regime` + `oms_buy_block_regimes()`（生产 env）与 TS `resolveExecutionGate`，`diff` 为空。
- 新增 23 个测试全通过，含从 Python 实跑出来的逐例对照表。
- `web` 44 files / 293 tests 全绿；`api` 19 files / 128 passed 2 skipped。
- `@wyckoff/shared` `tsc --noEmit` 干净。
- `tests/core/test_market_trade_mode.py` + `tests/integrations/test_supabase_market_signal.py` 27 passed。
- no-sql 闸门通过。
- `apps/web` eslint 的 6 个报错（`public/sw.js`、`routes/settings.tsx`）在干净 main 上同样存在，与本次改动无关，未一并修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
