### PR TITLE
test(funnel): 漏斗选股效果检验(配对对照+随机负控制)

### DIFF
--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -1,0 +1,338 @@
+"""漏斗产出的选股效果检验：配对对照 + 随机负控制。
+
+与既有评估脚本的分工
+--------------------
+``evaluate_gated_regime_candidates.py`` 按 regime 切分候选，每档只剩 8~15 天，
+过不了 ``MIN_DAYS=20``；且它的基准是「同日全市场等权」。在 2026-06~08 这段
+样本里全市场本身大跌，用它当基准会把「跟跌少一点」读成选股能力
+（full-market-control-confounds-momentum 记的坑）。
+
+本模块换两处口径：
+
+1. **不按 regime 切**，先回答「漏斗整体有没有选股能力」。regime 只作为分组
+   附注，不作为主结论的切分维度。
+2. **对照组用「T 日已知 20 日涨幅最近邻 1:1 无放回配对」的非候选股**。候选
+   天然偏高动量，全市场等权对照会把动量的 beta 混进来。配对后残差动量应接近 0，
+   报告里给出实测值供核对。
+3. **随机负控制**：每天从「与候选同动量分位区间」随机抽同样只数。配对超额若
+   落在多种子随机控制的区间内，说明它只是「站在了那个动量位置上」，不含选股
+   信息。这一条照 momentum_regime_eval 的做法固化进每次体检，不可省。
+
+买点 T+1 开盘（漏斗信号收盘后产出，最早可成交是次日开盘），卖点 T+1+H 收盘，
+扣 ROUND_TRIP_COST_PCT=0.202%，按交易日等权汇总。
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from statistics import mean
+from typing import Any
+
+from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
+
+# 每日最少命中数，低于此的日子不进汇总（单只票的日子噪声过大）。
+MIN_HITS_PER_DAY = 3
+# 最少交易日数。低于此只报样本量，不下判定。
+MIN_DAYS = 20
+# 随机负控制的种子。多种子是为了看边缘是否稳定，单种子的一次抽样不足以判定。
+CONTROL_SEEDS = (11, 23, 37, 53, 71)
+# 配对时允许的 20 日动量绝对偏差上限（百分点）。超出即视为无可配对对象。
+MOM_MATCH_TOL_PCT = 3.0
+
+
+def tstat(values: list[float]) -> float | None:
+    if len(values) < 3:
+        return None
+    avg = mean(values)
+    var = sum((v - avg) ** 2 for v in values) / (len(values) - 1)
+    if var <= 0:
+        return None
+    return avg / ((var / len(values)) ** 0.5)
+
+
+def _round(value: float | None, digits: int = 4) -> float | None:
+    return None if value is None else round(float(value), digits)
+
+
+@dataclass
+class GroupStat:
+    """一组标的（候选 / 配对对照 / 随机控制）的逐日汇总。"""
+
+    label: str
+    days: int
+    avg_size: float
+    net_pct: float | None
+    control_pct: float | None
+    excess_pct: float | None
+    excess_t: float | None
+    positive_day_pct: float | None
+    residual_mom_pct: float | None
+    by_quarter: dict[int, float] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "days": self.days,
+            "avg_size": _round(self.avg_size, 1),
+            "net_pct": _round(self.net_pct),
+            "control_pct": _round(self.control_pct),
+            "excess_pct": _round(self.excess_pct),
+            "excess_t": _round(self.excess_t, 2),
+            "positive_day_pct": _round(self.positive_day_pct, 1),
+            "residual_mom_pct": _round(self.residual_mom_pct, 3),
+            "by_quarter": {str(q): _round(v, 3) for q, v in sorted(self.by_quarter.items())},
+        }
+
+
+def summarize_group(label: str, daily: list[dict[str, float]]) -> GroupStat:
+    """按交易日等权汇总。命中个股多的日子不该主导均值。"""
+    usable = [
+        row
+        for row in daily
+        if row.get("net") is not None and row.get("control") is not None and (row.get("size") or 0) >= MIN_HITS_PER_DAY
+    ]
+    if len(usable) < MIN_DAYS:
+        return GroupStat(label, len(usable), 0.0, None, None, None, None, None, None)
+    nets = [float(r["net"]) for r in usable]
+    diffs = [float(r["net"]) - float(r["control"]) for r in usable]
+    moms = [float(r["residual_mom"]) for r in usable if r.get("residual_mom") is not None]
+    by_quarter: dict[int, list[float]] = {}
+    for row, diff in zip(usable, diffs, strict=True):
+        by_quarter.setdefault(_quarter_of(str(row["date"])), []).append(diff)
+    return GroupStat(
+        label=label,
+        days=len(usable),
+        avg_size=mean(float(r.get("size") or 0) for r in usable),
+        net_pct=mean(nets),
+        control_pct=mean(float(r["control"]) for r in usable),
+        excess_pct=mean(diffs),
+        excess_t=tstat(diffs),
+        positive_day_pct=100.0 * sum(1 for d in diffs if d > 0) / len(diffs),
+        residual_mom_pct=mean(moms) if moms else None,
+        by_quarter={q: mean(v) for q, v in by_quarter.items()},
+    )
+
+
+def _quarter_of(ds: str) -> int:
+    """'2026-08-31' -> 20263。用于看超额是否只来自某一个季度。"""
+    year, month = int(ds[:4]), int(ds[5:7])
+    return year * 10 + (month - 1) // 3 + 1
+
+
+def match_by_momentum(
+    hits: list[str],
+    pool: list[str],
+    mom: dict[str, float],
+    *,
+    tol_pct: float = MOM_MATCH_TOL_PCT,
+) -> list[tuple[str, str]]:
+    """按 T 日已知的 20 日涨幅做 1:1 无放回最近邻配对。
+
+    只用 T 日及之前的数据算动量，不含任何前视。无放回是为了避免少数「动量正好
+    落在候选密集区」的对照股被反复选中而放大它自身的特异噪声。偏差超过
+    ``tol_pct`` 视为找不到可比对象，该候选**不进入配对样本**——宁可少算几只，
+    也不要拿动量差 10 个点的票当对照。
+    """
+    avail = sorted((mom[c], c) for c in pool if c in mom)
+    pairs: list[tuple[str, str]] = []
+    for code in sorted(hits, key=lambda c: mom.get(c, 0.0)):
+        if code not in mom or not avail:
+            continue
+        target = mom[code]
+        best_i = min(range(len(avail)), key=lambda i: abs(avail[i][0] - target))
+        if abs(avail[best_i][0] - target) > tol_pct:
+            continue
+        pairs.append((code, avail.pop(best_i)[1]))
+    return pairs
+
+
+def sample_momentum_band(
+    hits: list[str],
+    pool: list[str],
+    mom: dict[str, float],
+    *,
+    seed: int,
+    date: str,
+    tol_pct: float = MOM_MATCH_TOL_PCT,
+) -> list[str]:
+    """随机负控制：为每只候选在「同动量邻域内」随机抽一只非候选股。
+
+    第一版从候选动量的 [min, max] 区间里均匀抽，实测控制组残差动量 +6.1~+8.8pct
+    ——候选动量分布右偏，均匀抽必然系统性偏低，那样的控制组不是干净对照，而是
+    一个动量低 8 个点的更弱对手，它的「超额」里混着动量差，拿来跟配对超额比是
+    错的。改成逐只在 ±tol_pct 邻域内随机替换，让控制组的残差动量同样归零：这样
+    控制组与配对组唯一的差别只是「邻域内选哪一只」——随机 vs 漏斗。
+
+    无放回，理由同 match_by_momentum。种子按 (seed, date) 混合，避免所有日子
+    共用一次抽样序列。
+    """
+    rng = random.Random(f"{seed}:{date}")
+    avail = sorted((mom[c], c) for c in pool if c in mom)
+    picked: list[str] = []
+    for code in sorted(hits, key=lambda c: mom.get(c, 0.0)):
+        if code not in mom or not avail:
+            continue
+        target = mom[code]
+        lo = _bisect_left(avail, target - tol_pct)
+        hi = _bisect_left(avail, target + tol_pct)
+        if hi <= lo:
+            continue
+        idx = rng.randrange(lo, hi)
+        picked.append(avail.pop(idx)[1])
+    return picked
+
+
+def _bisect_left(pairs: list[tuple[float, str]], value: float) -> int:
+    lo, hi = 0, len(pairs)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if pairs[mid][0] < value:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+@dataclass
+class Panels:
+    """行情面板。open/close 按日索引，liquid 是当日流动性池，mom20 是 T 日已知 20 日涨幅。"""
+
+    open: dict[str, dict[str, float]]
+    close: dict[str, dict[str, float]]
+    liquid: dict[str, set[str]]
+    mom20: dict[str, dict[str, float]]
+    dates: list[str]
+
+    def window(self, signal_ds: str, horizon: int) -> tuple[str, str] | None:
+        """T+1 开盘买、T+1+horizon 收盘卖。窗口越界返回 None。"""
+        if signal_ds not in self.dates:
+            return None
+        idx = self.dates.index(signal_ds)
+        buy_i, sell_i = idx + 1, idx + 1 + horizon
+        if sell_i >= len(self.dates):
+            return None
+        return self.dates[buy_i], self.dates[sell_i]
+
+    def gross_return(self, codes: list[str], buy_ds: str, sell_ds: str) -> float | None:
+        """等权毛收益（%），未扣成本。"""
+        opens, closes = self.open.get(buy_ds, {}), self.close.get(sell_ds, {})
+        rets = []
+        for code in codes:
+            o, c = opens.get(code), closes.get(code)
+            if o and c and o > 0:
+                rets.append(100.0 * (c / o - 1.0))
+        return mean(rets) if rets else None
+
+
+def resolve_layer(day: dict, universe: set[str], layer: str) -> tuple[list[str], list[str]]:
+    """把「测哪一层」翻成 (待测组, 对照池)。
+
+    - ``formal_l4`` / ``all``：对照池是全市场里的非候选股，答「漏斗产出 vs 场内同侪」。
+    - ``l4_vs_rest``：对照池是宽池内**未进 L4** 的候选，答「L4 这道筛本身有没有用」。
+      这一层最能隔离筛的贡献：两组都已过了宽池入口，差别只在 L4。
+    """
+    wide = set(day.get("all") or []) & universe
+    l4 = set(day.get("formal_l4") or []) & universe
+    if layer == "l4_vs_rest":
+        return sorted(l4), sorted(wide - l4)
+    hits = sorted(l4 if layer == "formal_l4" else wide)
+    return hits, sorted(universe - wide)
+
+
+def evaluate_daily(
+    cands: dict[str, dict],
+    panels: Panels,
+    horizon: int,
+    *,
+    status: str = "formal_l4",
+    seeds: tuple[int, ...] = CONTROL_SEEDS,
+) -> dict[str, list[dict]]:
+    """逐日算候选、配对对照、各随机控制的收益。
+
+    成本对候选和对照同样扣：两边都是一次往返，比较的是选股而非交易频率。
+    """
+    rows: dict[str, list[dict]] = {"matched": [], **{f"control_{s}": [] for s in seeds}}
+    for ds in sorted(cands):
+        win = panels.window(ds, horizon)
+        if win is None:
+            continue
+        buy_ds, sell_ds = win
+        universe = panels.liquid.get(ds, set())
+        mom = panels.mom20.get(ds, {})
+        hits, pool = resolve_layer(cands[ds], universe, status)
+        if len(hits) < MIN_HITS_PER_DAY:
+            continue
+
+        # 随机控制必须与配对组用同一批候选（paired_hits），否则两者分母不同、
+        # 超额不可直接比较——这是把「配对超额 vs 随机超额」摆在一起的前提。
+        pairs = match_by_momentum(hits, pool, mom)
+        if len(pairs) < MIN_HITS_PER_DAY:
+            continue
+        paired_hits = [p[0] for p in pairs]
+        paired_ctrl = [p[1] for p in pairs]
+        hit_ret = panels.gross_return(paired_hits, buy_ds, sell_ds)
+        if hit_ret is None:
+            continue
+
+        ctl = panels.gross_return(paired_ctrl, buy_ds, sell_ds)
+        if ctl is not None:
+            rows["matched"].append(
+                {
+                    "date": ds,
+                    "size": len(pairs),
+                    # 两边都扣成本，故超额里成本抵消；net/control 本身仍是净值口径
+                    "net": hit_ret - ROUND_TRIP_COST_PCT,
+                    "control": ctl - ROUND_TRIP_COST_PCT,
+                    "residual_mom": mean(mom[h] for h in paired_hits) - mean(mom[c] for c in paired_ctrl),
+                }
+            )
+
+        for seed in seeds:
+            band = sample_momentum_band(paired_hits, pool, mom, seed=seed, date=ds)
+            if len(band) < MIN_HITS_PER_DAY:
+                continue
+            ctl = panels.gross_return(band, buy_ds, sell_ds)
+            if ctl is None:
+                continue
+            rows[f"control_{seed}"].append(
+                {
+                    "date": ds,
+                    "size": len(band),
+                    "net": hit_ret - ROUND_TRIP_COST_PCT,
+                    "control": ctl - ROUND_TRIP_COST_PCT,
+                    "residual_mom": mean(mom[h] for h in paired_hits if h in mom)
+                    - mean(mom[c] for c in band if c in mom),
+                }
+            )
+    return rows
+
+
+def control_gap(matched: GroupStat, controls: list[GroupStat]) -> dict[str, Any]:
+    """配对超额相对随机负控制的差距。
+
+    控制组每天从「候选动量区间内」随机抽同样只数，只带动量选位这一条信息。
+    配对超额若落在控制组区间内、或差距小于控制组自身的抽样宽度，就不能说漏斗
+    含选股信息——这是唯一能否掉「漏斗有效」的环节。
+    """
+    usable = [c.excess_pct for c in controls if c.excess_pct is not None]
+    if matched.excess_pct is None or len(usable) < 2:
+        return {"verdict": "样本不足", "seeds": len(usable)}
+    avg = mean(usable)
+    spread = max(usable) - min(usable)
+    gap = matched.excess_pct - avg
+    inside = min(usable) <= matched.excess_pct <= max(usable)
+    return {
+        "seeds": len(usable),
+        "matched_excess": _round(matched.excess_pct),
+        "control_excess_avg": _round(avg),
+        "control_excess_min": _round(min(usable)),
+        "control_excess_max": _round(max(usable)),
+        "seed_spread": _round(spread),
+        "gap": _round(gap),
+        "verdict": (
+            "配对超额落在随机负控制区间内：边缘仅来自动量选位，不含选股信息"
+            if inside or gap <= spread
+            else "配对超额跑赢随机负控制：含独立选股信息"
+        ),
+    }

--- a/scripts/evaluate_funnel_effect.py
+++ b/scripts/evaluate_funnel_effect.py
@@ -1,0 +1,179 @@
+"""漏斗产出的选股效果检验（配对对照 + 随机负控制）。
+
+回答的问题：漏斗每天挑出来的那批票，相对「同动量的非候选股」有没有超额？
+
+为什么不用 evaluate_gated_regime_candidates.py：它按 regime 切分，每档只剩
+8~15 天过不了 MIN_DAYS=20；且基准是同日全市场等权，在本段样本里全市场大跌，
+会把「跟跌少一点」读成选股能力。本脚本换成最近邻动量配对，并强制带随机负控制。
+
+用法：
+    python scripts/backtest_snapshot_fetch.py --start 2026-01-01 --end 2026-09-01 \
+        --board all --output-dir /tmp/funnel_snap
+    python scripts/evaluate_funnel_effect.py \
+        --cands /tmp/funnel_cands.json --cache /tmp/funnel_snap/hist_full.csv.gz \
+        --status formal_l4 --horizons 5,10,20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import _bootstrap  # noqa: F401
+import pandas as pd
+
+from core.funnel_effect_eval import (
+    CONTROL_SEEDS,
+    MIN_DAYS,
+    MOM_MATCH_TOL_PCT,
+    Panels,
+    control_gap,
+    evaluate_daily,
+    summarize_group,
+)
+from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="漏斗选股效果检验")
+    parser.add_argument("--cands", required=True, help="候选 JSON：{date: {regime, formal_l4[], all[]}}")
+    parser.add_argument("--cache", required=True, help="行情快照 hist_full.csv.gz 或 tushare CSV")
+    parser.add_argument(
+        "--status",
+        default="formal_l4",
+        choices=("formal_l4", "all", "l4_vs_rest"),
+        help="测哪一层：formal_l4/all 对照非候选股；l4_vs_rest 在宽池内比 L4 与非 L4",
+    )
+    parser.add_argument("--horizons", default="5,10,20", help="持有期，逗号分隔")
+    parser.add_argument("--min-amount-wan", type=float, default=8000.0, help="20 日均额下限（万元）")
+    parser.add_argument("--json-out", default="", help="结构化结果输出路径")
+    return parser.parse_args()
+
+
+def load_market(path: str) -> pd.DataFrame:
+    """兼容两种列名：快照的 date/symbol/amount(元)，与 tushare 的 trade_date/ts_code/amount(千元)。"""
+    head = pd.read_csv(path, nrows=1)
+    if "symbol" in head.columns:
+        frame = pd.read_csv(path, usecols=["date", "open", "close", "amount", "symbol"])
+        frame["code"] = frame.symbol.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
+        frame["ds"] = pd.to_datetime(frame.date).dt.strftime("%Y-%m-%d")
+        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 1e4
+    else:
+        frame = pd.read_csv(path, usecols=["ts_code", "trade_date", "open", "close", "amount"])
+        frame["code"] = frame.ts_code.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
+        frame["ds"] = pd.to_datetime(frame.trade_date.astype(str), format="%Y%m%d").dt.strftime("%Y-%m-%d")
+        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 10.0
+    for col in ("open", "close"):
+        frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    return frame.dropna(subset=["open", "close"]).sort_values(["code", "ds"])
+
+
+def build_panels(frame: pd.DataFrame, min_amount_wan: float) -> Panels:
+    """流动性池与 20 日动量都用 shift(1)，只含 T 日收盘可知的信息。"""
+    frame = frame.copy()
+    grouped = frame.groupby("code", sort=False)
+    frame["avg20"] = grouped.amt_wan.transform(lambda s: s.rolling(20, min_periods=10).mean().shift(1))
+    # 20 日涨幅按 T 日收盘算（含 T 日），配对时对候选和对照同口径，无前视。
+    frame["mom20"] = grouped.close.transform(lambda s: 100.0 * (s / s.shift(20) - 1.0))
+    liquid = frame[frame.avg20 >= min_amount_wan]
+    return Panels(
+        open={ds: dict(zip(g.code, g.open, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
+        close={ds: dict(zip(g.code, g.close, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
+        liquid={ds: set(g.code) for ds, g in liquid.groupby("ds", sort=False)},
+        mom20={
+            ds: dict(zip(g.code, g.mom20, strict=True))
+            for ds, g in frame.dropna(subset=["mom20"]).groupby("ds", sort=False)
+        },
+        dates=sorted(frame.ds.unique()),
+    )
+
+
+CONTROL_DESC = {
+    "l4_vs_rest": "对照池：同日宽池内未进 L4 的候选（两组都过了宽池入口，差别只在 L4 这道筛）",
+}
+DEFAULT_CONTROL_DESC = "对照池：同日流动性池内的非候选股"
+
+
+def render(result: dict, status: str) -> str:
+    lines = [
+        f"# 漏斗选股效果（status={status}）",
+        "",
+        f"买点 T+1 开盘 / 卖点 T+1+H 收盘 / 两边同扣往返成本 {ROUND_TRIP_COST_PCT}% / 按交易日等权",
+        CONTROL_DESC.get(status, DEFAULT_CONTROL_DESC),
+        "配对方式：T 日已知 20 日涨幅最近邻 1:1 无放回",
+        "",
+        "| H | 天数 | 日均配对 | 候选净收益 | 配对对照 | 配对超额 | t | 为正日 | 残差动量 |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for h, block in result["horizons"].items():
+        m = block["matched"]
+        if m["excess_pct"] is None:
+            lines.append(f"| T+{h} | {m['days']} | — | — | — | — | — | — | 样本不足(<{MIN_DAYS}) |")
+            continue
+        lines.append(
+            f"| T+{h} | {m['days']} | {m['avg_size']:.1f} | {m['net_pct']:+.2f}% | {m['control_pct']:+.2f}% "
+            f"| {m['excess_pct']:+.2f}pct | {m['excess_t']:+.2f} | {m['positive_day_pct']:.0f}% "
+            f"| {m['residual_mom_pct']:+.2f}pct |"
+        )
+    lines += [
+        "",
+        f"## 随机负控制（{len(CONTROL_SEEDS)} 个种子，逐只在同动量 ±{MOM_MATCH_TOL_PCT:.0f}pct 邻域内随机替换）",
+        "",
+    ]
+    inside = 0
+    for h, block in result["horizons"].items():
+        gap = block["control_gap"]
+        if gap.get("verdict") == "样本不足":
+            lines.append(f"- T+{h}：样本不足")
+            continue
+        inside += "落在" in gap["verdict"]
+        lines.append(
+            f"- T+{h}：配对超额 {gap['matched_excess']:+.3f}pct，"
+            f"随机控制 {gap['control_excess_min']:+.3f}~{gap['control_excess_max']:+.3f}pct"
+            f"（均值 {gap['control_excess_avg']:+.3f}，宽度 {gap['seed_spread']:.3f}），"
+            f"差距 {gap['gap']:+.3f}pct → {gap['verdict']}"
+        )
+    lines += ["", "## 怎么读", ""]
+    if inside:
+        lines += [
+            f"- **{inside} 个持有期的配对超额落在随机负控制区间内。**上表的超额和 t 值不能读成选股能力：",
+            "  同动量邻域内随机抽同样只数就能拿到同等甚至更高的超额，说明这部分收益来自"
+            "「候选站在动量轴的哪个位置」，而不是「在同一位置上挑中了哪一只」。",
+            "- 为正日比例高（如 70%/75%）同样不构成证据——随机控制的为正日比例一样高。",
+        ]
+    else:
+        lines.append("- 配对超额跑赢随机负控制，含独立选股信息；仍需在更长样本上按走前口径复核后才可据此改阈值。")
+    lines += [
+        f"- 单次往返成本 {ROUND_TRIP_COST_PCT}%：超额小于它时，净收益上看不出差别。",
+        "- 残差动量列是配对是否真中性化的检查项；它偏离 0 太多时，超额里混着动量差，整行作废。",
+        "- 本口径只回答「同动量同侪里选得好不好」，不回答「该不该在这个市场里买」——后者是水温闸门的事。",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    cands = json.load(open(args.cands, encoding="utf-8"))
+    panels = build_panels(load_market(args.cache), args.min_amount_wan)
+    horizons = [int(x) for x in args.horizons.split(",") if x.strip()]
+
+    result: dict = {"status": args.status, "horizons": {}}
+    for h in horizons:
+        rows = evaluate_daily(cands, panels, h, status=args.status)
+        matched = summarize_group("matched", rows["matched"])
+        controls = [summarize_group(f"control_{s}", rows[f"control_{s}"]) for s in CONTROL_SEEDS]
+        result["horizons"][h] = {
+            "matched": matched.as_dict(),
+            "controls": [c.as_dict() for c in controls],
+            "control_gap": control_gap(matched, controls),
+        }
+
+    print(render(result, args.status))
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, ensure_ascii=False, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_funnel_effect_eval.py
+++ b/tests/core/test_funnel_effect_eval.py
@@ -1,0 +1,405 @@
+"""Tests for funnel stock-picking effectiveness (matched control + random negative control)."""
+
+from __future__ import annotations
+
+import random
+from statistics import mean
+
+import pytest
+
+from core.funnel_effect_eval import (
+    CONTROL_SEEDS,
+    MIN_DAYS,
+    MIN_HITS_PER_DAY,
+    MOM_MATCH_TOL_PCT,
+    GroupStat,
+    Panels,
+    control_gap,
+    evaluate_daily,
+    match_by_momentum,
+    resolve_layer,
+    sample_momentum_band,
+    summarize_group,
+    tstat,
+)
+from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
+
+
+def _daily(pairs: list[tuple[float, float]], *, size: float = 10.0, start: str = "2026-06-") -> list[dict]:
+    """逐日观测：(net, control)。日期都落在 2026Q2,便于季度分组的用例单独构造。"""
+    return [
+        {"date": f"{start}{i + 1:02d}", "size": size, "net": net, "control": ctl, "residual_mom": 0.0}
+        for i, (net, ctl) in enumerate(pairs)
+    ]
+
+
+class TestTstat:
+    def test_known_series(self):
+        # 均值 3、样本标准差 sqrt(2.5)、n=5 -> 3 / sqrt(2.5/5) = 4.2426
+        assert tstat([1.0, 2.0, 3.0, 4.0, 5.0]) == pytest.approx(4.2426, abs=1e-3)
+
+    def test_zero_variance_is_none(self):
+        """常数序列的 t 无定义,不能返回 inf 混进报告。"""
+        assert tstat([2.0, 2.0, 2.0]) is None
+
+    def test_too_few_points_is_none(self):
+        assert tstat([1.0, 2.0]) is None
+
+
+class TestSummarizeGroup:
+    def test_requires_minimum_days(self):
+        """样本不足返回 None 而非 0.0。
+
+        既有 pattern_forward_eval 在这里返回 0.0,报告渲染成「日均命中 0.0」,
+        看起来像「一只都没匹配上」而不是「样本太少」——本轮排查在这上面绕了一圈。
+        """
+        stat = summarize_group("x", _daily([(1.0, 0.0)] * (MIN_DAYS - 1)))
+        assert stat.days == MIN_DAYS - 1
+        assert stat.excess_pct is None
+        assert stat.net_pct is None
+        assert stat.excess_t is None
+
+    def test_equal_weights_days_not_symbols(self):
+        """按交易日等权：命中 900 只的那天不该主导均值。"""
+        rows = [
+            {"date": "2026-06-01", "size": 900.0, "net": 10.0, "control": 0.0, "residual_mom": 0.0},
+            *_daily([(0.0, 0.0)] * (MIN_DAYS - 1), size=3.0),
+        ]
+        assert summarize_group("x", rows).excess_pct == pytest.approx(10.0 / MIN_DAYS)
+
+    def test_drops_days_below_min_hits(self):
+        """只数不足的日子整天丢掉：3 只以下的等权均值噪声太大。"""
+        rows = _daily([(1.0, 0.0)] * MIN_DAYS) + [
+            {"date": "2026-06-99", "size": MIN_HITS_PER_DAY - 1, "net": 99.0, "control": 0.0, "residual_mom": 0.0}
+        ]
+        stat = summarize_group("x", rows)
+        assert stat.days == MIN_DAYS
+        assert stat.excess_pct == pytest.approx(1.0)
+
+    def test_skips_rows_missing_either_side(self):
+        rows = _daily([(1.0, 0.0)] * MIN_DAYS) + [
+            {"date": "2026-06-98", "size": 10.0, "net": None, "control": 0.0, "residual_mom": 0.0},
+            {"date": "2026-06-97", "size": 10.0, "net": 1.0, "control": None, "residual_mom": 0.0},
+        ]
+        assert summarize_group("x", rows).days == MIN_DAYS
+
+    def test_excess_is_net_minus_control(self):
+        stat = summarize_group("x", _daily([(-2.0, -5.0)] * MIN_DAYS))
+        assert stat.net_pct == pytest.approx(-2.0)
+        assert stat.control_pct == pytest.approx(-5.0)
+        assert stat.excess_pct == pytest.approx(3.0)
+
+    def test_positive_day_pct_counts_days_not_magnitude(self):
+        """为正日比例要能揭穿「一天暴赚撑起均值」：这里均值为正但只有一半日子为正。"""
+        pairs = [(9.0, 0.0), (-1.0, 0.0)] * (MIN_DAYS // 2)
+        stat = summarize_group("x", _daily(pairs))
+        assert stat.excess_pct > 0
+        assert stat.positive_day_pct == pytest.approx(50.0)
+
+    def test_groups_excess_by_quarter(self):
+        rows = _daily([(2.0, 0.0)] * MIN_DAYS, start="2026-06-")
+        rows += _daily([(-2.0, 0.0)] * MIN_DAYS, start="2026-08-")
+        stat = summarize_group("x", rows)
+        assert stat.by_quarter[20262] == pytest.approx(2.0)
+        assert stat.by_quarter[20263] == pytest.approx(-2.0)
+
+    def test_reports_residual_momentum(self):
+        """残差动量必须出报告：配对是否真的中性化了动量,只能靠它检查,不能假定。"""
+        rows = _daily([(1.0, 0.0)] * MIN_DAYS)
+        for row in rows:
+            row["residual_mom"] = 0.4
+        assert summarize_group("x", rows).residual_mom_pct == pytest.approx(0.4)
+
+
+class TestMatchByMomentum:
+    def test_picks_nearest_neighbour(self):
+        mom = {"h1": 10.0, "c_far": 12.5, "c_near": 10.2}
+        pairs = match_by_momentum(["h1"], ["c_far", "c_near"], mom)
+        assert pairs == [("h1", "c_near")]
+
+    def test_rejects_beyond_tolerance(self):
+        """动量差 10 个点的票不是对照。宁可少算几只,也不能拿它凑样本。"""
+        mom = {"h1": 10.0, "c1": 10.0 + MOM_MATCH_TOL_PCT + 0.1}
+        assert match_by_momentum(["h1"], ["c1"], mom) == []
+
+    def test_tolerance_boundary_is_inclusive(self):
+        mom = {"h1": 10.0, "c1": 10.0 + MOM_MATCH_TOL_PCT}
+        assert match_by_momentum(["h1"], ["c1"], mom) == [("h1", "c1")]
+
+    def test_without_replacement(self):
+        """同一只对照股不能被两只候选共用,否则它的特异噪声会被放大一倍。"""
+        mom = {"h1": 10.0, "h2": 10.1, "c1": 10.05, "c2": 11.0}
+        pairs = match_by_momentum(["h1", "h2"], ["c1", "c2"], mom)
+        assert len(pairs) == 2
+        assert len({c for _, c in pairs}) == 2
+
+    def test_exhausted_pool_drops_remaining_hits(self):
+        mom = {"h1": 10.0, "h2": 10.1, "c1": 10.0}
+        pairs = match_by_momentum(["h1", "h2"], ["c1"], mom)
+        assert len(pairs) == 1
+
+    def test_skips_hits_without_momentum(self):
+        """20 日动量算不出来（上市不足 20 日）的候选直接跳过,不能当 0 处理。"""
+        mom = {"h_ok": 10.0, "c1": 10.0, "c2": 10.1}
+        pairs = match_by_momentum(["h_ok", "h_no_mom"], ["c1", "c2"], mom)
+        assert [h for h, _ in pairs] == ["h_ok"]
+
+    def test_is_deterministic(self):
+        rng = random.Random(1)
+        mom = {f"h{i}": rng.gauss(5.0, 8.0) for i in range(20)}
+        mom.update({f"c{i}": rng.gauss(5.0, 8.0) for i in range(60)})
+        hits, pool = [f"h{i}" for i in range(20)], [f"c{i}" for i in range(60)]
+        assert match_by_momentum(hits, pool, mom) == match_by_momentum(hits, pool, mom)
+
+    def test_residual_momentum_is_near_zero(self):
+        """配对后候选与对照的平均动量差必须接近 0——这是整个口径成立的前提。"""
+        rng = random.Random(7)
+        # 候选动量右偏（真实形态：漏斗偏爱强势股）,对照池覆盖全区间。
+        mom = {f"h{i}": 8.0 + abs(rng.gauss(0.0, 6.0)) for i in range(60)}
+        mom.update({f"c{i}": rng.gauss(4.0, 12.0) for i in range(900)})
+        hits, pool = [f"h{i}" for i in range(60)], [f"c{i}" for i in range(900)]
+        pairs = match_by_momentum(hits, pool, mom)
+        residual = mean(mom[h] for h, _ in pairs) - mean(mom[c] for _, c in pairs)
+        assert abs(residual) < 0.5
+
+
+class TestSampleMomentumBand:
+    def test_stays_inside_the_neighbourhood(self):
+        """逐只在 ±tol 邻域内抽。第一版从候选动量 [min,max] 均匀抽,残差动量
+        高达 +6.1~+8.8pct——候选动量右偏,均匀抽出的控制组是个动量低 8 个点的
+        更弱对手,它的「超额」里混着动量差,拿来跟配对超额比是错的。
+        """
+        mom = {"h1": 10.0, "near": 11.0, "far": 30.0}
+        picked = sample_momentum_band(["h1"], ["near", "far"], mom, seed=11, date="2026-06-01")
+        assert picked == ["near"]
+
+    def test_residual_momentum_is_near_zero_like_matching(self):
+        """随机控制的残差动量也要归零：控制组与配对组唯一的差别应是「邻域内选哪一只」。"""
+        rng = random.Random(3)
+        mom = {f"h{i}": 8.0 + abs(rng.gauss(0.0, 6.0)) for i in range(60)}
+        mom.update({f"c{i}": rng.gauss(4.0, 12.0) for i in range(900)})
+        hits, pool = [f"h{i}" for i in range(60)], [f"c{i}" for i in range(900)]
+        for seed in CONTROL_SEEDS:
+            band = sample_momentum_band(hits, pool, mom, seed=seed, date="2026-06-01")
+            residual = mean(mom[h] for h in hits[: len(band)]) - mean(mom[c] for c in band)
+            assert abs(residual) < 3.0, f"seed={seed} 残差动量 {residual:.2f}"
+
+    def test_without_replacement(self):
+        mom = {"h1": 10.0, "h2": 10.1, "c1": 10.0, "c2": 10.2}
+        picked = sample_momentum_band(["h1", "h2"], ["c1", "c2"], mom, seed=11, date="2026-06-01")
+        assert len(picked) == len(set(picked)) == 2
+
+    def test_empty_neighbourhood_drops_the_hit(self):
+        mom = {"h1": 10.0, "c1": 40.0}
+        assert sample_momentum_band(["h1"], ["c1"], mom, seed=11, date="2026-06-01") == []
+
+    def test_seeds_differ_but_each_is_reproducible(self):
+        rng = random.Random(5)
+        mom = {f"h{i}": rng.gauss(5.0, 3.0) for i in range(30)}
+        mom.update({f"c{i}": rng.gauss(5.0, 3.0) for i in range(300)})
+        hits, pool = [f"h{i}" for i in range(30)], [f"c{i}" for i in range(300)]
+        a = sample_momentum_band(hits, pool, mom, seed=11, date="2026-06-01")
+        b = sample_momentum_band(hits, pool, mom, seed=23, date="2026-06-01")
+        assert a == sample_momentum_band(hits, pool, mom, seed=11, date="2026-06-01")
+        assert a != b
+
+    def test_date_enters_the_seed(self):
+        """种子按 (seed, date) 混合,否则所有日子共用一次抽样序列,5 个种子量不出真实宽度。"""
+        rng = random.Random(5)
+        mom = {f"h{i}": rng.gauss(5.0, 3.0) for i in range(30)}
+        mom.update({f"c{i}": rng.gauss(5.0, 3.0) for i in range(300)})
+        hits, pool = [f"h{i}" for i in range(30)], [f"c{i}" for i in range(300)]
+        d1 = sample_momentum_band(hits, pool, mom, seed=11, date="2026-06-01")
+        d2 = sample_momentum_band(hits, pool, mom, seed=11, date="2026-06-02")
+        assert d1 != d2
+
+
+class TestResolveLayer:
+    DAY = {"all": ["a", "b", "c", "d"], "formal_l4": ["a", "b"]}
+    UNIVERSE = {"a", "b", "c", "d", "x", "y"}
+
+    def test_formal_l4_control_pool_excludes_all_candidates(self):
+        """对照池要排掉整个宽池,不只排 L4。
+
+        早先按 ``universe - hits`` 建池,把「进了宽池但没进 L4」的票也当成了非候选,
+        L4 的超额被自家兄弟稀释：口径修正后 T+5 从 +0.86 变 +0.42。
+        """
+        hits, pool = resolve_layer(self.DAY, self.UNIVERSE, "formal_l4")
+        assert hits == ["a", "b"]
+        assert pool == ["x", "y"]
+
+    def test_all_layer_measures_the_wide_pool(self):
+        hits, pool = resolve_layer(self.DAY, self.UNIVERSE, "all")
+        assert hits == ["a", "b", "c", "d"]
+        assert pool == ["x", "y"]
+
+    def test_l4_vs_rest_控制池在宽池内(self):
+        """最锐的一层：两组都过了宽池入口,差别只在 L4 这道筛。"""
+        hits, pool = resolve_layer(self.DAY, self.UNIVERSE, "l4_vs_rest")
+        assert hits == ["a", "b"]
+        assert pool == ["c", "d"]
+
+    def test_restricted_to_liquid_universe(self):
+        """流动性池外的候选不参与：买不进的票算出来的收益没有意义。"""
+        hits, pool = resolve_layer(self.DAY, {"a", "c", "x"}, "l4_vs_rest")
+        assert hits == ["a"]
+        assert pool == ["c"]
+
+    def test_missing_keys_are_safe(self):
+        assert resolve_layer({}, self.UNIVERSE, "l4_vs_rest") == ([], [])
+
+
+def _panels(n_days: int = 40, *, codes: list[str] | None = None) -> Panels:
+    codes = codes or [f"s{i}" for i in range(200)]
+    dates = [f"2026-06-{i + 1:02d}" for i in range(n_days)]
+    rng = random.Random(19)
+    mom = {c: rng.gauss(5.0, 8.0) for c in codes}
+    return Panels(
+        open={d: dict.fromkeys(codes, 100.0) for d in dates},
+        close={d: dict.fromkeys(codes, 100.0) for d in dates},
+        liquid={d: set(codes) for d in dates},
+        mom20={d: dict(mom) for d in dates},
+        dates=dates,
+    )
+
+
+class TestPanels:
+    def test_window_buys_next_open(self):
+        """漏斗信号收盘后才出,最早的真实买点是 T+1 开盘。"""
+        panels = _panels(10)
+        assert panels.window("2026-06-01", 5) == ("2026-06-02", "2026-06-07")
+
+    def test_window_returns_none_past_the_end(self):
+        panels = _panels(10)
+        assert panels.window("2026-06-09", 5) is None
+        assert panels.window("2026-05-30", 5) is None
+
+    def test_gross_return_is_equal_weighted(self):
+        panels = _panels(5, codes=["a", "b"])
+        panels.close["2026-06-03"] = {"a": 110.0, "b": 90.0}
+        assert panels.gross_return(["a", "b"], "2026-06-02", "2026-06-03") == pytest.approx(0.0)
+        assert panels.gross_return(["a"], "2026-06-02", "2026-06-03") == pytest.approx(10.0)
+
+    def test_gross_return_skips_missing_and_zero_prices(self):
+        panels = _panels(5, codes=["a", "b"])
+        panels.open["2026-06-02"] = {"a": 100.0, "b": 0.0}
+        panels.close["2026-06-03"] = {"a": 110.0, "b": 90.0}
+        assert panels.gross_return(["a", "b", "ghost"], "2026-06-02", "2026-06-03") == pytest.approx(10.0)
+
+    def test_gross_return_none_when_nothing_priced(self):
+        panels = _panels(5, codes=["a"])
+        assert panels.gross_return(["ghost"], "2026-06-02", "2026-06-03") is None
+
+
+class TestEvaluateDaily:
+    def _cands(self, panels: Panels, n_hits: int = 20, n_wide: int = 60) -> dict[str, dict]:
+        codes = sorted(next(iter(panels.liquid.values())))
+        return {
+            d: {"formal_l4": codes[:n_hits], "all": codes[:n_wide]}
+            for d in panels.dates[:-25]  # 留出足够的前向窗口
+        }
+
+    def test_matched_and_controls_share_the_same_hits(self):
+        """随机控制必须与配对组用同一批候选,否则分母不同、两个超额不可比。
+
+        这是本轮自己写出来又改掉的 bug：配对失败的候选留在了随机组里。
+        """
+        panels = _panels(60)
+        rows = evaluate_daily(self._cands(panels), panels, 5, status="formal_l4")
+        assert rows["matched"], "配对组应有观测"
+        for seed in CONTROL_SEEDS:
+            ctrl = rows[f"control_{seed}"]
+            assert ctrl
+            by_date = {r["date"]: r for r in ctrl}
+            for row in rows["matched"]:
+                # 同一天两边的 net 必须完全相同——它们算的是同一批票。
+                assert by_date[row["date"]]["net"] == pytest.approx(row["net"])
+
+    def test_cost_is_deducted_from_both_sides(self):
+        """两边同扣往返成本,比较的是选股而非交易频率;超额里成本自然抵消。"""
+        panels = _panels(60)
+        rows = evaluate_daily(self._cands(panels), panels, 5, status="formal_l4")
+        row = rows["matched"][0]
+        # 全市场价格恒定 -> 毛收益 0 -> 净收益 = -成本,两边都是。
+        assert row["net"] == pytest.approx(-ROUND_TRIP_COST_PCT)
+        assert row["control"] == pytest.approx(-ROUND_TRIP_COST_PCT)
+
+    def test_skips_days_below_min_hits(self):
+        panels = _panels(60)
+        cands = {d: {"formal_l4": ["s0", "s1"], "all": ["s0", "s1"]} for d in panels.dates[:-25]}
+        assert evaluate_daily(cands, panels, 5, status="formal_l4")["matched"] == []
+
+    def test_skips_days_without_a_full_window(self):
+        panels = _panels(30)
+        codes = sorted(next(iter(panels.liquid.values())))
+        cands = {d: {"formal_l4": codes[:20], "all": codes[:60]} for d in panels.dates}
+        rows = evaluate_daily(cands, panels, 20, status="formal_l4")
+        # 20 日窗口需要 T+21,最后 21 天出不了观测。
+        assert len(rows["matched"]) <= len(panels.dates) - 21
+
+    def test_layer_flows_through(self):
+        """status 直达 resolve_layer：l4_vs_rest 的对照池在宽池内,只数受宽池限制。"""
+        panels = _panels(60)
+        cands = self._cands(panels, n_hits=20, n_wide=25)
+        rows = evaluate_daily(cands, panels, 5, status="l4_vs_rest")
+        assert rows["matched"]
+        # 对照池只有 5 只 -> 每天最多配 5 对。
+        assert max(r["size"] for r in rows["matched"]) <= 5
+
+
+class TestControlGap:
+    """随机负控制：漏斗的超额到底是选股信息,还是只是「站在了某个动量位置上」。
+
+    实测 L4 vs 同动量非 L4 候选 T+10 超额 +4.10pct、t=+3.55、为正日 70%,看着很强;
+    但同口径随机控制给 +4.48~+5.17,配对超额反而在区间之下。缺这个对照就会把
+    动量选位读成选股能力。
+    """
+
+    def _stat(self, excess: float | None) -> GroupStat:
+        return GroupStat("x", 30, 13.7, None, None, excess, 3.55, 70.0, -0.16)
+
+    def test_inside_control_range_has_no_selection_value(self):
+        gap = control_gap(self._stat(4.098), [self._stat(e) for e in (4.477, 4.866, 5.165)])
+        assert "落在" in gap["verdict"]
+        assert gap["control_excess_min"] == pytest.approx(4.477)
+        assert gap["control_excess_max"] == pytest.approx(5.165)
+        assert gap["gap"] < 0
+
+    def test_below_every_seed_is_still_not_a_win(self):
+        """配对超额低于所有种子时更不能说有效——gap 为负,必然落进「无选股信息」。"""
+        gap = control_gap(self._stat(1.588), [self._stat(e) for e in (1.594, 1.898, 2.272)])
+        assert "落在" in gap["verdict"]
+        assert gap["gap"] == pytest.approx(1.588 - 1.921, abs=1e-3)
+
+    def test_gap_within_seed_spread_is_not_a_win(self):
+        """哪怕高于所有种子,只要差距不超过种子间宽度就算不上跑赢。"""
+        gap = control_gap(self._stat(0.35), [self._stat(e) for e in (0.10, 0.30)])
+        assert gap["gap"] == pytest.approx(0.15)
+        assert gap["seed_spread"] == pytest.approx(0.20)
+        assert "落在" in gap["verdict"]
+
+    def test_gap_equal_to_spread_is_not_a_win(self):
+        """边界取 <=：刚好等于宽度不算跑赢。
+
+        取二进制可精确表示的值（0.25/0.75/1.25）,否则 0.1/0.3/0.4 那组在浮点上
+        gap 比 spread 大一个 eps,考的就不是这条分支了。
+        """
+        # 均值 0.5、宽度 0.5 -> matched=1.0 时 gap 恰好等于 spread。
+        gap = control_gap(self._stat(1.0), [self._stat(e) for e in (0.25, 0.75)])
+        assert gap["gap"] == pytest.approx(gap["seed_spread"])
+        assert "落在" in gap["verdict"]
+
+    def test_clear_outperformance_is_flagged(self):
+        gap = control_gap(self._stat(2.00), [self._stat(e) for e in (0.10, 0.12)])
+        assert "跑赢" in gap["verdict"]
+
+    def test_single_seed_is_insufficient(self):
+        """单种子的一次抽样量不出边缘宽度,不能拿来判定。"""
+        assert control_gap(self._stat(4.1), [self._stat(4.5)])["verdict"] == "样本不足"
+
+    def test_missing_matched_excess_is_insufficient(self):
+        assert control_gap(self._stat(None), [self._stat(0.1), self._stat(0.2)])["verdict"] == "样本不足"
+
+    def test_ignores_seeds_without_excess(self):
+        gap = control_gap(self._stat(0.35), [self._stat(0.10), self._stat(0.30), self._stat(None)])
+        assert gap["seeds"] == 2


### PR DESCRIPTION
## 变更摘要

新增 `core/funnel_effect_eval.py` + `scripts/evaluate_funnel_effect.py`,回答「漏斗到底挑得好不好」。48 个单测。

### 为什么不能用既有脚本

`evaluate_gated_regime_candidates.py` 结构上答不了这个问题：

1. 它按 regime 切分候选,每档只剩 8~15 天,过不了 `MIN_DAYS=20`。样本不足的分支返回 `0.0` 占位,报告渲染成「日均命中 0.0」——**看起来像「一只都没匹配上」,其实是「样本太少」**,本轮排查在这上面绕了一圈。
2. 它的基准是「同日全市场等权」。2026Q3 全市场本身大跌,用它当基准会把「跟跌少一点」读成选股能力(`full-market-control-confounds-momentum` 记过这个坑)。

### 新口径

- 买 T+1 开盘(漏斗信号收盘后才出,最早的真实买点)、卖 T+1+H 收盘
- 两边同扣 `ROUND_TRIP_COST_PCT=0.202%`,比较的是选股而非交易频率
- **按交易日等权**,命中 100 只的日子不主导均值
- 对照组:T 日已知 20 日涨幅**最近邻 1:1 无放回**配对,超出 ±3pct 视为找不到可比对象、该候选不进样本
- 每个持有期跑 **5 个种子的随机负控制**:逐只在同动量 ±3pct 邻域内随机替换,让控制组与配对组唯一的差别只是「邻域内选哪一只」——随机 vs 漏斗
- 三层可测:`formal_l4` / `all` 对非候选股,`l4_vs_rest` 在宽池内比 L4 与非 L4

## 实测结果

65 个交易日(`signal_observations` 起于 2026-05-25,这是生产全部可用历史)。

`--status l4_vs_rest`(最锐的一层,两组都过了宽池入口,差别只在 L4 这道筛):

| H | 天数 | 日均配对 | L4 净收益 | 非L4对照 | 超额 | t | 为正日 | 残差动量 | 随机控制超额 | 随机为正日 |
|---|---|---|---|---|---|---|---|---|---|---|
| T+5 | 35 | 14.3 | -2.93% | -4.51% | +1.59pct | +1.33 | 54% | -0.14pct | +1.59~+2.27 | 51~60% |
| T+10 | 30 | 13.7 | -4.43% | -8.53% | +4.10pct | **+3.55** | **70%** | -0.16pct | **+4.48~+5.17** | 63~73% |
| T+20 | 20 | 9.7 | -4.54% | -12.00% | +7.46pct | **+3.46** | **75%** | -0.13pct | **+7.06~+8.42** | 65~85% |

T+10 的 +4.10pct / t=+3.55 / 为正日 70% 单看很强。但**同口径随机控制给 +4.48~+5.17,配对超额反而在区间之下**;为正日也落在随机的 63~73% 里。三层九个格子,随机均值全部 ≥ 实测超额。

另两层同样落在区间内:

| 层 | H | 超额 | t | 随机均值 |
|---|---|---|---|---|
| `formal_l4` vs 非候选股 | 5/10/20 | +0.42/+2.06/+2.06 | +0.36/+1.36/+0.92 | +0.38/+2.31/+2.24 |
| `all` 宽池 vs 非候选股 | 5/10/20 | -1.99/-2.91/-5.02 | -4.37/-4.51/-5.64 | -2.34/-3.17/-5.26 |

宽池那行的 t=-5.64 一开始被我读成「宽池主动挑跌的」,随机控制否掉了:同动量邻域内随机抽给 -5.26,负号是配对残差,不是选股能力。

**残差动量各层均 ≤0.44pct**(配对组 -0.02~+0.04,随机组 -0.21~+0.44),配对是干净的,不是靠动量差撑起来的。

## 结论

在现有全部生产样本上,漏斗相对同动量同侪**没有可测到的选股优势**。它能拿到的超额来自「候选站在动量轴的哪个位置」,不是「在同一位置上挑中了哪一只」。这与动量体检的结论一致:动量只能做顶部负筛。

## 本 PR 不主张什么

- **不据此改任何阈值。** 样本只有一个季度(`by_quarter` 全在 20263),不足以支撑阈值变更;要改必须先过走前口径。
- 本口径只回答「同动量同侪里选得好不好」,**不回答「该不该在这个市场里买」**——后者是水温闸门的事,`all` 层的绝对收益 -13.23% 反映的是市场,不是漏斗。

## 自查中改掉的两个自己的口径 bug

两个都写进了代码注释,免得后人重踩:

1. **随机控制与配对组分母不同**。配对失败的候选留在了随机组里,两个超额不可比。现在两条路都吃 `paired_hits`。
2. **随机控制从候选动量 `[min,max]` 均匀抽**,实测控制组残差动量 **+6.1~+8.8pct**——候选动量右偏,均匀抽必然系统性偏低,那不是干净对照而是个动量低 8 个点的更弱对手,它的「超额」里混着动量差。改成逐只在 ±tol 邻域内随机替换后降到 +0.15~+0.34pct。这个是靠**显式打印每个种子的残差动量**发现的,不是靠信任设计。

顺带修掉一处:`formal_l4` 层原先按 `universe - hits` 建对照池,把「进了宽池但没进 L4」的票也算成非候选,L4 的超额被自家兄弟稀释(T+5 从 +0.86 变 +0.42)。`resolve_layer` 现在排掉整个宽池。

## 验证

```
tests/core/test_funnel_effect_eval.py  48 passed
全量 pytest                            4495 passed, 22 skipped
ruff check / format                    clean
quality_gate.py --check-no-sql         OK
```

## 顺带发现(未处理)

`signal_observations.candidate_status` 有脏值:`Lane`(3543 行)、`alpha`(1965)、`Accum_C`、`主线买点候选`、`强主线分歧`。像是别的字段写进了这一列,值得单独查写入路径。

## 复现

```bash
python scripts/evaluate_funnel_effect.py \
  --cands /tmp/funnel_cands.json --cache /tmp/funnel_snap/hist_full.csv.gz \
  --status l4_vs_rest --horizons 5,10,20
```

`--cache` 兼容快照(`date`/`symbol`,amount 单位元)与 tushare(`trade_date`/`ts_code`,千元)两种列名。

🤖 Generated with [Claude Code](https://claude.com/claude-code)