### PR TITLE
fix(tracking): 起跳板/跨日确认行补齐报告字段族

### DIFF
--- a/core/signal_policy_shadow_schema.py
+++ b/core/signal_policy_shadow_schema.py
@@ -1,0 +1,75 @@
+"""``signal_policy_shadow_runs`` 缺失列的补列语句。
+
+本项目不保留 .sql 文件（``scripts/quality_gate.py --check-no-sql`` 会拦），且 Supabase
+Python SDK 走 REST 不支持 DDL、环境也无 psycopg2/asyncpg 与连接串，故 schema 以 Python
+常量形式版本化，由 ``scripts/print_signal_policy_shadow_ddl.py`` 打印后人工在 SQL
+Editor 执行一次。与 ``core/recommendation_tracking_schema.py``、``core/factor_ic_schema.py``
+同一套做法。
+
+这里只补列、不建表：``signal_policy_shadow_runs`` 早已存在（实测 21 列）。
+
+## 影子账本为什么停在 2026-07-01
+
+``strategy_policy_governor`` 的归因重算长期报 ``insufficient_shadow_sample``
+（``MIN_SHADOW_RUNS = 10`` / ``MIN_SHADOW_MATCHED = 3``），一直被读成"门槛太严"。
+实测这张表**只有 24 行、最新一行是 2026-07-01**，即写入方两个月前就停了，门槛是症状
+不是原因。
+
+停写时点与代码改动严格对应：``workflows/funnel_ai_selection.py`` 的
+``_policy_shadow_row`` 在 2026-07-04（``4ec40f05`` / ``e098a494``）新增了
+``attribution_signal_weights`` 与 ``attribution_policy_meta`` 两个键，而生产表没跟上。
+两者一起决定了此后每次写入都是 42703：
+
+    column signal_policy_shadow_runs.attribution_signal_weights does not exist
+
+而 ``upsert_policy_shadow_run`` 用的是 ``raise_on_error=False``，异常只落到
+``logger.warning``，日志里那行 ``动态策略shadow已写入 ... written=0`` 看着像正常输出。
+于是漏斗每天照跑、影子对照一行没进、归因重算永久卡在 insufficient_sample，两个月无人
+察觉。
+
+对照 ``recommendation_tracking`` 那次：写入侧有"剔掉报错列重试"的降级，缺列只丢字段
+不丢行。这张表没有那层降级，缺列直接丢整行——同一种 schema 漂移，后果重一个量级。
+本次同时给 ``_execute_upsert`` 补上按表登记的可选列降级（见
+``OPTIONAL_COLUMNS_BY_TABLE``），下次再加列最坏只丢字段。
+"""
+
+from __future__ import annotations
+
+from core.constants import TABLE_SIGNAL_POLICY_SHADOW_RUNS
+
+# (列名, 类型, 注释)。类型与表内同类列对齐：结构化 payload 用 jsonb
+# （实测 base_policy / signal_weights 回来就是 dict）。
+MISSING_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    (
+        "attribution_signal_weights",
+        "jsonb",
+        "归因产出的信号权重（shadow 口径）。缺列会让整行写入 42703 失败",
+    ),
+    (
+        "attribution_policy_meta",
+        "jsonb",
+        "归因快照元信息：report_date/next_action/source/weight_count 等",
+    ),
+)
+
+
+def build_ddl() -> str:
+    """生成补列语句。幂等——``add column if not exists`` 可重复执行。"""
+    lines = [
+        f"-- 补 public.{TABLE_SIGNAL_POLICY_SHADOW_RUNS} 的两个缺失列。",
+        "-- 2026-07-04 起写入侧新增这两个键，生产表未跟上，此后每次 upsert 都 42703；",
+        "-- 且该写入是 raise_on_error=False，异常只进 logger.warning，两个月静默无产出。",
+        "",
+        f"alter table public.{TABLE_SIGNAL_POLICY_SHADOW_RUNS}",
+    ]
+    clauses = [f"    add column if not exists {name} {ddl_type}" for name, ddl_type, _ in MISSING_COLUMNS]
+    lines.append(",\n".join(clauses) + ";")
+    lines.append("")
+    for name, _, comment in MISSING_COLUMNS:
+        lines.append(f"comment on column public.{TABLE_SIGNAL_POLICY_SHADOW_RUNS}.{name} is")
+        lines.append(f"    '{comment}';")
+    return "\n".join(lines)
+
+
+def column_names() -> frozenset[str]:
+    return frozenset(name for name, _, _ in MISSING_COLUMNS)

--- a/core/signal_policy_shadow_schema.py
+++ b/core/signal_policy_shadow_schema.py
@@ -31,6 +31,12 @@ Editor 执行一次。与 ``core/recommendation_tracking_schema.py``、``core/fa
 不丢行。这张表没有那层降级，缺列直接丢整行——同一种 schema 漂移，后果重一个量级。
 本次同时给 ``_execute_upsert`` 补上按表登记的可选列降级（见
 ``OPTIONAL_COLUMNS_BY_TABLE``），下次再加列最坏只丢字段。
