### PR TITLE
feat(funnel): 漏斗效果检验加绝对收益口径

### DIFF
--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -184,11 +184,7 @@ def summarize_absolute(daily: list[dict[str, float]]) -> AbsoluteStat:
     基准差额只用**同时有 net_abs 和 bench 的日子**算，缺基准的日子不静默按 0
     处理——那会把无基准段当成「基准不涨不跌」，凭空造出超额。
     """
-    usable = [
-        row
-        for row in daily
-        if row.get("net_abs") is not None and (row.get("size_abs") or 0) >= MIN_HITS_PER_DAY
-    ]
+    usable = [row for row in daily if row.get("net_abs") is not None and (row.get("size_abs") or 0) >= MIN_HITS_PER_DAY]
     if len(usable) < MIN_DAYS:
         return AbsoluteStat(len(usable), 0.0, None, None, None, None, None, None, None, None)
     nets = [float(row["net_abs"]) for row in usable]
@@ -400,8 +396,7 @@ def random_control_row(
         "size": len(band),
         "net": hit_ret - ROUND_TRIP_COST_PCT,
         "control": ctl - ROUND_TRIP_COST_PCT,
-        "residual_mom": mean(mom[h] for h in paired_hits if h in mom)
-        - mean(mom[c] for c in band if c in mom),
+        "residual_mom": mean(mom[h] for h in paired_hits if h in mom) - mean(mom[c] for c in band if c in mom),
     }
 
 
@@ -459,9 +454,7 @@ def evaluate_daily(
             )
 
         for seed in seeds:
-            ctrl_row = random_control_row(
-                paired_hits, pool, mom, panels, ds, buy_ds, sell_ds, hit_ret, seed=seed
-            )
+            ctrl_row = random_control_row(paired_hits, pool, mom, panels, ds, buy_ds, sell_ds, hit_ret, seed=seed)
             if ctrl_row is not None:
                 rows[f"control_{seed}"].append(ctrl_row)
     return rows

--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -20,6 +20,14 @@
 
 买点 T+1 开盘（漏斗信号收盘后产出，最早可成交是次日开盘），卖点 T+1+H 收盘，
 扣 ROUND_TRIP_COST_PCT=0.202%，按交易日等权汇总。
+
+绝对收益口径（``AbsoluteStat``）
+--------------------------------
+配对超额只答「同动量同侪里选得好不好」，它为正**不等于赚钱**：对照亏 5%、候选
+亏 2%，超额 +3pct 而仓位实亏 2%。反向的例子在威科夫纯度检验里——LPS T+40 绝对
++0.99% 而超额 -0.35pct，赚的是市场的钱。所以中性化口径与绝对口径必须同时出，
+单看任何一栏都会得出相反的结论。绝对栏还带一个不做任何中性化的指数基准差额，
+用来分清「赚的是 beta 还是 alpha」。
 """
 
 from __future__ import annotations
@@ -114,6 +122,93 @@ def summarize_group(label: str, daily: list[dict[str, float]]) -> GroupStat:
     )
 
 
