### PR TITLE
fix(candidate): candidate_status 只存语义状态,不再当 candidate_lane 的副本

### DIFF
--- a/agents/screen_tools.py
+++ b/agents/screen_tools.py
@@ -1555,6 +1555,7 @@ def _ranked_candidates(
     priority_scores = _priority_score_map(details or {}, selected_rows)
     shadow_scores = _shadow_score_map(details or {})
     metadata_map = _candidate_metadata_map(details or {})
+    stage_map = _accum_stage_map(details or {})
     rows: dict[str, dict] = {}
     for trigger_name, candidates in trigger_groups.items():
         for candidate in candidates:
@@ -1570,6 +1571,7 @@ def _ranked_candidates(
                     selected,
                     shadow_scores.get(code),
                     _metadata_for_code(metadata_map, code),
+                    stage=stage_map.get(code6(code), ""),
                 ),
             )
             row["score"] = max(float(row["score"]), candidate_score_value(candidate.get("score")))
@@ -1586,6 +1588,7 @@ def _ranked_candidates(
                 selected,
                 shadow_scores.get(code),
                 _metadata_for_code(metadata_map, code),
+                stage=stage_map.get(code6(code), ""),
             ),
         )
         row["priority_score"] = max(float(row["priority_score"]), candidate_score_value(priority_scores.get(code)))
@@ -1599,6 +1602,15 @@ def _candidate_metadata_map(details: dict) -> dict[str, dict[str, Any]]:
         _safe_dict_list(details.get("candidate_entries")),
         _safe_dict_list(details.get("mainline_candidates")),
     )
+
+
+def _accum_stage_map(details: dict) -> dict[str, str]:
+    """Wyckoff 阶段的唯一来源：``metrics.accum_stage_map``（detect_accum_stage 产出）。"""
+    metrics = details.get("metrics") if isinstance(details.get("metrics"), dict) else {}
+    raw = (metrics or {}).get("accum_stage_map") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {code6(code): str(stage or "").strip() for code, stage in raw.items() if code6(code)}
 
 
 def _safe_dict_list(value: Any) -> list[dict[str, Any]]:
@@ -1647,6 +1659,7 @@ def _candidate_row(
     selected: set[str],
     shadow_score: object = None,
     metadata: dict[str, Any] | None = None,
+    stage: str = "",
 ) -> dict:
     report_row = report_row or {}
     metadata = metadata or {}