+
+## 现状
+
+DDL 已于 2026-09-01 在 SQL Editor 执行，两列实测存在。此后本模块的作用从"待执行的补列
+清单"转为**版本化记录**：``MISSING_COLUMNS`` 仍是 ``OPTIONAL_COLUMNS_BY_TABLE`` 的数据源，
+即"这两列缺了也只丢字段不丢行"，所以不能因为已建好就删掉。
 """
 
 from __future__ import annotations

--- a/integrations/supabase_signal_feedback.py
+++ b/integrations/supabase_signal_feedback.py
@@ -13,6 +13,7 @@ from core.constants import (
     TABLE_SIGNAL_POLICY_SHADOW_RUNS,
     TABLE_SIGNAL_REGISTRY,
 )
+from core.signal_policy_shadow_schema import column_names as _SHADOW_OPTIONAL_COLUMNS_FN
 from integrations.supabase_base import close_client as _close
 from integrations.supabase_base import create_admin_client as _admin
 from integrations.supabase_base import is_admin_configured as _configured
@@ -34,6 +35,19 @@ OPTIONAL_SIGNAL_OBSERVATION_COLUMNS = (
     "signal_key",
     "candidate_status",
 )
+
+# 缺列时可以牺牲的列，按表登记。命中就剔掉重试，只丢字段不丢行。
+#
+# 为什么要扩到 shadow_runs：这层降级原先只保 signal_observations，别的表缺列直接丢整行。
+# 2026-07-04 ``_policy_shadow_row`` 新增 attribution_signal_weights /
+# attribution_policy_meta 两个键而生产表没跟上，此后每次 upsert 都 42703；又因
+# ``upsert_policy_shadow_run`` 是 raise_on_error=False，异常只进 logger.warning，
+# 影子账本停在 2026-07-01 整两个月无人发现，归因重算一直误报 insufficient_shadow_sample。
+# 补 DDL（core/signal_policy_shadow_schema.py）治本，这里治「下次再漂移」。
+OPTIONAL_COLUMNS_BY_TABLE: dict[str, tuple[str, ...]] = {
+    TABLE_SIGNAL_OBSERVATIONS: OPTIONAL_SIGNAL_OBSERVATION_COLUMNS,
+    TABLE_SIGNAL_POLICY_SHADOW_RUNS: tuple(sorted(_SHADOW_OPTIONAL_COLUMNS_FN())),
+}
 
 
 def _recent_cutoff(days: int) -> str:
@@ -67,14 +81,20 @@ def _looks_like_schema_miss(exc: Exception) -> bool:
     return "column" in text or "schema cache" in text or "could not find" in text
 
 
-def _drop_optional_columns(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    clean = []
-    for row in rows:
-        r = dict(row)
-        for column in OPTIONAL_SIGNAL_OBSERVATION_COLUMNS:
-            r.pop(column, None)
-        clean.append(r)
-    return clean
+def _drop_optional_columns(table: str, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
+    """剔掉该表登记的可选列，返回 (新行, 实际剔掉的列)。
+
+    返回剔掉了哪些列是为了让调用方 warn 出来：静默降级正是影子账本停摆两个月
+    没被发现的原因。
+    """
+    optional = OPTIONAL_COLUMNS_BY_TABLE.get(table, ())
+    if not optional:
+        return rows, []
+    dropped = sorted({column for row in rows for column in optional if column in row})
+    if not dropped:
+        return rows, []
+    clean = [{key: value for key, value in row.items() if key not in set(dropped)} for row in rows]
+    return clean, dropped
 
 
 def _execute_upsert(
@@ -93,9 +113,17 @@ def _execute_upsert(
         try:
             client.table(table).upsert(rows, on_conflict=conflict).execute()
         except Exception as exc:
-            if table != TABLE_SIGNAL_OBSERVATIONS or not _looks_like_schema_miss(exc):
+            if not _looks_like_schema_miss(exc):
                 raise
-            client.table(table).upsert(_drop_optional_columns(rows), on_conflict=conflict).execute()
+            compatible, dropped = _drop_optional_columns(table, rows)
+            if not dropped:
+                raise
+            logger.warning(
+                "%s missing optional columns; retried without %s (run scripts/print_*_ddl.py and apply)",
+                table,
+                dropped,
+            )
+            client.table(table).upsert(compatible, on_conflict=conflict).execute()
         return len(rows)
     except Exception as exc:
         logger.warning("upsert %s failed: %s", table, exc)

--- a/scripts/print_signal_policy_shadow_ddl.py
+++ b/scripts/print_signal_policy_shadow_ddl.py
@@ -1,0 +1,26 @@
+"""打印 signal_policy_shadow_runs 的补列语句，供人工在 Supabase SQL Editor 执行。
+
+本项目不保留 .sql 文件，且 Supabase Python SDK 走 REST 不支持 DDL,
+故 schema 以 core/signal_policy_shadow_schema.py 的常量形式版本化并由此脚本输出。
+
+执行完这段 DDL，影子账本才会重新有产出（自 2026-07-04 起因缺列静默丢行）。
+
+用法::
+
+    python scripts/print_signal_policy_shadow_ddl.py
+"""
+
+from __future__ import annotations
+
+import _bootstrap  # noqa: F401
+
+from core.signal_policy_shadow_schema import build_ddl
+
+
+def main() -> int:
+    print(build_ddl())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_signal_policy_shadow_schema.py
+++ b/tests/core/test_signal_policy_shadow_schema.py
@@ -46,11 +46,12 @@ def test_declared_columns_are_actually_emitted_by_the_writer() -> None:
 
 
 def test_writer_columns_are_all_either_live_or_pending_ddl() -> None:
-    """写入侧新加键时,要么表里已有,要么必须登记进 MISSING_COLUMNS 等人工执行 DDL。
+    """写入侧新加键时，要么表里已有，要么必须登记进 MISSING_COLUMNS。
 
-    这条是本次事故的直接防线:2026-07-04 那两个键当时既不在表里、也没有任何清单
-    记着它们缺,于是没有任何环节会报警。``_LIVE_COLUMNS`` 是 2026-09-01 对生产表
-    实测的列集合;下次改 payload 若引入新键,这条会失败并要求同步登记。
+    这条是本次事故的直接防线：2026-07-04 那两个键当时既不在表里、也没有任何清单
+    记着它们缺，于是没有任何环节会报警。下面那份 live_columns 是 2026-09-01 对生产表
+    实测的**建列前**基线（那两列于同日补上，现已存在，仍留在 MISSING_COLUMNS 里作为
+    「缺了只丢字段」的登记）；下次改 payload 若引入新键，这条会失败并要求同步登记。
     """
     from workflows import funnel_ai_selection
 