+@dataclass
+class AbsoluteStat:
+    """绝对收益口径：这批票拿在手里到底赚不赚钱。
+
+    配对超额回答的是「同动量同侪里选得好不好」，它为正**不等于**赚钱：对照组亏
+    5%、候选亏 2%，超额 +3pct 而仓位实亏。纯度检验里 LPS T+40 是反向的同一件事
+    ——绝对 +0.99% 而超额 -0.35pct，赚的是市场的钱不是选股的钱。两栏必须同时看。
+
+    ``positive_day_pct`` 这里算的是**净收益为正的交易日占比**（胜率），与
+    ``GroupStat.positive_day_pct`` 的「超额为正日占比」不是一回事，不可混用。
+
+    收益算在**全部候选**上（``net_abs``），不是配对子集：配对会丢掉找不到同动量
+    对照的候选，而漏斗当天真正给出的就是全集。超额那一栏必须用配对子集（分母要
+    和对照组一致），这一栏必须用全集（要如实反映持有这批票的结果）——两栏分母
+    本就不同，``avg_size`` 与 ``matched.avg_size`` 的差就是被配对丢掉的只数。
+    """
+
+    days: int
+    avg_size: float
+    net_pct: float | None
+    net_t: float | None
+    positive_day_pct: float | None
+    worst_day_pct: float | None
+    best_day_pct: float | None
+    bench_pct: float | None
+    bench_excess_pct: float | None
+    bench_excess_t: float | None
+    bench_days: int = 0
+
+    @property
+    def verdict(self) -> str:
+        if self.days < MIN_DAYS or self.net_pct is None:
+            return "样本不足"
+        if self.net_pct <= 0:
+            return "绝对收益为负：这批票拿着是亏的"
+        if self.bench_excess_pct is not None and self.bench_excess_pct <= 0:
+            return "绝对为正但跑输基准：只赚了市场的钱"
+        return "绝对为正且跑赢基准"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "days": self.days,
+            "avg_size": _round(self.avg_size, 1),
+            "net_pct": _round(self.net_pct),
+            "net_t": _round(self.net_t, 2),
+            "positive_day_pct": _round(self.positive_day_pct, 1),
+            "worst_day_pct": _round(self.worst_day_pct),
+            "best_day_pct": _round(self.best_day_pct),
+            "bench_days": self.bench_days,
+            "bench_pct": _round(self.bench_pct),
+            "bench_excess_pct": _round(self.bench_excess_pct),
+            "bench_excess_t": _round(self.bench_excess_t, 2),
+            "verdict": self.verdict,
+        }
+
+
+def summarize_absolute(daily: list[dict[str, float]]) -> AbsoluteStat:
+    """绝对收益汇总。不要求配对成功，日子比 summarize_group 多，对读时看 days 差。
+
+    基准差额只用**同时有 net_abs 和 bench 的日子**算，缺基准的日子不静默按 0
+    处理——那会把无基准段当成「基准不涨不跌」，凭空造出超额。
+    """
+    usable = [
+        row
+        for row in daily
+        if row.get("net_abs") is not None and (row.get("size_abs") or 0) >= MIN_HITS_PER_DAY
+    ]
+    if len(usable) < MIN_DAYS:
+        return AbsoluteStat(len(usable), 0.0, None, None, None, None, None, None, None, None)
+    nets = [float(row["net_abs"]) for row in usable]
+    paired = [(float(r["net_abs"]), float(r["bench"])) for r in usable if r.get("bench") is not None]
+    bench_diffs = [net - bench for net, bench in paired]
+    return AbsoluteStat(
+        days=len(usable),
+        avg_size=mean(float(row.get("size_abs") or 0) for row in usable),
+        net_pct=mean(nets),
+        net_t=tstat(nets),
+        positive_day_pct=100.0 * sum(1 for value in nets if value > 0) / len(nets),
+        worst_day_pct=min(nets),
+        best_day_pct=max(nets),
+        bench_days=len(paired),
+        bench_pct=mean(b for _, b in paired) if paired else None,
+        bench_excess_pct=mean(bench_diffs) if len(bench_diffs) >= MIN_DAYS else None,
+        bench_excess_t=tstat(bench_diffs) if len(bench_diffs) >= MIN_DAYS else None,
+    )
+
+
 def _quarter_of(ds: str) -> int:
     """'2026-08-31' -> 20263。用于看超额是否只来自某一个季度。"""
     year, month = int(ds[:4]), int(ds[5:7])
@@ -196,13 +291,29 @@ def _bisect_left(pairs: list[tuple[float, str]], value: float) -> int:
 
 @dataclass
 class Panels:
-    """行情面板。open/close 按日索引，liquid 是当日流动性池，mom20 是 T 日已知 20 日涨幅。"""
+    """行情面板。open/close 按日索引，liquid 是当日流动性池，mom20 是 T 日已知 20 日涨幅。
+
+    ``bench_open`` / ``bench_close`` 是基准指数，缺失时绝对收益仍出，只是不出基准差额三列。
+    """
 
     open: dict[str, dict[str, float]]
     close: dict[str, dict[str, float]]
     liquid: dict[str, set[str]]
     mom20: dict[str, dict[str, float]]
     dates: list[str]
+    bench_open: dict[str, float] = field(default_factory=dict)
+    bench_close: dict[str, float] = field(default_factory=dict)
+
+    def bench_return(self, buy_ds: str, sell_ds: str) -> float | None:
+        """基准在**同一持有窗口**内的收益（%）：T+1 开盘进、T+1+H 收盘出。
+
+        必须与候选同窗口。用 buy_ds 收盘当起点会把 T+1 当天的涨跌从基准里剔掉、
+        却留在候选里，跳空大的日子能凭空造出 1pct 以上的假超额。
+        """
+        start, end = self.bench_open.get(buy_ds), self.bench_close.get(sell_ds)
+        if not start or not end or start <= 0:
+            return None
+        return 100.0 * (end / start - 1.0)
 
     def window(self, signal_ds: str, horizon: int) -> tuple[str, str] | None:
         """T+1 开盘买、T+1+horizon 收盘卖。窗口越界返回 None。"""