@@ -1661,7 +1674,10 @@ def _candidate_row(
         "selected_for_report": code in selected,
         "selection_source": str(report_row.get("selection_source") or _metadata_selection_source(metadata)).strip(),
         "track": str(report_row.get("track") or _metadata_track(metadata)).strip(),
-        "stage": str(report_row.get("stage") or metadata.get("candidate_status") or "").strip(),
+        # 阶段取 metrics.accum_stage_map。曾经兜底读 metadata["candidate_status"]，
+        # 那只是因为 candidate_status 被写进了 Wyckoff 阶段名（Accum_B/Accum_C/Markup）;
+        # 写入侧已修，阶段回到 accum_stage_map 这个唯一来源。
+        "stage": str(report_row.get("stage") or stage or "").strip(),
         "tag": str(report_row.get("tag") or _metadata_tag(metadata)).strip(),
         "candidate_lane": str(report_row.get("candidate_lane") or metadata.get("candidate_lane") or "").strip(),
         "entry_type": str(report_row.get("entry_type") or metadata.get("entry_type") or "").strip(),

--- a/core/candidate_metadata.py
+++ b/core/candidate_metadata.py
@@ -9,6 +9,8 @@ from typing import Any
 from core.candidate_policy import candidate_score_value
 from core.candidate_report_semantics import candidate_phase, candidate_role, candidate_theme
 from core.candidate_tracks import (
+    CANDIDATE_PRODUCER_TAGS,
+    WYCKOFF_STAGE_NAMES,
     candidate_entry_key,
     normalize_candidate_entry_key,
     stronger_candidate_entry,
@@ -108,7 +110,13 @@ def candidate_entry_metadata(item: dict[str, Any], mainline: dict[str, Any] | No
         "entry_type": _text(item.get("entry_type")) or lane,
         "signal_key": candidate_entry_key(item, fields=("signal_key", "lane", "entry_type"))
         or normalize_candidate_entry_key(lane),
-        "candidate_status": _text(item.get("state")) or _text((mainline or {}).get("status")),
+        # candidate_status 是语义状态位（主线买点候选 / 过热不追 / AI复核候选…），
+        # 下游 TRADEABLE_MAINLINE_STATUSES 按它放行推荐写入。item["state"] 是生产者
+        # 标签（formal_l4/alpha/Lane/Mainline），照抄进来会把这一列变成 candidate_lane
+        # 的副本：实测 7318 行里 6391 行存的是标签，且 stage 已知时被 Accum_B/Accum_C
+        # 顶掉，连 formal_l4 这个标记本身都丢了 104 行。通道信息由 candidate_lane 承载，
+        # stage 由 stage 列承载，这里只取语义状态。
+        "candidate_status": _semantic_status(item) or _text((mainline or {}).get("status")),
         "candidate_timing": _text(item.get("timing")) or _text((mainline or {}).get("entry_type")),
         "candidate_risk": _text(item.get("risk")) or _join_texts((mainline or {}).get("risk_flags")),
         "candidate_reasons": _json_object(_candidate_reason_payload(item, mainline)),
@@ -243,6 +251,19 @@ def _optional_float(raw: Any) -> float | None:
 def _text(raw: Any) -> str | None:
     text = str(raw or "").strip()
     return text or None
+
+
+def _semantic_status(item: dict[str, Any]) -> str | None:
+    """取候选条目上的语义状态，滤掉生产者标签与 Wyckoff 阶段名。
+
+    ``state`` 这一个字段同时承载了两种东西：``_formal_candidate_entries`` 写的是
+    ``stage_map`` 命中时的阶段名、否则是 ``"formal_l4"``；alpha/Lane/Mainline 三条
+    产出路径写的是各自的通道标签。两者都不是候选状态，不该进 candidate_status。
+    """
+    state = _text(item.get("state"))
+    if state is None or state in CANDIDATE_PRODUCER_TAGS or state in WYCKOFF_STAGE_NAMES:
+        return None
+    return state
 
 
 def _join_texts(raw: Any) -> str | None:

--- a/core/candidate_tracks.py
+++ b/core/candidate_tracks.py
@@ -8,6 +8,20 @@ from typing import Any
 
 from core.candidate_policy import candidate_score_value
 
+#: 正式 L4 触发通道（``_formal_candidate_entries`` 产出的六条）。判「这一行是不是
+#: 正式 L4 候选」要按 ``candidate_lane`` 落在这个集合里，不要去比
+#: ``candidate_status == "formal_l4"``——那个字段是语义状态位，历史上被生产者标签
+#: 占用过，且在 stage 已知时会被 ``Accum_B``/``Accum_C`` 顶掉。
+FORMAL_L4_LANES = frozenset({"sos", "evr", "lps", "spring", "compression", "trend_pullback"})
+
+#: 生产者标签：候选条目 ``state`` 字段用它区分产出通道（正式触发 / alpha / Lane /
+#: Mainline），是流水线内部用的来源标记，不是给人看的候选状态。
+CANDIDATE_PRODUCER_TAGS = frozenset({"formal_l4", "alpha", "Lane", "Mainline"})
+
+#: Wyckoff 阶段名（``detect_accum_stage`` + ``detect_markup_stage`` 的全部取值）。
+#: 它有自己的 ``stage``/``stage_tag`` 列，不该挤进 candidate_status。
+WYCKOFF_STAGE_NAMES = frozenset({"Accum_A", "Accum_B", "Accum_C", "Markup"})
+
 ACCUM_TRACK_KEYS = {
     "accum",
     "accumulation",

--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -231,6 +231,10 @@ def resolve_layer(day: dict, universe: set[str], layer: str) -> tuple[list[str],
     - ``formal_l4`` / ``all``：对照池是全市场里的非候选股，答「漏斗产出 vs 场内同侪」。
     - ``l4_vs_rest``：对照池是宽池内**未进 L4** 的候选，答「L4 这道筛本身有没有用」。
       这一层最能隔离筛的贡献：两组都已过了宽池入口，差别只在 L4。
+
+    ``day["formal_l4"]`` 的成员判定要按 ``candidate_lane in FORMAL_L4_LANES``。早先
+    按 ``candidate_status == "formal_l4"`` 建集合，漏掉了 104 只 stage 已知（状态位
+    被 ``Accum_B``/``Accum_C`` 顶掉）的正式候选，这些票还被算进了对照池。
     """
     wide = set(day.get("all") or []) & universe
     l4 = set(day.get("formal_l4") or []) & universe

--- a/scripts/build_funnel_cands.py
+++ b/scripts/build_funnel_cands.py
@@ -1,0 +1,88 @@
+"""从 signal_observations 导出漏斗候选集，供 evaluate_funnel_effect.py 使用。
+
+原先这一步是临时脚本，正是因此埋了个口径错误：按 ``candidate_status == "formal_l4"``
+建 L4 集合，漏掉 104 只 stage 已知（状态位被 ``Accum_B``/``Accum_C`` 顶掉）的正式
+候选，且把它们算进了对照池。L4 成员判定只认 ``candidate_lane in FORMAL_L4_LANES``。
+
+用法：
+    python scripts/build_funnel_cands.py --output /tmp/funnel_cands.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from typing import Any
+
+import _bootstrap  # noqa: F401
+
+from core.candidate_metadata import code6
+from core.candidate_tracks import FORMAL_L4_LANES
+
+PAGE = 1000
+COLUMNS = "trade_date,code,candidate_lane,candidate_status,regime"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="导出漏斗候选集")
+    parser.add_argument("--output", required=True, help="输出 JSON 路径")
+    parser.add_argument("--start", default="", help="起始交易日 YYYY-MM-DD，留空取全部")
+    parser.add_argument("--end", default="", help="结束交易日 YYYY-MM-DD，留空取全部")
+    return parser.parse_args()
+
+
+def fetch_rows(start: str, end: str) -> list[dict[str, Any]]:
+    from supabase import create_client
+
+    url, key = os.environ.get("SUPABASE_URL"), os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise SystemExit("缺少 SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY")
+    client = create_client(url, key)
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        query = client.table("signal_observations").select(COLUMNS)
+        if start:
+            query = query.gte("trade_date", start)
+        if end:
+            query = query.lte("trade_date", end)
+        page = query.range(offset, offset + PAGE - 1).execute().data or []
+        rows += page
+        if len(page) < PAGE:
+            return rows
+        offset += PAGE
+
+
+def build(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    wide: dict[str, set[str]] = defaultdict(set)
+    l4: dict[str, set[str]] = defaultdict(set)
+    regime: dict[str, str] = {}
+    for row in rows:
+        date = str(row.get("trade_date") or "")[:10]
+        code = code6(row.get("code"))
+        if not date or not code:
+            continue
+        wide[date].add(code)
+        if str(row.get("candidate_lane") or "").strip() in FORMAL_L4_LANES:
+            l4[date].add(code)
+        regime.setdefault(date, str(row.get("regime") or ""))
+    return {
+        date: {"regime": regime.get(date, ""), "formal_l4": sorted(l4[date]), "all": sorted(codes)}
+        for date, codes in sorted(wide.items())
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    out = build(fetch_rows(args.start, args.end))
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(out, fh, ensure_ascii=False)
+    l4_total = sum(len(day["formal_l4"]) for day in out.values())
+    wide_total = sum(len(day["all"]) for day in out.values())
+    print(f"{len(out)} 个交易日，宽池 {wide_total} 行，正式 L4 {l4_total} 行 -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_funnel_effect.py
+++ b/scripts/evaluate_funnel_effect.py
@@ -9,9 +9,13 @@
 用法：
     python scripts/backtest_snapshot_fetch.py --start 2026-01-01 --end 2026-09-01 \
         --board all --output-dir /tmp/funnel_snap
+    python scripts/build_funnel_cands.py --output /tmp/funnel_cands.json
     python scripts/evaluate_funnel_effect.py \
         --cands /tmp/funnel_cands.json --cache /tmp/funnel_snap/hist_full.csv.gz \
         --status formal_l4 --horizons 5,10,20
+
+候选集必须由 build_funnel_cands.py 生成：L4 成员判定按 candidate_lane 落在
+FORMAL_L4_LANES，手搓 ``candidate_status == "formal_l4"`` 会漏掉 stage 已知的那批。
 """
 
 from __future__ import annotations

--- a/tests/core/test_candidate_metadata.py
+++ b/tests/core/test_candidate_metadata.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import pytest
+
 from core.candidate_metadata import (
     build_candidate_metadata_map,
     build_candidate_signal_metadata_map,
     candidate_metadata_for_signal,
     candidate_signal_triggers,
 )
-from core.candidate_tracks import best_candidate_entry_map
+from core.candidate_tracks import (
+    CANDIDATE_PRODUCER_TAGS,
+    FORMAL_L4_LANES,
+    WYCKOFF_STAGE_NAMES,
+    best_candidate_entry_map,
+)
 
 
 def test_build_candidate_metadata_map_keeps_highest_scored_duplicate_entry() -> None:
@@ -120,3 +127,66 @@ def test_formal_signal_keeps_identity_and_inherits_mainline_context() -> None:
     assert row["candidate_theme"] == "光模块"
     assert row["candidate_phase"] == "分歧机会"
     assert row["candidate_role"] == "主线核心"
+
+
+class TestCandidateStatusIsSemanticOnly:
+    """candidate_status 只放语义状态，不放生产者标签，也不放 Wyckoff 阶段名。
+
+    2026-09-01 在生产 signal_observations 上实测：7318 行里 6391 行（87%）存的是
+    生产者标签（``Lane`` 3507、``alpha`` 2025、``formal_l4`` 799、``shadow_observe``
+    60），另有 104 行存的是阶段名（``Accum_C`` 56、``Accum_B`` 45、``Markup`` 3）。
+    交叉表显示这些值 100% 复述 ``candidate_lane``，这一列等于白占。
+
+    两个后果：
+    1. ``_tracking_status`` 里 ``if existing: return existing`` 把标签当成已有状态，
+       那 6391 行永远拿不到真状态（``AI复核候选``/``跨日确认观察``/``市场拦截观察``）。
+    2. ``_formal_candidate_entries`` 写的是 ``stage_map.get(code, "formal_l4")``,
+       stage 已知时 ``formal_l4`` 这个标记本身被顶掉，漏斗效果检验按状态位建 L4
+       集合就漏了 104 只正式候选，还把它们算进了对照池。
+    """
+
+    @staticmethod
+    def _status(state: str, lane: str = "sos") -> str | None:
+        item = {"code": "000001", "lane": lane, "entry_type": lane, "signal_key": lane, "state": state, "score": 80.0}
+        return build_candidate_metadata_map([item])[item["code"]].get("candidate_status")
+
+    @pytest.mark.parametrize("tag", sorted(CANDIDATE_PRODUCER_TAGS))
+    def test_producer_tag_never_lands_in_status(self, tag: str) -> None:
+        assert self._status(tag) is None
+
+    @pytest.mark.parametrize("stage", sorted(WYCKOFF_STAGE_NAMES))
+    def test_stage_name_never_lands_in_status(self, stage: str) -> None:
+        """阶段名有自己的 stage/stage_tag 列，实测那 104 行两处都存了同一个值。"""
+        assert self._status(stage) is None
+
+    def test_lane_still_carries_the_channel(self) -> None:
+        """过滤状态位不能把通道信息一起丢掉——通道由 candidate_lane 承载。"""
+        item = {"code": "000001", "lane": "lps", "entry_type": "lps", "signal_key": "lps", "state": "Accum_C"}
+        meta = build_candidate_metadata_map([item])["000001"]
+        assert meta["candidate_lane"] == "lps"
+        assert meta["candidate_lane"] in FORMAL_L4_LANES
+
+    def test_real_semantic_status_on_state_survives(self) -> None:
+        """影子/过热路径确实往 state 上写语义状态，这些必须留下。"""
+        assert self._status("过热不追") == "过热不追"
+        assert self._status("shadow") == "shadow"
+
+    def test_mainline_status_comes_from_mainline_context(self) -> None:
+        """主线路径的状态来自 mainline.status,不受 state 过滤影响。"""
+        metadata = build_candidate_metadata_map(
+            [{"code": "300308", "lane": "mainline", "entry_type": "主线回踩MA5", "state": "Mainline", "score": 80.0}],
+            [{"code": "300308", "status": "主线买点候选", "theme": "光模块", "mainline_score": 0.86}],
+        )
+        assert metadata["300308"]["candidate_status"] == "主线买点候选"
+
+    def test_formal_l4_lanes_cover_every_formal_trigger(self) -> None:
+        """FORMAL_L4_LANES 要与 _formal_candidate_entries 的 base_map 键一致。
+
+        漏一条通道就等于把那条通道的票判进对照池,超额会被自家兄弟稀释。
+        """
+        from core.wyckoff_engine import _formal_candidate_entries
+
+        triggers = {key: [("000001", 1.0)] for key in FORMAL_L4_LANES}
+        entries = _formal_candidate_entries(triggers, {}, {})
+        assert {entry["entry_type"] for entry in entries} == set(FORMAL_L4_LANES)
+        assert {entry["state"] for entry in entries} == {"formal_l4"}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4072,7 +4072,9 @@ class TestSymbolPool:
                 [],
                 {},
                 {
-                    "metrics": {},
+                    # 阶段来自 accum_stage_map，不是候选条目的 state：state 存的是生产者
+                    # 标签/阶段名，早先 candidate_status 直抄 state 才让阶段"顺带"传下来。
+                    "metrics": {"accum_stage_map": {"000007": "Markup"}},
                     "triggers": {"launchpad": [("000007", 8.0)]},
                     "candidate_entries": [
                         {

--- a/tests/workflows/test_daily_job_preview.py
+++ b/tests/workflows/test_daily_job_preview.py
@@ -288,6 +288,51 @@ def test_recommendation_write_symbols_tracks_market_blocked_springboard_candidat
     assert got[0]["tag"] == "SOS起跳板结构(A+C)"
 
 
+def test_producer_tagged_candidate_gets_a_real_tracking_status():
+    """生产者标签不再冒充状态,起跳板候选拿到真状态「跨日确认观察」。
+
+    2026-09-01 实测：生产库 7318 行里 6391 行的 candidate_status 存的是
+    ``Lane``/``alpha``/``formal_l4``。``_tracking_status`` 的 ``if existing:
+    return existing`` 把标签当成已有状态,于是这些行永远走不到默认分支
+    （``跨日确认观察``/``AI复核候选``),这里锁死这条回归。
+    """
+    from core.market_trade_mode import resolve_market_trade_mode
+    from workflows.daily_job_persistence import recommendation_write_symbols
+
+    details = {
+        "candidate_entries": [
+            {
+                "code": "000007",
+                "lane": "trend_breakout",
+                "entry_type": "trend_breakout",
+                "signal_key": "trend_breakout",
+                "state": "Lane",
+                "score": 72.0,
+            }
+        ],
+        "formal_triggers": {"trend_breakout": [("000007", 9.0)]},
+        "springboard_map": {
+            "trend_breakout:000007": {
+                "springboard_met_count": 2,
+                "springboard_grade": "A+C",
+                "springboard_scored": True,
+            }
+        },
+        "metrics": {"latest_close_map": {"000007": 12.3}},
+        "name_map": {"000007": "全新好"},
+    }
+
+    got = recommendation_write_symbols(
+        [],
+        step2_details=details,
+        trade_mode=resolve_market_trade_mode("NEUTRAL"),
+    )
+
+    assert len(got) == 1
+    assert got[0]["candidate_status"] not in {"Lane", "alpha", "formal_l4"}
+    assert got[0]["candidate_status"] == "跨日确认观察"
+
+
 def test_recommendation_write_symbols_merges_multiple_tracking_signals():
     from core.market_trade_mode import resolve_market_trade_mode
     from workflows.daily_job_persistence import recommendation_write_symbols

--- a/web/packages/shared/src/pattern-review.ts
+++ b/web/packages/shared/src/pattern-review.ts
@@ -66,7 +66,11 @@ export function labelCandidateTerm(value: string): string | null {
     evr: 'EVR放量不跌',
     lps: 'LPS缩量回踩',
     spring: 'Spring震仓',
+    // 2026-09-01 前的历史行里 candidate_status 存的是生产者标签而非语义状态
+    // （Lane/alpha/formal_l4 共 6391 行）。写入侧已修，这里保留翻译只为让旧行可读。
     Lane: '入选路径',
+    alpha: '入选路径',
+    formal_l4: '正式触发',
     可买主线: '主线买点候选',
     主线买点候选: '主线买点候选',
     主线观察: '主线观察',


### PR DESCRIPTION
## 问题

生产 `signal_observations` 实测 7318 行:

| candidate_status 实际存的 | 行数 | 是什么 |
|---|---|---|
| `Lane` / `alpha` / `formal_l4` / `shadow_observe` | 6391 (87%) | 生产者标签 |
| `Accum_C` / `Accum_B` / `Markup` | 104 | Wyckoff 阶段名 |

交叉表按 `(candidate_lane, entry_type)` 分组显示:这 6391 行的取值 100% 由
`candidate_lane` 决定。这一列等于白占,没带任何信息。

根因 `core/candidate_metadata.py:111` 把候选条目的 `state` 直抄进 `candidate_status`。
`state` 一个字段承载两种东西:`_formal_candidate_entries` 写 `stage_map` 命中的阶段名、
否则写 `"formal_l4"`;alpha/Lane/Mainline 三条产出路径写各自的通道标签。两者都不是
候选状态,而下游把这一列当纯语义位用(`TRADEABLE_MAINLINE_STATUSES` 按它放行推荐写入)。

## 两个后果

**1. 6391 行永远拿不到真状态。** `_tracking_status` 里 `if existing: return existing`
把标签当成已有状态,默认分支走不到,`跨日确认观察` / `AI复核候选` / `市场拦截观察`
都发不出去。

**2. 漏斗检验的 L4 口径错了。** `_formal_candidate_entries` 写
`stage_map.get(code, "formal_l4")`,stage 已知时连 `formal_l4` 这个标记本身都被顶掉。
按 `candidate_status == "formal_l4"` 建 L4 集合就漏了 104 只正式候选,还把它们算进
对照池——这正是已合并的 #365 输入口径错的地方。

## 改动

- `_semantic_status()` 过滤生产者标签与阶段名,状态位只收真状态;主线路径仍从
  `mainline.status` 取,不受影响
- `core/candidate_tracks.py` 落三个规范常量:`FORMAL_L4_LANES`(六条正式通道)、
  `CANDIDATE_PRODUCER_TAGS`、`WYCKOFF_STAGE_NAMES`。层级归属按
  `candidate_lane in FORMAL_L4_LANES` 判,不再比字符串
- `agents/screen_tools.py` 的 `stage` 回到唯一来源 `metrics.accum_stage_map`,
  删掉 `metadata.get("candidate_status")` 兜底(那只是因为阶段名被写进了状态位)
- 新增 `scripts/build_funnel_cands.py`:漏斗检验输入可复现(70 交易日 / 宽池 7201 /
  正式 L4 903),不再靠 `/tmp` 里的一次性脚本。旧脚本已删,那个错口径当时不可复审
- 前端保留 `Lane` / `alpha` / `formal_l4` 的翻译,只为让修复前的历史行可读

## 复算:#365 的结论稳

用修正后的 903 行 L4 定义重跑 `l4_vs_rest`(宽池内 L4 vs 非 L4):

| H | 日数 | L4 净收益 | 配对对照 | 超额 | t | 为正日 | 随机带 | 判定 |
|---|---|---|---|---|---|---|---|---|
| T+5 | 35 | -2.60% | -4.63% | +2.03pct | +1.60 | 60% | +2.10~+2.58 | 带内 |
| T+10 | 30 | -4.43% | -8.71% | +4.28pct | **+3.72** | **77%** | +4.19~+5.40 | 带内 |
| T+20 | 20 | -4.75% | -11.79% | +7.05pct | **+3.48** | **75%** | +7.28~+8.73 | 带内 |

口径改对后原始信号反而更强(T+10 t 从 +3.55 升到 +3.72、为正日 70%→77%),但与同动量
随机对照的差距同步走宽,超额仍**全部落在随机带内**。边缘还是动量选位,不是选股。
残差动量 -0.13~-0.22pct,配对干净。

## 验证

- 全量 `4508 passed, 22 skipped`(修复暴露的 `test_screen_stocks_enriches_watch_candidates_from_candidate_metadata`
  已一并修正:它的 `stage == "Markup"` 原本靠 bug 传递,现在从 `accum_stage_map` 取)
- 新增 `TestCandidateStatusIsSemanticOnly`(9 例):标签/阶段名都进不了状态位、通道信息
  不丢、真语义状态保留、`FORMAL_L4_LANES` 与 `base_map` 键一致
- 新增 `test_producer_tagged_candidate_gets_a_real_tracking_status`:反证过——还原成
  修复前的直抄行为,该测试拿到 `Lane` 而失败
- ruff check / format 全绿,`quality_gate.py --check-no-sql` OK,`@wyckoff/shared` tsc 干净

## 未做

修复前的 6391 行历史数据没回填,靠前端翻译层兜。这些行的 `candidate_lane` 完好,
信息没真丢;回填要重跑历史 `_tracking_status` 才能得出当时该发什么状态,收益不抵风险。

🤖 Generated with [Claude Code](https://claude.com/claude-code)