--- a/tests/core/test_signal_policy_shadow_schema.py
+++ b/tests/core/test_signal_policy_shadow_schema.py
@@ -1,0 +1,84 @@
+"""``signal_policy_shadow_runs`` 补列语句与写入侧的自洽约束。
+
+背景：影子账本停在 2026-07-01 整两个月无产出，归因重算一直报
+``insufficient_shadow_sample``，一直被读成「门槛太严」。真因是 2026-07-04
+``_policy_shadow_row`` 新增了 ``attribution_signal_weights`` /
+``attribution_policy_meta`` 两个键而生产表没跟上：此后每次 upsert 都 42703，
+且 ``upsert_policy_shadow_run`` 是 ``raise_on_error=False``，异常只进
+``logger.warning``，日志那行还写着「已写入」。
+
+和 ``recommendation_tracking`` 那次的关键差别：那张表有「剔掉报错列重试」的降级，
+缺列只丢字段；这张表没有，缺列丢整行。所以同一种漂移在这里后果重一个量级，值得
+把「写入侧发的键」和「schema 清单」在 CI 里钉死。
+
+这些用例不连生产库。
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from core.signal_policy_shadow_schema import MISSING_COLUMNS, build_ddl, column_names
+
+
+def test_ddl_is_idempotent_add_column() -> None:
+    """人工执行一次，重跑不能炸 —— 不确定当前表状态时得能安全重放。"""
+    ddl = build_ddl()
+    assert ddl.count("add column if not exists") == len(MISSING_COLUMNS)
+    assert "create table" not in ddl.lower()
+    assert "drop" not in ddl.lower()
+
+
+def test_ddl_covers_every_declared_column() -> None:
+    ddl = build_ddl()
+    for name, ddl_type, _ in MISSING_COLUMNS:
+        assert f"add column if not exists {name} {ddl_type}" in ddl
+
+
+def test_declared_columns_are_actually_emitted_by_the_writer() -> None:
+    """补的列必须确实是 ``_policy_shadow_row`` 会发的键，否则补了也没人用。"""
+    from workflows import funnel_ai_selection
+
+    source = inspect.getsource(funnel_ai_selection._policy_shadow_row)
+    for name in column_names():
+        assert f'"{name}"' in source, f"{name} 不在 _policy_shadow_row 的 payload 里"
+
+
+def test_writer_columns_are_all_either_live_or_pending_ddl() -> None:
+    """写入侧新加键时,要么表里已有,要么必须登记进 MISSING_COLUMNS 等人工执行 DDL。
+
+    这条是本次事故的直接防线:2026-07-04 那两个键当时既不在表里、也没有任何清单
+    记着它们缺,于是没有任何环节会报警。``_LIVE_COLUMNS`` 是 2026-09-01 对生产表
+    实测的列集合;下次改 payload 若引入新键,这条会失败并要求同步登记。
+    """
+    from workflows import funnel_ai_selection
+
+    live_columns = {
+        "market",
+        "trade_date",
+        "regime",
+        "schema_version",
+        "snapshot_level",
+        "base_policy",
+        "shadow_policy",
+        "signal_weights",
+        "base_selected",
+        "shadow_selected",
+        "diff_added",
+        "diff_removed",
+        "selection_summary",
+        "policy_summary",
+        "registry_summary",
+        "health_summary",
+        "registry_snapshot",
+        "health_snapshot",
+        "updated_at",
+        "created_at",
+    }
+    source = inspect.getsource(funnel_ai_selection._policy_shadow_row)
+    # payload 的键都是 return 字典里缩进 8 格的 `"name":` 字面量。
+    emitted = set(re.findall(r'^\s{8}"([a-z_]+)":', source, flags=re.MULTILINE))
+    assert emitted, "没能从 _policy_shadow_row 解析出 payload 键，正则需要跟着改"
+    unaccounted = emitted - live_columns - column_names()
+    assert not unaccounted, f"这些键既不在生产表里也没登记进 MISSING_COLUMNS: {sorted(unaccounted)}"

--- a/tests/test_signal_feedback.py
+++ b/tests/test_signal_feedback.py
@@ -586,6 +586,57 @@ def test_signal_observations_drop_features_json_when_schema_missing(monkeypatch)
     assert "features_json" not in client.rows[0]
 
 
+def test_policy_shadow_run_drops_attribution_columns_when_schema_missing(monkeypatch, caplog):
+    """缺列必须降级成「丢字段」而不是「丢整行」，且必须 warn 出来。
+
+    影子账本停在 2026-07-01 整两个月无人发现，正是因为这里既没有降级（缺列丢整行）
+    也没有告警（``raise_on_error=False`` + 日志写着「已写入」）。
+    """
+    import logging
+
+    from integrations import supabase_signal_feedback
+
+    client = _SchemaMissThenCaptureClient()
+    monkeypatch.setenv("WYCKOFF_WRITE_CONTEXT", "server_job")
+    monkeypatch.setattr(supabase_signal_feedback, "_configured", lambda: True)
+    monkeypatch.setattr(supabase_signal_feedback, "_admin", lambda: client)
+    monkeypatch.setattr(supabase_signal_feedback, "_close", lambda _client: None)
+
+    row = {
+        "market": "cn",
+        "trade_date": "2026-07-04",
+        "regime": "NEUTRAL",
+        "base_selected": ["000001"],
+        "attribution_signal_weights": {"lps": 0.5},
+        "attribution_policy_meta": {"report_date": "2026-07-04"},
+    }
+
+    with caplog.at_level(logging.WARNING):
+        assert supabase_signal_feedback.upsert_policy_shadow_run(row) == 1
+    assert client.calls == 2
+    assert "attribution_signal_weights" not in client.rows[0]
+    assert "attribution_policy_meta" not in client.rows[0]
+    # 行本身必须留下来 —— 缺列只该丢字段。
+    assert client.rows[0]["trade_date"] == "2026-07-04"
+    assert any("missing optional columns" in record.message for record in caplog.records)
+
+
+def test_schema_miss_without_registered_optional_columns_still_raises(monkeypatch):
+    """没登记可选列的表不能被这层降级悄悄吞掉异常。"""
+    from integrations import supabase_signal_feedback
+
+    client = _SchemaMissThenCaptureClient()
+    monkeypatch.setenv("WYCKOFF_WRITE_CONTEXT", "server_job")
+    monkeypatch.setattr(supabase_signal_feedback, "_configured", lambda: True)
+    monkeypatch.setattr(supabase_signal_feedback, "_admin", lambda: client)
+    monkeypatch.setattr(supabase_signal_feedback, "_close", lambda _client: None)
+
+    # signal_registry 没登记可选列：缺列应当照常抛出，不进降级。
+    with pytest.raises(RuntimeError):
+        supabase_signal_feedback.upsert_signal_registry([{"market": "cn", "signal_type": "sos", "regime": "ALL"}])
+    assert client.calls == 1
+
+
 def test_summarize_signal_health_classifies_watch_and_all_regime():
     outcomes = []
     for idx in range(20):

--- a/tests/workflows/test_daily_job_preview.py
+++ b/tests/workflows/test_daily_job_preview.py
@@ -359,6 +359,127 @@ def test_recommendation_write_symbols_merges_multiple_tracking_signals():
     assert got[0]["tag"] == "双形态共振(SOS+LPS)"
 
 
+def _enrichment_details() -> dict:
+    return {
+        "formal_triggers": {"sos": [("000007", 9.0)]},
+        "review_triggers": {"sos": [("000007", 9.0)]},
+        "springboard_map": {"sos:000007": {"springboard_met_count": 2, "springboard_grade": "A+C"}},
+        "metrics": {
+            "latest_close_map": {"000007": 12.3, "000009": 8.6},
+            "accum_stage_map": {"000007": "Markup", "000009": "Accumulation"},
+            "layer3_score_map": {"000007": 71.5, "000009": 64.0},
+            "sector_rotation": {
+                "state_map": {
+                    "测试行业": {
+                        "state": "leading",
+                        "label": "领涨",
+                        "note": "资金持续流入",
+                        "guidance": "可正常参与",
+                    }
+                }
+            },
+            "exit_signals": {"000009": {"signal": "跌破MA20", "price": 8.1, "reason": "量能衰竭"}},
+            "theme_radar": {
+                "strategic_candidates": [
+                    {"code": "000007", "theme": "机器人", "theme_score": 0.72, "stock_score": 0.66, "state": "active"},
+                    {"code": "000009", "theme": "机器人", "theme_score": 0.72, "stock_score": 0.61, "state": "active"},
+                ]
+            },
+            "capital_migration": {"inflow": [{"theme": "机器人", "score": 0.5}]},
+        },
+        "name_map": {"000007": "全新好", "000009": "测试股"},
+        "sector_map": {"000007": "测试行业", "000009": "测试行业"},
+        "priority_score_map": {"000009": 55.0},
+    }
+
+
+def test_bypassing_producers_get_the_full_report_field_family():
+    """起跳板行与跨日确认行不再丢行业轮动/主题/资金迁移/离场字段。
+
+    2026-09-01 实测：生产库 822 行里 690 行 ``l4_springboard`` 和 129 行
+    ``signal_confirmed`` 的 ``sector_state_code``/``strategic_theme*``/
+    ``capital_migration_bonus``/``exit_signal`` 全 100% NULL,只有 3 行
+    ``mainline`` 带全 —— 因为前两者各自从零拼 dict,绕开了
+    ``build_symbol_report_row``,而 ``FunnelReportMaps`` 不进 step2_details。
+    """
+    from core.market_trade_mode import resolve_market_trade_mode
+    from workflows.daily_job_persistence import recommendation_write_symbols
+
+    confirmed = {
+        "code": "000009",
+        "name": "测试股",
+        "signal_status": "confirmed",
+        "selection_source": "signal_confirmed",
+        "signal_type": "lps",
+        "track": "Accum",
+        "score": 61.0,
+    }
+
+    got = recommendation_write_symbols(
+        [confirmed],
+        step2_details=_enrichment_details(),
+        trade_mode=resolve_market_trade_mode("NEUTRAL"),
+    )
+    by_code = {row["code"]: row for row in got}
+
+    springboard = by_code["000007"]
+    assert springboard["sector_state_code"] == "leading"
+    assert springboard["sector_state"] == "领涨"
+    assert springboard["sector_guidance"] == "可正常参与"
+    assert springboard["strategic_theme"] == "机器人"
+    assert springboard["strategic_theme_score"] == 0.72
+    assert springboard["strategic_theme_bonus"] > 0
+    assert springboard["capital_migration_bonus"] > 0
+    assert springboard["layer3_quality_score"] == 71.5
+    # 生产者已给出的值不被复原值覆盖
+    assert springboard["tag"] == "SOS起跳板结构(A+C)"
+    assert springboard["stage"] == "Markup"
+
+    confirmed_row = by_code["000009"]
+    assert confirmed_row["industry"] == "测试行业"
+    assert confirmed_row["stage"] == "Accumulation"
+    assert confirmed_row["priority_score"] == 55.0
+    assert confirmed_row["primary_signal"] == "lps"
+    assert confirmed_row["signal_types"] == ["lps"]
+    assert confirmed_row["sector_state_code"] == "leading"
+    assert confirmed_row["exit_signal"] == "跌破MA20"
+    assert confirmed_row["exit_price"] == 8.1
+    assert confirmed_row["exit_reason"] == "量能衰竭"
+    assert confirmed_row["capital_migration_bonus"] > 0
+    # priority_rank 只在排序上下文里有意义,不能补一个假名次
+    assert "priority_rank" not in confirmed_row
+
+
+def test_enrichment_never_overwrites_existing_tracking_values():
+    from core.market_trade_mode import resolve_market_trade_mode
+    from workflows.daily_job_persistence import recommendation_write_symbols
+
+    mainline = {
+        "code": "000009",
+        "signal_status": "confirmed",
+        "selection_source": "mainline",
+        "industry": "既有行业",
+        "sector_state_code": "lagging",
+        "strategic_theme": "既有主题",
+        "strategic_theme_bonus": 0.0,
+        "priority_score": 90.0,
+        "stage": "Distribution",
+    }
+
+    got = recommendation_write_symbols(
+        [mainline],
+        step2_details=_enrichment_details(),
+        trade_mode=resolve_market_trade_mode("NEUTRAL"),
+    )
+    row = next(item for item in got if item["code"] == "000009")
+
+    assert row["industry"] == "既有行业"
+    assert row["sector_state_code"] == "lagging"
+    assert row["strategic_theme"] == "既有主题"
+    assert row["priority_score"] == 90.0
+    assert row["stage"] == "Distribution"
+
+
 def test_step3_springboard_updates_patch_recommendation_payload():
     from workflows.daily_signal_observations import apply_step3_springboard_updates
 

--- a/workflows/daily_job_persistence.py
+++ b/workflows/daily_job_persistence.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any
 
 from core.candidate_metadata import build_candidate_metadata_map, code6
+from core.funnel_report import FunnelReportMaps, build_symbol_report_row
 from core.mainline_engine import TRADEABLE_MAINLINE_STATUSES
 from core.market_trade_mode import MarketTradeMode, resolve_market_trade_mode
 from core.signal_feedback import signal_track
@@ -18,11 +19,15 @@ from integrations.recommendation_payload import (
     write_recommendation_backup_artifact,
 )
 from integrations.supabase_market_signal import upsert_market_signal_daily
+from utils.safe import has_value
 from utils.safe import safe_float as _safe_float
+from workflows.funnel_render_context import rebuild_report_maps
 from workflows.step4_pipeline import TZ, is_confirmed_step4_candidate
 from workflows.step4_text import clean_text as _clean_text
 
 RECOMMENDATION_MAINLINE_STATUSES = TRADEABLE_MAINLINE_STATUSES
+# priority_rank 只有排序上下文才有意义，补一个 0 会让 selection_rank 读到假名次。
+_ENRICH_SKIP_KEYS = frozenset({"priority_rank"})
 RECOMMENDATION_STRATEGIC_MIN_THEME_SCORE = 0.45
 RECOMMENDATION_STRATEGIC_MIN_STOCK_SCORE = 0.55
 STEP3_CONFIRMED_REVIEW_CAP = "STEP3_CONFIRMED_REVIEW_CAP"
@@ -111,7 +116,70 @@ def recommendation_write_symbols(
     rows = [_tracking_symbol(item, mode) for item in symbols_info if is_recommendation_tracking_candidate(item)]
     if step2_details:
         rows.extend(_springboard_tracking_symbols(step2_details, mode))
+        _enrich_tracking_rows(rows, step2_details)
     return _dedupe_tracking_symbols(rows)
+
+
+def _enrich_tracking_rows(rows: list[dict], step2_details: dict) -> None:
+    """补齐绕过 build_symbol_report_row 的写入行的报告字段族。
+
+    起跳板行(`_springboard_tracking_row`)与跨日确认行(`_confirmed_symbol_info`)各自
+    从零拼 dict,行业轮动/主题/资金迁移/离场信号字段全部缺失,归因表里这些列长期
+    100% NULL。这里用同一套映射复原并只填缺失键,已有值(含 mainline 行)不动。
+    """
+    metrics = step2_details.get("metrics") or {}
+    if not metrics:
+        return
+    maps = rebuild_report_maps(
+        metrics,
+        name_map=step2_details.get("name_map") or {},
+        sector_map=step2_details.get("sector_map") or {},
+        triggers=step2_details.get("review_triggers") or step2_details.get("triggers") or {},
+    )
+    priority_scores = step2_details.get("priority_score_map") or {}
+    stage_map = metrics.get("accum_stage_map") or {}
+    for row in rows:
+        _seed_signal_family(row)
+        _fill_report_fields(row, maps, priority_scores, stage_map)
+
+
+def _seed_signal_family(row: dict) -> None:
+    """跨日确认行只带单数 signal_type,归因列读的是 signal_types/primary_signal。"""
+    signal = _clean_text(row.get("signal_type")).lower()
+    if not signal:
+        return
+    if not row.get("signal_types"):
+        row["signal_types"] = [signal]
+    if not _clean_text(row.get("primary_signal")):
+        row["primary_signal"] = signal
+
+
+def _fill_report_fields(
+    row: dict,
+    maps: FunnelReportMaps,
+    priority_scores: dict[str, Any],
+    stage_map: dict[str, str],
+) -> None:
+    code = code6(row.get("code"))
+    score = _safe_float(row.get("score"))
+    reference = build_symbol_report_row(
+        code,
+        rank=int(_safe_float(row.get("priority_rank"), 0.0) or 0),
+        tag=str(row.get("tag") or ""),
+        track=str(row.get("track") or ""),
+        stage=str(row.get("stage") or stage_map.get(code, "") or ""),
+        score=score,
+        priority_score=_safe_float(priority_scores.get(code), score),
+        selection_source=str(row.get("selection_source") or ""),
+        selection_is_fill=bool(row.get("selection_is_fill")),
+        market_regime=str(row.get("market_regime") or ""),
+        maps=maps,
+    )
+    for key, value in reference.items():
+        if key in _ENRICH_SKIP_KEYS:
+            continue
+        if not has_value(row.get(key)) and has_value(value):
+            row[key] = value
 
 
 def step3_review_symbols(

--- a/workflows/funnel_ai_selection.py
+++ b/workflows/funnel_ai_selection.py
@@ -246,10 +246,20 @@ def maybe_persist_policy_shadow_run(
     diff_added, diff_removed = selection_diff(selected_for_ai, shadow_selected)
     row = _policy_shadow_row(ai_policy, metrics, selected_for_ai, shadow_selected, diff_added, diff_removed, regime)
     written = upsert_policy_shadow_run(row)
-    print(
-        "[funnel] 动态策略shadow已写入 signal_policy_shadow_runs: "
-        f"written={written}, added={len(diff_added)}, removed={len(diff_removed)}"
-    )
+    if written:
+        print(
+            "[funnel] 动态策略shadow已写入 signal_policy_shadow_runs: "
+            f"written={written}, added={len(diff_added)}, removed={len(diff_removed)}"
+        )
+    else:
+        # 原先「已写入 ... written=0」照样打印，读着像正常输出。实测这条就是影子账本
+        # 2026-07-04 起停摆两个月没被发现的原因：upsert 是 raise_on_error=False，
+        # 缺列异常只进 logger.warning，而这行日志说的是「已写入」。
+        print(
+            "[funnel] 警告: 动态策略shadow写入失败(0 行落库)，"
+            "归因重算会持续报 insufficient_shadow_sample；"
+            "检查 signal_policy_shadow_runs 是否缺列(scripts/print_signal_policy_shadow_ddl.py)"
+        )
     return _policy_shadow_meta(written, shadow_selected, diff_added, diff_removed, score_map)
 
 

--- a/workflows/funnel_render_context.py
+++ b/workflows/funnel_render_context.py
@@ -127,6 +127,15 @@ class _ReviewScoreContext:
 
 
 @dataclass(frozen=True)
+class _ThemeMaps:
+    theme_candidate_map: dict
+    theme_badge_map: dict[str, str]
+    theme_bonus_map: dict[str, float]
+    capital_migration_bonus_map: dict[str, float]
+    capital_migration_badge_map: dict[str, str]
+
+
+@dataclass(frozen=True)
 class _MetricPools:
     l2_bypass_pool: list[str]
     strategic_pool: list[str]
@@ -260,6 +269,50 @@ def _build_report_maps(
     )
 
 
+def rebuild_report_maps(
+    metrics: dict,
+    *,
+    name_map: dict[str, str] | None = None,
+    sector_map: dict[str, str] | None = None,
+    triggers: dict[str, list[tuple[str, float]]] | None = None,
+) -> FunnelReportMaps:
+    """从 metrics 复原报告字段族映射,不触发任何网络 I/O。
+
+    `build_render_context` 只在渲染期存在,`FunnelReportMaps` 不进 step2_details,
+    所以绕过 `build_symbol_report_row` 的写入方(起跳板/跨日确认)拿不到行业轮动、
+    主题、资金迁移、离场信号字段。这里用同一套纯函数复原,name_map/sector_map 由
+    调用方从 step2_details 传入,避免重复 `load_stock_name_map()`/`fetch_sector_map()`。
+    """
+    themes = _theme_maps(metrics)
+    pools = _metric_pools(metrics)
+    score_ctx = _build_review_score_context(
+        metrics,
+        triggers or {},
+        pools.strategic_pool,
+        pools.bypass_triggers,
+        pools.strategic_triggers,
+        pools.candidate_entry_map,
+        themes.theme_badge_map,
+        themes.theme_bonus_map,
+        themes.capital_migration_badge_map,
+        themes.capital_migration_bonus_map,
+        benchmark_context=metrics.get("benchmark_context", {}) or {},
+    )
+    return _build_report_maps(
+        name_map or {},
+        sector_map or {},
+        pools.sector_rotation_map,
+        pools.exit_signals,
+        metrics.get("latest_close_map", {}) or {},
+        themes.theme_candidate_map,
+        themes.theme_bonus_map,
+        score_ctx,
+        themes.theme_badge_map,
+        themes.capital_migration_bonus_map,
+        metrics.get("layer3_score_map", {}) or {},
+    )
+
+
 def _build_review_score_context(
     metrics: dict,
     triggers: dict[str, list[tuple[str, float]]],
@@ -314,8 +367,23 @@ def _base_render_context(
 ]:
     benchmark_context = metrics.get("benchmark_context", {}) or {}
     name_map, sector_map, latest_close_map = _load_run_reference_maps(metrics, benchmark_context)
+    themes = _theme_maps(metrics)
+    return (
+        benchmark_context,
+        name_map,
+        sector_map,
+        latest_close_map,
+        themes.theme_candidate_map,
+        themes.theme_badge_map,
+        themes.theme_bonus_map,
+        themes.capital_migration_bonus_map,
+        themes.capital_migration_badge_map,
+    )
+
+
+def _theme_maps(metrics: dict) -> _ThemeMaps:
+    """主题/资金迁移映射,纯函数(只读 metrics),离线复原报告字段族时可复用。"""
     theme_candidate_map = build_theme_candidate_map(metrics.get("theme_radar") or {})
-    theme_badge_map = build_theme_badge_map(theme_candidate_map)
     theme_bonus_map = build_theme_bonus_map(theme_candidate_map, FUNNEL_THEME_RADAR_BONUS_MAX)
     capital_migration_bonus_map = build_capital_migration_bonus_map(
         theme_candidate_map,
@@ -323,20 +391,15 @@ def _base_render_context(
         bonus_max=FUNNEL_CAPITAL_MIGRATION_BONUS_MAX,
         penalty_max=FUNNEL_CAPITAL_MIGRATION_PENALTY_MAX,
     )
-    capital_migration_badge_map = build_capital_migration_badge_map(
-        theme_candidate_map,
-        capital_migration_bonus_map,
-    )
-    return (
-        benchmark_context,
-        name_map,
-        sector_map,
-        latest_close_map,
-        theme_candidate_map,
-        theme_badge_map,
-        theme_bonus_map,
-        capital_migration_bonus_map,
-        capital_migration_badge_map,
+    return _ThemeMaps(
+        theme_candidate_map=theme_candidate_map,
+        theme_badge_map=build_theme_badge_map(theme_candidate_map),
+        theme_bonus_map=theme_bonus_map,
+        capital_migration_bonus_map=capital_migration_bonus_map,
+        capital_migration_badge_map=build_capital_migration_badge_map(
+            theme_candidate_map,
+            capital_migration_bonus_map,
+        ),
     )
 
 


### PR DESCRIPTION
## 问题

`recommendation_tracking` 里的归因字段族按 `selection_source` 分组实测（822 行，`recommend_date ≥ 20260717`）：

| selection_source | n | 实际缺的 |
|---|--:|---|
| `l4_springboard` | 138 | 8 列 100% NULL：`capital_migration_bonus`、`strategic_theme_bonus`、`strategic_theme_score`、`strategic_stock_score`、`strategic_theme`、`sector_state_code`、`exit_signal`、`exit_price`；`stage` NULL 125/138 |
| `l4_springboard:market_blocked` | 552 | 同上 8 列 100% NULL；`stage` NULL 482/552 |
| `signal_confirmed` | 18 | 同上 8 列，**外加** `priority_score`/`industry`/`stage` 100% NULL；`primary_signal` NULL 14/18；`signal_types` 空 14/18 |
| `signal_confirmed:market_blocked` | 111 | 同上，`priority_score`/`industry`/`stage` NULL 111；`primary_signal` NULL 95 |
| `mainline` | 3 | 几乎带全 |

即：**819 行归因样本缺行业轮动、主题、资金迁移、离场信号，只有 3 行是完整的。** 复盘按板块状态或主题强度切片时，这些行只能整体丢掉。

## 根因

三个生产者，只有一个发全字段族：

- `core/funnel_report.py:27` `build_symbol_report_row` — 唯一发出完整字段族的地方（`mainline` 走这条）
- `workflows/daily_job_persistence.py` `_springboard_tracking_row` — 从零拼 dict
- `core/signal_confirmation.py:383` `_confirmed_symbol_info` — 从零拼 dict

后两者不是"忘了填"，是**拿不到映射**：`FunnelReportMaps` 只在渲染期由 `build_render_context` 造出来，`funnel_run_details` 往 `step2_details` 里拷了约 30 个键，其中没有 `report_maps`。

## 改法

`FunnelReportMaps` 的每个输入都在 `metrics` 里（`sector_rotation` / `capital_migration` / `theme_radar` / `layer3_score_map` / `exit_signals` / `latest_close_map` 逐个核过 `workflows/wyckoff_funnel.py:625-735`），`_metric_pools` 和主题映射都是只读 `metrics` 的纯函数；唯一的 I/O 是 `_load_run_reference_maps` 的 `load_stock_name_map()` + `fetch_sector_map()`，而 `name_map`/`sector_map` 本来就在 `step2_details` 里。

于是：

1. 抽 `_theme_maps(metrics)` 出来（`_base_render_context` 与新helper共用，行为不变）
2. 新增 `rebuild_report_maps(metrics, *, name_map, sector_map, triggers)` —— 复原同一套映射，**零额外网络 I/O**
3. 在 `recommendation_write_symbols` 这一个汇合点做**只填缺失键**的补齐

选这个点的理由：两个行族在这里合流；日常任务（`workflows/daily_job_step2.py` → `persist_recommendations`）和历史回补（`workflows/recommendation_backfill.py:106` `_build_day_result`）都走它，一处改动同时覆盖；不需要把 maps 参数一路穿到 `run_step2_5` → `run_confirmation_cycle` → `_confirmed_symbol_info`（那一层拿不到 metrics）。

两个细节：

- **只填缺失键**，`has_value()` 判定，所以 `mainline` 行和生产者已给出的 `tag`/`stage` 不受影响。与下游 `_is_missing_payload_value` 语义一致：`0`/`False` 算有值，不会被覆盖。
- **`priority_rank` 显式跳过**：它只在排序上下文里有意义，补一个 0 会让 `selection_rank` 读到假名次。

跨日确认行只带单数 `signal_type`，归因列读的是 `signal_types`/`primary_signal`，一并补上。

不需要 DDL —— 这 12 列在生产表 79 列里全都有，也都在 `RECOMMENDATION_ATTRIBUTION_COLUMNS` 里。

## 两条审计更正

之前把这两条也列进缺陷清单了，实测后撤回：

- **`selection_is_fill` 全 `False` 不是缺陷**，是 `_optional_bool(...) or False` 的正常取值，从来不是 NULL。
- **`capital_migration_bonus` 的历史 NULL 不是构建 bug**：该列今天才随 #355（`9c511465`）建好，全表零个非 NULL 值。`mainline` 行下一轮跑就自愈；起跳板/确认行仍需本次补齐，因为它们的生产者根本不发这个字段。

## 留了一个没动

`layer3_quality_score` 是审计侧孤字段：`build_symbol_report_row` 发出它，`workflows/step4_payload.py:353` 在内存里读它拼 AI 提示的 `L3质量=` 上下文行，但它既不在 `RECOMMENDATION_ATTRIBUTION_COLUMNS`、也不在 `RECOMMENDATION_BACKUP_COLUMNS`、也不在生产表里。**功能上没丢，只是跨轮复盘看不到。** 本次不顺手加列 —— 加列要动 DDL，值得单独判断要不要。

## 验证

- `4516 passed, 22 skipped in 187.38s`（新增 2 条）
- 端到端过 `build_recommendation_payload`，确认 12 列在起跳板行和确认行上全部落值（`sector_state_code='leading'`、`strategic_theme_bonus=12.47`、`capital_migration_bonus=3.0`、`exit_signal='跌破MA20'`…）
- `ruff check` / `ruff format --check` / `quality_gate.py --ci` 全过，无新增超长函数
- 无 import 环：AST 走图确认 `workflows.funnel_render_context` 可达的 40 个模块里没有 `daily_job`/`step4`

新增测试两条：一条锁死两个行族都拿到完整字段族，一条锁死已有值不被复原值覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)