@@ -244,6 +355,56 @@ def resolve_layer(day: dict, universe: set[str], layer: str) -> tuple[list[str],
     return hits, sorted(universe - wide)
 
 
+def absolute_row(hits: list[str], panels: Panels, ds: str, buy_ds: str, sell_ds: str) -> dict | None:
+    """当日绝对收益观测。算在**全部候选**上，与配对成败无关。
+
+    配对会丢掉找不到同动量对照的票，而漏斗当天真正给出的就是全集，两栏分母本就不同。
+    """
+    gross = panels.gross_return(hits, buy_ds, sell_ds)
+    if gross is None:
+        return None
+    return {
+        "date": ds,
+        "size_abs": len(hits),
+        "net_abs": gross - ROUND_TRIP_COST_PCT,
+        # 基准不扣成本：它是「不动手」的参照，不产生交易。
+        "bench": panels.bench_return(buy_ds, sell_ds),
+    }
+
+
+def random_control_row(
+    paired_hits: list[str],
+    pool: list[str],
+    mom: dict[str, float],
+    panels: Panels,
+    ds: str,
+    buy_ds: str,
+    sell_ds: str,
+    hit_ret: float,
+    *,
+    seed: int,
+) -> dict | None:
+    """单个随机负控制的当日观测。
+
+    必须与配对组用同一批候选（``paired_hits``），否则两者分母不同、超额不可直接
+    比较——这是把「配对超额 vs 随机超额」摆在一起的前提。
+    """
+    band = sample_momentum_band(paired_hits, pool, mom, seed=seed, date=ds)
+    if len(band) < MIN_HITS_PER_DAY:
+        return None
+    ctl = panels.gross_return(band, buy_ds, sell_ds)
+    if ctl is None:
+        return None
+    return {
+        "date": ds,
+        "size": len(band),
+        "net": hit_ret - ROUND_TRIP_COST_PCT,
+        "control": ctl - ROUND_TRIP_COST_PCT,
+        "residual_mom": mean(mom[h] for h in paired_hits if h in mom)
+        - mean(mom[c] for c in band if c in mom),
+    }
+
+
 def evaluate_daily(
     cands: dict[str, dict],
     panels: Panels,
@@ -256,7 +417,7 @@ def evaluate_daily(
 
     成本对候选和对照同样扣：两边都是一次往返，比较的是选股而非交易频率。
     """
-    rows: dict[str, list[dict]] = {"matched": [], **{f"control_{s}": [] for s in seeds}}
+    rows: dict[str, list[dict]] = {"absolute": [], "matched": [], **{f"control_{s}": [] for s in seeds}}
     for ds in sorted(cands):
         win = panels.window(ds, horizon)
         if win is None:
@@ -267,6 +428,11 @@ def evaluate_daily(
         hits, pool = resolve_layer(cands[ds], universe, status)
         if len(hits) < MIN_HITS_PER_DAY:
             continue
+
+        # 放在配对之前，否则「找不到同动量对照」的日子会连绝对收益一起丢掉。
+        abs_row = absolute_row(hits, panels, ds, buy_ds, sell_ds)
+        if abs_row is not None:
+            rows["absolute"].append(abs_row)
 
         # 随机控制必须与配对组用同一批候选（paired_hits），否则两者分母不同、
         # 超额不可直接比较——这是把「配对超额 vs 随机超额」摆在一起的前提。
@@ -293,22 +459,11 @@ def evaluate_daily(
             )
 
         for seed in seeds:
-            band = sample_momentum_band(paired_hits, pool, mom, seed=seed, date=ds)
-            if len(band) < MIN_HITS_PER_DAY:
-                continue
-            ctl = panels.gross_return(band, buy_ds, sell_ds)
-            if ctl is None:
-                continue
-            rows[f"control_{seed}"].append(
-                {
-                    "date": ds,
-                    "size": len(band),
-                    "net": hit_ret - ROUND_TRIP_COST_PCT,
-                    "control": ctl - ROUND_TRIP_COST_PCT,
-                    "residual_mom": mean(mom[h] for h in paired_hits if h in mom)
-                    - mean(mom[c] for c in band if c in mom),
-                }
+            ctrl_row = random_control_row(
+                paired_hits, pool, mom, panels, ds, buy_ds, sell_ds, hit_ret, seed=seed
             )
+            if ctrl_row is not None:
+                rows[f"control_{seed}"].append(ctrl_row)
     return rows
 
 

--- a/scripts/evaluate_funnel_effect.py
+++ b/scripts/evaluate_funnel_effect.py
@@ -1,6 +1,14 @@
-"""漏斗产出的选股效果检验（配对对照 + 随机负控制）。
+"""漏斗产出的选股效果检验（绝对收益 + 配对对照 + 随机负控制）。
 
-回答的问题：漏斗每天挑出来的那批票，相对「同动量的非候选股」有没有超额？
+两个不同的问题，必须同时看：
+
+1. **绝对口径**：拿着这批票赚不赚钱？算在全部候选上，扣往返成本，另给一个不做
+   任何中性化的指数基准差额，用来分清赚的是 beta 还是 alpha。
+2. **配对超额**：同动量同侪里选得好不好？相对「同动量的非候选股」有没有超额。
+
+只看任何一栏都会得出相反的结论。2026-06-01~08-31 这段就是活例子：T+10 配对超额
++2.06pct 看着像有边缘，同期绝对净收益 **-3.35%**、胜率 42%、减基准 -2.81pct——
+候选跌得比同动量同侪少，但仍然是亏的，而且比什么都不做还差。
 
 为什么不用 evaluate_gated_regime_candidates.py：它按 regime 切分，每档只剩
 8~15 天过不了 MIN_DAYS=20；且基准是同日全市场等权，在本段样本里全市场大跌，
@@ -12,6 +20,7 @@
     python scripts/build_funnel_cands.py --output /tmp/funnel_cands.json
     python scripts/evaluate_funnel_effect.py \
         --cands /tmp/funnel_cands.json --cache /tmp/funnel_snap/hist_full.csv.gz \
+        --benchmark /tmp/funnel_snap/benchmark_main.csv \
         --status formal_l4 --horizons 5,10,20
 
 候选集必须由 build_funnel_cands.py 生成：L4 成员判定按 candidate_lane 落在
@@ -33,6 +42,7 @@ from core.funnel_effect_eval import (
     Panels,
     control_gap,
     evaluate_daily,
+    summarize_absolute,
     summarize_group,
 )
 from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
@@ -50,6 +60,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--horizons", default="5,10,20", help="持有期，逗号分隔")
     parser.add_argument("--min-amount-wan", type=float, default=8000.0, help="20 日均额下限（万元）")
+    parser.add_argument("--benchmark", default="", help="基准指数 CSV（快照的 benchmark_main.csv），缺省则不出基准差额")
     parser.add_argument("--json-out", default="", help="结构化结果输出路径")
     return parser.parse_args()
 
@@ -72,7 +83,22 @@ def load_market(path: str) -> pd.DataFrame:
     return frame.dropna(subset=["open", "close"]).sort_values(["code", "ds"])
 
 
-def build_panels(frame: pd.DataFrame, min_amount_wan: float) -> Panels:
+def load_benchmark(path: str) -> tuple[dict[str, float], dict[str, float]]:
+    """基准指数的 (开盘, 收盘)。窗口要与候选完全一致，所以两头都要。"""
+    if not path:
+        return {}, {}
+    frame = pd.read_csv(path, usecols=["date", "open", "close"])
+    frame["ds"] = pd.to_datetime(frame.date).dt.strftime("%Y-%m-%d")
+    for col in ("open", "close"):
+        frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    frame = frame.dropna(subset=["open", "close"]).drop_duplicates("ds")
+    return (
+        dict(zip(frame.ds, frame.open.astype(float), strict=True)),
+        dict(zip(frame.ds, frame.close.astype(float), strict=True)),
+    )
+
+
+def build_panels(frame: pd.DataFrame, min_amount_wan: float, benchmark: str = "") -> Panels:
     """流动性池与 20 日动量都用 shift(1)，只含 T 日收盘可知的信息。"""
     frame = frame.copy()
     grouped = frame.groupby("code", sort=False)
@@ -80,6 +106,7 @@ def build_panels(frame: pd.DataFrame, min_amount_wan: float) -> Panels:
     # 20 日涨幅按 T 日收盘算（含 T 日），配对时对候选和对照同口径，无前视。
     frame["mom20"] = grouped.close.transform(lambda s: 100.0 * (s / s.shift(20) - 1.0))
     liquid = frame[frame.avg20 >= min_amount_wan]
+    bench_open, bench_close = load_benchmark(benchmark)
     return Panels(
         open={ds: dict(zip(g.code, g.open, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
         close={ds: dict(zip(g.code, g.close, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
@@ -89,6 +116,8 @@ def build_panels(frame: pd.DataFrame, min_amount_wan: float) -> Panels:
             for ds, g in frame.dropna(subset=["mom20"]).groupby("ds", sort=False)
         },
         dates=sorted(frame.ds.unique()),
+        bench_open=bench_open,
+        bench_close=bench_close,
     )
 
 
@@ -98,6 +127,54 @@ CONTROL_DESC = {
 DEFAULT_CONTROL_DESC = "对照池：同日流动性池内的非候选股"
 
 
+def read_absolute_notes(result: dict) -> list[str]:
+    """绝对口径的读法。放在超额结论之前——超额为正而仓位实亏时，先说的那句才算。"""
+    losing = [h for h, b in result["horizons"].items() if (b["absolute"]["net_pct"] or 0) < 0]
+    lagging = [h for h, b in result["horizons"].items() if (b["absolute"]["bench_excess_pct"] or 0) < 0]
+    if not losing:
+        return [
+            "- 绝对收益为正。若「减基准」为负，赚的是 beta 不是 alpha，"
+            "换成买指数能拿到同样的钱且不承担个股风险。",
+        ]
+    notes = [
+        f"- **T+{'/T+'.join(str(h) for h in losing)} 绝对收益为负：这批票拿在手里是亏的。**"
+        "配对超额为正只说明「同动量同侪里选得不算差」，不说明赚钱——"
+        "对照亏得更多而已，仓位实亏照样是实亏。",
+    ]
+    if lagging:
+        notes.append(
+            f"- T+{'/T+'.join(str(h) for h in lagging)} 还跑输基准：同期什么都不做（买主指数）"
+            "亏得更少，这批票连 beta 都没赚到。",
+        )
+    return notes
+
+
+def render_absolute(result: dict) -> list[str]:
+    """绝对收益块。与超额块分开，因为它回答的是完全不同的问题：拿着赚不赚钱。"""
+    lines = [
+        "## 绝对收益（不做任何中性化）",
+        "",
+        "算在**全部候选**上（不是配对子集），已扣往返成本。基准为主指数同窗口 T+1 开盘进、T+1+H 收盘出，不扣成本。",
+        "",
+        "| H | 天数 | 日均只数 | 绝对净收益 | t | 胜率 | 最差日 | 最好日 | 基准 | 减基准 | t | 判定 |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for h, block in result["horizons"].items():
+        a = block["absolute"]
+        if a["net_pct"] is None:
+            lines.append(f"| T+{h} | {a['days']} | — | — | — | — | — | — | — | — | — | 样本不足(<{MIN_DAYS}) |")
+            continue
+        bench = "—" if a["bench_pct"] is None else f"{a['bench_pct']:+.2f}%"
+        b_ex = "—" if a["bench_excess_pct"] is None else f"{a['bench_excess_pct']:+.2f}pct"
+        b_t = "—" if a["bench_excess_t"] is None else f"{a['bench_excess_t']:+.2f}"
+        lines.append(
+            f"| T+{h} | {a['days']} | {a['avg_size']:.1f} | {a['net_pct']:+.2f}% | {a['net_t']:+.2f} "
+            f"| {a['positive_day_pct']:.0f}% | {a['worst_day_pct']:+.2f}% | {a['best_day_pct']:+.2f}% "
+            f"| {bench} | {b_ex} | {b_t} | {a['verdict']} |"
+        )
+    return lines
+
+
 def render(result: dict, status: str) -> str:
     lines = [
         f"# 漏斗选股效果（status={status}）",
@@ -105,6 +182,10 @@ def render(result: dict, status: str) -> str:
         f"买点 T+1 开盘 / 卖点 T+1+H 收盘 / 两边同扣往返成本 {ROUND_TRIP_COST_PCT}% / 按交易日等权",
         CONTROL_DESC.get(status, DEFAULT_CONTROL_DESC),
         "配对方式：T 日已知 20 日涨幅最近邻 1:1 无放回",
+        "",
+        *render_absolute(result),
+        "",
+        "## 配对超额（同动量中性化后）",
         "",
         "| H | 天数 | 日均配对 | 候选净收益 | 配对对照 | 配对超额 | t | 为正日 | 残差动量 |",
         "|---|---|---|---|---|---|---|---|---|",
@@ -137,7 +218,7 @@ def render(result: dict, status: str) -> str:
             f"（均值 {gap['control_excess_avg']:+.3f}，宽度 {gap['seed_spread']:.3f}），"
             f"差距 {gap['gap']:+.3f}pct → {gap['verdict']}"
         )
-    lines += ["", "## 怎么读", ""]
+    lines += ["", "## 怎么读", "", *read_absolute_notes(result)]
     if inside:
         lines += [
             f"- **{inside} 个持有期的配对超额落在随机负控制区间内。**上表的超额和 t 值不能读成选股能力：",
@@ -150,6 +231,9 @@ def render(result: dict, status: str) -> str:
     lines += [
         f"- 单次往返成本 {ROUND_TRIP_COST_PCT}%：超额小于它时，净收益上看不出差别。",
         "- 残差动量列是配对是否真中性化的检查项；它偏离 0 太多时，超额里混着动量差，整行作废。",
+        "- **所有 t 值都被高估**：逐日观测的持有窗口互相重叠（T+H 每天与相邻 H 天共用行情），"
+        "有效样本远小于天数。要判显著性得取不重叠日并扫遍相位，本表的 t 只当方向参考，"
+        "不能拿来宣布「显著」或「不显著」。",
         "- 本口径只回答「同动量同侪里选得好不好」，不回答「该不该在这个市场里买」——后者是水温闸门的事。",
     ]
     return "\n".join(lines)
@@ -158,7 +242,7 @@ def render(result: dict, status: str) -> str:
 def main() -> int:
     args = parse_args()
     cands = json.load(open(args.cands, encoding="utf-8"))
-    panels = build_panels(load_market(args.cache), args.min_amount_wan)
+    panels = build_panels(load_market(args.cache), args.min_amount_wan, args.benchmark)
     horizons = [int(x) for x in args.horizons.split(",") if x.strip()]
 
     result: dict = {"status": args.status, "horizons": {}}
@@ -167,6 +251,7 @@ def main() -> int:
         matched = summarize_group("matched", rows["matched"])
         controls = [summarize_group(f"control_{s}", rows[f"control_{s}"]) for s in CONTROL_SEEDS]
         result["horizons"][h] = {
+            "absolute": summarize_absolute(rows["absolute"]).as_dict(),
             "matched": matched.as_dict(),
             "controls": [c.as_dict() for c in controls],
             "control_gap": control_gap(matched, controls),

--- a/scripts/evaluate_funnel_effect.py
+++ b/scripts/evaluate_funnel_effect.py
@@ -133,8 +133,7 @@ def read_absolute_notes(result: dict) -> list[str]:
     lagging = [h for h, b in result["horizons"].items() if (b["absolute"]["bench_excess_pct"] or 0) < 0]
     if not losing:
         return [
-            "- 绝对收益为正。若「减基准」为负，赚的是 beta 不是 alpha，"
-            "换成买指数能拿到同样的钱且不承担个股风险。",
+            "- 绝对收益为正。若「减基准」为负，赚的是 beta 不是 alpha，换成买指数能拿到同样的钱且不承担个股风险。",
         ]
     notes = [
         f"- **T+{'/T+'.join(str(h) for h in losing)} 绝对收益为负：这批票拿在手里是亏的。**"

--- a/tests/core/test_funnel_effect_eval.py
+++ b/tests/core/test_funnel_effect_eval.py
@@ -19,6 +19,7 @@ from core.funnel_effect_eval import (
     match_by_momentum,
     resolve_layer,
     sample_momentum_band,
+    summarize_absolute,
     summarize_group,
     tstat,
 )
@@ -249,6 +250,78 @@ class TestResolveLayer:
         assert resolve_layer({}, self.UNIVERSE, "l4_vs_rest") == ([], [])
 
 
+def _abs_daily(nets: list[float], benches: list[float | None] | None = None, *, size: float = 10.0) -> list[dict]:
+    """绝对口径的逐日观测。benches 为 None 表示整段无基准。"""
+    return [
+        {
+            "date": f"2026-06-{i + 1:02d}",
+            "size_abs": size,
+            "net_abs": net,
+            "bench": None if benches is None else benches[i],
+        }
+        for i, net in enumerate(nets)
+    ]
+
+
+class TestSummarizeAbsolute:
+    def test_sample_floor_blocks_short_windows(self):
+        stat = summarize_absolute(_abs_daily([1.0] * (MIN_DAYS - 1)))
+        assert stat.net_pct is None
+        assert stat.verdict == "样本不足"
+
+    def test_thin_days_are_dropped_like_matched(self):
+        """当日候选不足 MIN_HITS_PER_DAY 的日子不参与,与配对口径同一道门槛。"""
+        rows = _abs_daily([1.0] * MIN_DAYS)
+        rows[0]["size_abs"] = MIN_HITS_PER_DAY - 1
+        assert summarize_absolute(rows).days == MIN_DAYS - 1
+
+    def test_negative_absolute_is_called_out(self):
+        """超额可能为正而仓位实亏,判定必须先看绝对收益本身。"""
+        stat = summarize_absolute(_abs_daily([-2.0] * MIN_DAYS))
+        assert stat.net_pct == pytest.approx(-2.0)
+        assert stat.verdict == "绝对收益为负：这批票拿着是亏的"
+
+    def test_win_rate_counts_net_positive_days(self):
+        """AbsoluteStat.positive_day_pct 是胜率,不是 GroupStat 的「超额为正日」。"""
+        stat = summarize_absolute(_abs_daily([1.0] * 15 + [-1.0] * 5))
+        assert stat.positive_day_pct == pytest.approx(75.0)
+        assert stat.worst_day_pct == pytest.approx(-1.0)
+        assert stat.best_day_pct == pytest.approx(1.0)
+
+    def test_beats_market_only_when_bench_excess_positive(self):
+        """绝对为正但跑输基准 = 只赚了 beta,这正是纯度检验里 LPS T+40 的形态。"""
+        rows = _abs_daily([1.0] * MIN_DAYS, [3.0] * MIN_DAYS)
+        stat = summarize_absolute(rows)
+        assert stat.bench_pct == pytest.approx(3.0)
+        assert stat.bench_excess_pct == pytest.approx(-2.0)
+        assert stat.verdict == "绝对为正但跑输基准：只赚了市场的钱"
+
+        beat = summarize_absolute(_abs_daily([4.0] * MIN_DAYS, [3.0] * MIN_DAYS))
+        assert beat.verdict == "绝对为正且跑赢基准"
+
+    def test_missing_bench_days_are_not_treated_as_zero(self):
+        """缺基准的日子若按 0 计,会把无基准段当成「基准不涨不跌」凭空造超额。"""
+        benches: list[float | None] = [None] * 5 + [2.0] * MIN_DAYS
+        stat = summarize_absolute(_abs_daily([1.0] * (5 + MIN_DAYS), benches))
+        assert stat.days == 5 + MIN_DAYS
+        assert stat.bench_days == MIN_DAYS
+        assert stat.bench_excess_pct == pytest.approx(-1.0)
+
+    def test_bench_columns_absent_without_benchmark(self):
+        stat = summarize_absolute(_abs_daily([1.0] * MIN_DAYS))
+        assert stat.bench_days == 0
+        assert (stat.bench_pct, stat.bench_excess_pct, stat.bench_excess_t) == (None, None, None)
+        assert stat.verdict == "绝对为正且跑赢基准"
+
+    def test_bench_excess_needs_its_own_sample_floor(self):
+        """基准日数不够时只压掉基准三列,绝对收益本身照出。"""
+        benches: list[float | None] = [2.0] * (MIN_DAYS - 1) + [None] * 5
+        stat = summarize_absolute(_abs_daily([1.0] * (MIN_DAYS + 4), benches))
+        assert stat.net_pct == pytest.approx(1.0)
+        assert stat.bench_days == MIN_DAYS - 1
+        assert stat.bench_excess_pct is None
+
+
 def _panels(n_days: int = 40, *, codes: list[str] | None = None) -> Panels:
     codes = codes or [f"s{i}" for i in range(200)]
     dates = [f"2026-06-{i + 1:02d}" for i in range(n_days)]
@@ -289,6 +362,32 @@ class TestPanels:
     def test_gross_return_none_when_nothing_priced(self):
         panels = _panels(5, codes=["a"])
         assert panels.gross_return(["ghost"], "2026-06-02", "2026-06-03") is None
+
+    def test_bench_return_spans_the_same_window_as_candidates(self):
+        """基准必须 T+1 开盘进、T+1+H 收盘出。用 buy_ds 收盘当起点会把 T+1 的涨跌
+        从基准里剔掉却留在候选里,跳空日能造出假超额。"""
+        panels = _panels(5, codes=["a"])
+        panels.bench_open = {"2026-06-02": 100.0}
+        panels.bench_close = {"2026-06-02": 105.0, "2026-06-04": 110.0}
+        assert panels.bench_return("2026-06-02", "2026-06-04") == pytest.approx(10.0)
+
+    def test_bench_return_none_when_either_end_missing(self):
+        panels = _panels(5, codes=["a"])
+        panels.bench_open = {"2026-06-02": 100.0}
+        panels.bench_close = {"2026-06-04": 110.0}
+        assert panels.bench_return("2026-06-03", "2026-06-04") is None
+        assert panels.bench_return("2026-06-02", "2026-06-05") is None
+
+    def test_bench_return_none_on_nonpositive_start(self):
+        panels = _panels(5, codes=["a"])
+        panels.bench_open = {"2026-06-02": 0.0}
+        panels.bench_close = {"2026-06-04": 110.0}
+        assert panels.bench_return("2026-06-02", "2026-06-04") is None
+
+    def test_bench_panels_default_to_empty(self):
+        """没传基准时绝对收益照出,只是不出基准差额三列。"""
+        panels = _panels(5)
+        assert (panels.bench_open, panels.bench_close) == ({}, {})
 
 
 class TestEvaluateDaily:
@@ -345,6 +444,41 @@ class TestEvaluateDaily:
         assert rows["matched"]
         # 对照池只有 5 只 -> 每天最多配 5 对。
         assert max(r["size"] for r in rows["matched"]) <= 5
+
+    def test_absolute_covers_all_hits_not_the_paired_subset(self):
+        """绝对口径算在全部候选上：配对会丢掉没有同动量对照的票,而漏斗当天
+        真正给出的是全集,分母本就不同。"""
+        panels = _panels(60)
+        cands = self._cands(panels, n_hits=20, n_wide=25)
+        rows = evaluate_daily(cands, panels, 5, status="l4_vs_rest")
+        assert rows["absolute"]
+        assert all(r["size_abs"] == 20 for r in rows["absolute"])
+        assert max(r["size"] for r in rows["matched"]) < rows["absolute"][0]["size_abs"]
+
+    def test_absolute_survives_days_where_pairing_fails(self):
+        """配对不成的日子不能连绝对收益一起丢——所以它算在配对之前。"""
+        panels = _panels(60)
+        codes = sorted(next(iter(panels.liquid.values())))
+        # 宽池 == 命中集 -> 无对照可配,配对组整段为空。
+        cands = {d: {"formal_l4": codes[:20], "all": codes[:20]} for d in panels.dates[:-25]}
+        rows = evaluate_daily(cands, panels, 5, status="l4_vs_rest")
+        assert rows["matched"] == []
+        assert len(rows["absolute"]) >= MIN_DAYS
+
+    def test_absolute_net_is_cost_deducted_and_bench_is_not(self):
+        """基准是「不动手」的参照,不产生交易,所以不扣成本。"""
+        panels = _panels(60)
+        panels.bench_open = dict.fromkeys(panels.dates, 100.0)
+        panels.bench_close = dict.fromkeys(panels.dates, 100.0)
+        rows = evaluate_daily(self._cands(panels), panels, 5, status="formal_l4")
+        row = rows["absolute"][0]
+        assert row["net_abs"] == pytest.approx(-ROUND_TRIP_COST_PCT)
+        assert row["bench"] == pytest.approx(0.0)
+
+    def test_absolute_bench_is_none_without_benchmark_panels(self):
+        panels = _panels(60)
+        rows = evaluate_daily(self._cands(panels), panels, 5, status="formal_l4")
+        assert all(r["bench"] is None for r in rows["absolute"])
 
 
 class TestControlGap:


### PR DESCRIPTION
## 变更摘要

`evaluate_funnel_effect.py` 之前只出配对超额，回答的是「同动量同侪里选得好不好」。**它为正不等于赚钱**：对照亏 5%、候选亏 2%，超额 +3pct 而仓位实亏 2%。反向的例子在威科夫纯度检验里——LPS T+40 绝对 +0.99% 而超额 -0.35pct，赚的是市场的钱。单看任何一栏都会得出相反的结论。

本次加一层不做任何中性化的绝对口径，与超额栏同时出，并带一个指数基准差额用来分清 beta 与 alpha。**没有改动任何生产阈值或参数**，只加检验口径与测试。

- `AbsoluteStat` / `summarize_absolute`：净收益、t、胜率、最差最好日、基准差额
- `Panels.bench_open` / `bench_close` / `bench_return`：基准与候选同窗口
- `evaluate_daily` 新增 `"absolute"` 行族；抽出 `absolute_row()` 与 `random_control_row()` 两个函数以守住核心层 70 行上限
- 脚本加 `--benchmark`，缺省时绝对收益照出，只是不出基准差额三列

## 实测结果（formal_l4，2026-06-01~08-31）

### 绝对收益（新增，不做任何中性化）

| H | 天数 | 日均只数 | 绝对净收益 | t | 胜率 | 最差日 | 最好日 | 基准 | 减基准 | t |
|---|---|---|---|---|---|---|---|---|---|---|
| T+5 | 36 | 15.4 | **-2.16%** | -1.74 | 47% | -23.92% | +10.04% | -0.23% | -2.05pct | -1.95 |
| T+10 | 31 | 14.8 | **-3.35%** | -1.74 | 42% | -29.94% | +18.88% | -0.66% | -2.81pct | -1.83 |
| T+20 | 21 | 10.0 | **-3.13%** | -1.20 | 43% | -27.16% | +22.96% | -0.11% | -4.32pct | -2.49 |

### 配对超额（原有）

| H | 天数 | 日均配对 | 配对超额 | t | 为正日 | 随机控制区间 | 结论 |
|---|---|---|---|---|---|---|---|
| T+5 | 36 | 15.1 | +0.42pct | +0.36 | 50% | -0.11~+0.98 | 落在区间内 |
| T+10 | 31 | 14.5 | +2.06pct | +1.36 | 61% | +1.10~+3.05 | 落在区间内 |
| T+20 | 21 | 9.8 | +2.06pct | +0.92 | 62% | -0.43~+3.66 | 落在区间内 |

**三个持有期一致**：配对超额为正且落在随机负控制区间内（边缘只来自动量选位），而绝对收益为负、胜率低于 50%、还跑输主指数。这批票跌得比同动量同侪少，但拿在手里是亏的，且比什么都不做更差。

这与 `funnel-edge-is-momentum-position` 的结论同向，绝对栏把「亏多少」也补上了。样本为 36/31/21 个可用日，刚过 `MIN_DAYS=20`，本身不足以下长期结论——它证明的是**口径缺失**：同一批数据，缺这一栏就会读成「有边缘」。

## 口径决定

- **基准与候选同窗口**：T+1 开盘进、T+1+H 收盘出。用 `buy_ds` 收盘当起点会把 T+1 的涨跌从基准里剔掉却留在候选里，跳空日能造出 1pct 以上的假超额。所以 `Panels` 需要 `bench_open` 和 `bench_close` 两头。
- **绝对收益算在全部候选上**，不是配对子集：配对会丢掉找不到同动量对照的票，而漏斗当天真正给出的是全集。超额那栏必须用配对子集（分母要和对照组一致），两栏分母本就不同，`avg_size` 之差就是被配对丢掉的只数（T+20 是 10.0 vs 9.8）。
- **绝对行在配对之前算**，否则「找不到同动量对照」的日子会连绝对收益一起丢掉。见用例 `test_absolute_survives_days_where_pairing_fails`。
- **缺基准的日子不按 0 处理**——那会把无基准段当成「基准不涨不跌」凭空造超额。基准差额只用同时有 `net_abs` 和 `bench` 的日子算，单独带 `bench_days`。
- **基准不扣成本**：它是「不动手」的参照，不产生交易。候选与对照两边都扣 `ROUND_TRIP_COST_PCT=0.202`，成本在超额里抵消、在绝对栏不抵消。
- `AbsoluteStat.positive_day_pct` 是**净收益为正日占比（胜率）**，与 `GroupStat.positive_day_pct` 的「超额为正日占比」不是一回事，两个 docstring 都写明了不可混用。

## 顺带补的一条说明

新表里印了 `net_t` / `bench_excess_t`，而逐日观测的持有窗口互相重叠（T+5 在 36 天上每天与相邻 4 天共用行情），有效样本远小于天数、t 被高估。在「怎么读」里写明这些 t 只当方向参考，判显著性得取不重叠日并扫遍相位——与 #362 里 `spread_t` 的两条纪律同一个道理。

## 验证

- **全量 `4532 passed, 22 skipped`**；新增 18 个用例覆盖 `AbsoluteStat` / `summarize_absolute` / `bench_return` / `evaluate_daily` 的绝对行，含「配对失败仍出绝对收益」「缺基准不按 0 处理」「基准不扣成本而候选扣」三个反例
- `ruff check` + `ruff format --check` 通过
- `quality_gate.py --check-functions` 与 `--check-no-sql` 通过。`evaluate_daily` 加绝对行后到 80 行超核心层 70 行上限，抽出两个函数后行为不变（原有 46 个用例全过）
- 上表数字为真实运行输出，非构造。复现：

```
python scripts/evaluate_funnel_effect.py \
  --cands /tmp/funnel_cands.json --cache /tmp/funnel_snap/hist_full.csv.gz \
  --benchmark /tmp/funnel_snap/benchmark_main.csv \
  --status formal_l4 --horizons 5,10,20
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
