### PR TITLE
fix(review): 影子车道常数分排不了序，复盘报告拿结果选样提改动方案

### DIFF
--- a/core/review_shadow_lanes.py
+++ b/core/review_shadow_lanes.py
@@ -13,16 +13,27 @@ from core.funnel_taxonomy import (
     REVIEW_STAGE_TRIGGER_MISS,
 )
 
-SHADOW_POLICY_VERSION = "review_shadow_v1"
+SHADOW_POLICY_VERSION = "review_shadow_v2"
 NEAR_L2_MAX_GAP_PCT = 10.0
+
+# 常数分不是分:v1 里 pre_breakout 恒为 78.0、rotation_setup 恒为 72.0,
+# 2026-09-01 那份复盘的 31 只「买点未确认」因此全同分。同分的车道排不了序,
+# 「取前 N 只看超额」这类效果检验就无从下手。v2 的处理:
+#   - pre_breakout 用漏斗自己算过的 watch_score(layer3_score_map)当排序键,
+#     它是 0.25*q20+0.20*q5+0.05*q3+0.20*dry_q+0.30*trigger_q ± 加减项,
+#     取值约 [0,1],乘 100 落到 0~100 与另两条车道同量纲
+#   - rotation_setup 所在层(题材共振)没有连续键,不硬造一个:score 置 None,
+#     ranked=False,当标签用。下游要排序时按 ranked 过滤,而不是拿它跟别的比
+_PRE_BREAKOUT_SCORE_FLOOR = 40.0
 
 
 @dataclass(frozen=True)
 class ReviewShadowSignal:
     lane: str
-    score: float
+    score: float | None
     reason: str
     policy_version: str = SHADOW_POLICY_VERSION
+    ranked: bool = True
 
 
 def shadow_signal_from_decision(
@@ -38,11 +49,36 @@ def shadow_signal_from_decision(
         return _near_l2_signal(str(row.get("reason") or ""), near_l2_max_gap_pct)
     if stage == REVIEW_STAGE_THEME_MISS and bool(row.get("l2_eligible")):
         channel = str(row.get("l2_channel") or "结构通道")
-        return ReviewShadowSignal("rotation_setup", 72.0, f"已通过{channel}，等待板块轮动确认")
+        return ReviewShadowSignal(
+            "rotation_setup", None, f"已通过{channel}，等待板块轮动确认（本层无连续排序键，仅作标签）", ranked=False
+        )
     if stage == REVIEW_STAGE_TRIGGER_MISS and bool(row.get("l3_eligible")):
-        channel = str(row.get("l2_channel") or "结构通道")
-        return ReviewShadowSignal("pre_breakout", 78.0, f"已通过L1-L3及{channel}，等待爆发前夜确认")
+        return _pre_breakout_signal(row)
     return None
+
+
+def _pre_breakout_signal(row: dict[str, Any]) -> ReviewShadowSignal:
+    """排序键取漏斗自己算的 watch_score,不再返回常数 78.0。
+
+    watch_score 在 rank_l3_candidates 里对 L3 全体算过一次,已含动量分位、缩量
+    程度和触发强度,是这一层唯一现成的连续键。老 trace 没有这个字段,此时退回
+    不可排序标签——宁可显式说明排不了序,也不要用常数假装能排。
+    """
+    channel = str(row.get("l2_channel") or "结构通道")
+    raw = row.get("layer3_quality_score")
+    try:
+        watch = float(raw)
+    except (TypeError, ValueError):
+        return ReviewShadowSignal(
+            "pre_breakout",
+            None,
+            f"已通过L1-L3及{channel}，等待爆发前夜确认（trace 缺 watch_score，无法排序）",
+            ranked=False,
+        )
+    score = max(0.0, min(100.0, _PRE_BREAKOUT_SCORE_FLOOR + watch * 100.0))
+    return ReviewShadowSignal(
+        "pre_breakout", score, f"已通过L1-L3及{channel}，等待爆发前夜确认（watch_score={watch:.3f}）"
+    )
 
 
 def attach_shadow_signal(row: dict[str, Any], *, near_l2_max_gap_pct: float = NEAR_L2_MAX_GAP_PCT) -> dict[str, Any]:
@@ -53,6 +89,7 @@ def attach_shadow_signal(row: dict[str, Any], *, near_l2_max_gap_pct: float = NE
         **row,
         "shadow_lane": signal.lane,
         "shadow_score": signal.score,
+        "shadow_ranked": signal.ranked,
         "shadow_reason": signal.reason,
         "shadow_policy_version": signal.policy_version,
     }

--- a/tests/core/test_review_shadow_lanes.py
+++ b/tests/core/test_review_shadow_lanes.py
@@ -1,4 +1,9 @@
-from core.funnel_taxonomy import REVIEW_STAGE_RISK_BLOCK, REVIEW_STAGE_STRENGTH_MISS, REVIEW_STAGE_THEME_MISS
+from core.funnel_taxonomy import (
+    REVIEW_STAGE_RISK_BLOCK,
+    REVIEW_STAGE_STRENGTH_MISS,
+    REVIEW_STAGE_THEME_MISS,
+    REVIEW_STAGE_TRIGGER_MISS,
+)
 from core.review_shadow_lanes import shadow_signal_from_decision
 
 
@@ -22,3 +27,53 @@ def test_rotation_lane_requires_l2_and_risk_block_never_promotes() -> None:
 
     assert signal is not None and signal.lane == "rotation_setup"
     assert shadow_signal_from_decision({"stage": REVIEW_STAGE_RISK_BLOCK, "l3_eligible": True}) is None
+
+
+def test_rotation_setup_is_a_tag_not_a_score() -> None:
+    """题材共振层没有连续键,就不要造一个。
+
+    v1 给 rotation_setup 恒定 72.0,读着像分其实是标签,拿去跟 near_l2 的真分比
+    就是在比两个不同量纲的东西。layer3_sector_resonance 是集合成员判断
+    (top_sector_set/keep_sector_set/hot_set),压根没有缺口指标可拿。
+    """
+    signal = shadow_signal_from_decision(
+        {"stage": REVIEW_STAGE_THEME_MISS, "l2_eligible": True, "l2_channel": "主升通道"}
+    )
+
+    assert signal is not None
+    assert signal.score is None
+    assert signal.ranked is False
+    assert "无连续排序键" in signal.reason
+
+
+def test_pre_breakout_score_tracks_watch_score() -> None:
+    """pre_breakout 的分要随 watch_score 变,不能像 v1 那样恒为 78.0。
+
+    2026-09-01 那份复盘的 31 只「买点未确认」在 v1 下全同分——同分排不了序,
+    「取前 N 只看超额」就无从下手。watch_score 是漏斗自己在 rank_l3_candidates
+    里对 L3 全体算过的连续键,取值约 [0,1]。
+    """
+    base = {"stage": REVIEW_STAGE_TRIGGER_MISS, "l3_eligible": True, "l2_channel": "主升通道"}
+    low = shadow_signal_from_decision({**base, "layer3_quality_score": 0.12})
+    high = shadow_signal_from_decision({**base, "layer3_quality_score": 0.61})
+
+    assert low is not None and high is not None
+    assert low.lane == high.lane == "pre_breakout"
+    assert low.ranked is True and high.ranked is True
+    assert low.score is not None and high.score is not None
+    assert high.score > low.score
+    # 与 near_l2 同量纲(0~100),否则跨车道分档没法比。
+    assert 0.0 <= low.score <= 100.0 and 0.0 <= high.score <= 100.0
+    assert "watch_score=0.610" in high.reason
+
+
+def test_pre_breakout_without_watch_score_degrades_to_unranked() -> None:
+    """老 trace 没有 watch_score 字段时显式说排不了序,而不是用常数假装能排。"""
+    signal = shadow_signal_from_decision(
+        {"stage": REVIEW_STAGE_TRIGGER_MISS, "l3_eligible": True, "l2_channel": "主升通道"}
+    )
+
+    assert signal is not None and signal.lane == "pre_breakout"
+    assert signal.score is None
+    assert signal.ranked is False
+    assert "无法排序" in signal.reason

--- a/tests/workflows/test_review_list_replay.py
+++ b/tests/workflows/test_review_list_replay.py
@@ -395,6 +395,69 @@ def test_build_report_lines_separates_raw_and_executable_capture_rates() -> None
     assert "可交易样本前日候选 1/1" in text
 
 
+def test_report_head_carries_the_only_same_pool_ratio() -> None:
+    """「可买到且被捕获」必须在报告头,不能只埋在可交易口径的第三段。
+
+    实测 2026-09-01 这个比率是 1/54,而同一份报告头上写的是影子召回 35/98 ——
+    后者的分母是涨幅筛出来的,读着像召回率其实是事后命中计数。分子分母同池的
+    只有这一个,它得排在前面。
+    """
+    lines = build_report_lines(
+        [_row("000001", "平安银行", REVIEW_STAGE_CANDIDATE_HIT)],
+        Counter({REVIEW_STAGE_CANDIDATE_HIT: 1}),
+        today=date(2026, 9, 1),
+        previous_trade_date=date(2026, 8, 31),
+        end_trade_date="2026-08-31",
+        stats={
+            "candidate": 2,
+            "recommended": 1,
+            "total": 98,
+            "l1_eligible": 58,
+            "open_executable": 54,
+            "candidate_open_executable": 1,
+            "execution_available": 98,
+            "shadow": 35,
+            "shadow_open_executable": 32,
+        },
+    )
+
+    text = "\n".join(lines)
+    assert "**可买到且被捕获**: 1/54（1.9%）" in text
+    # 必须排在影子召回之前:影子那行的分母是结果筛出来的。
+    assert text.index("可买到且被捕获") < text.index("影子召回")
+
+
+def test_trigger_miss_focus_stops_proposing_lane_changes() -> None:
+    """买点未确认这档不能提「补强爆发前夜车道」。
+
+    同一份报告的基础准入档已经写了「不建议为涨停复盘反向放宽」,证据强度一样,
+    两档结论必须一致。原措辞是在结果选样上直接提改动方案。
+    """
+    lines = build_focus_lines(
+        [_row("000004", "长江证券", REVIEW_STAGE_TRIGGER_MISS)],
+        today=date(2026, 9, 1),
+        previous_trade_date=date(2026, 8, 31),
+    )
+    text = "\n".join(lines)
+
+    assert "买点未确认" in text
+    assert "需要补强" not in text
+    assert "影子回放" in text
+
+
+def test_focus_lines_open_with_the_result_selected_caveat() -> None:
+    """报告一进「重点归因」就要说样本是按结果选的,否则每档只数会被当淘汰率读。"""
+    lines = build_focus_lines(
+        [_row("000006", "深振业A", REVIEW_STAGE_BASE_REJECT)],
+        today=date(2026, 9, 1),
+        previous_trade_date=date(2026, 8, 31),
+    )
+
+    assert lines[0] == "**重点归因**"
+    assert "没有分母" in lines[1]
+    assert "不能作为放宽" in lines[1]
+
+
 def test_tushare_cross_sections_avoid_full_market_history_fetch(monkeypatch):
     from integrations import tushare_client
 

--- a/tests/workflows/test_review_shadow_backtest.py
+++ b/tests/workflows/test_review_shadow_backtest.py
@@ -94,3 +94,75 @@ def test_shadow_backtest_requires_exact_next_market_trade_date() -> None:
     market_calendar = _history()
 
     assert evaluate_shadow_traces(traces, {"000001": suspended, "000002": market_calendar}) == []
+
+
+def _trigger_miss_trace(scores: dict[str, float | None]) -> list[dict]:
+    return [
+        {
+            "trade_date": "2026-05-12",
+            "symbols": {
+                code: {
+                    "name": f"票{code}",
+                    "stage": REVIEW_STAGE_TRIGGER_MISS,
+                    "l3_eligible": True,
+                    "l2_channel": "主升通道",
+                    **({} if score is None else {"layer3_quality_score": score}),
+                }
+                for code, score in scores.items()
+            },
+        }
+    ]
+
+
+def test_score_band_reports_unranked_when_every_score_ties() -> None:
+    """分值全同要显式说「排序键无区分度」,不能悄悄把全体塞进一个桶。
+
+    这就是 v1 的具体形态:pre_breakout 恒 78.0,分档表看着有三行,其实低中高
+    是同一批票。让它自报 ranked=False,才不会有人拿这张表当单调性证据。
+    """
+    scores = {"000001": 0.42, "000002": 0.42, "000003": 0.42}
+    traces = _trigger_miss_trace(scores)
+    history = {code: _history() for code in scores}
+
+    report = summarize_shadow_trades(evaluate_shadow_traces(traces, history), traces, history)
+    band = report["by_score_band"]["pre_breakout"]
+
+    assert band["ranked"] is False
+    assert "分值全同" in band["reason"]
+
+
+def test_score_band_splits_tertiles_once_scores_differ() -> None:
+    """watch_score 有区分度时才给出低/中/高三档,切点要落在样本内。"""
+    scores = {f"00000{i}": 0.1 * i for i in range(1, 7)}
+    traces = _trigger_miss_trace(scores)
+    history = {code: _history() for code in scores}
+
+    report = summarize_shadow_trades(evaluate_shadow_traces(traces, history), traces, history)
+    band = report["by_score_band"]["pre_breakout"]
+
+    assert band["ranked"] is True
+    lo, hi = band["cut_points"]
+    assert lo < hi
+    assert sum(band["bands"][name]["count"] for name in ("low", "mid", "high")) == len(scores)
+
+
+def test_score_band_marks_rotation_setup_unrankable() -> None:
+    """题材车道没有连续键,分档表只能标注不可排序,不能造一个假结论。"""
+    traces = [
+        {
+            "trade_date": "2026-05-12",
+            "symbols": {
+                code: {"name": f"票{code}", "stage": REVIEW_STAGE_THEME_MISS, "l2_eligible": True}
+                for code in ("000001", "000002", "000003")
+            },
+        }
+    ]
+    history = {code: _history() for code in ("000001", "000002", "000003")}
+
+    report = summarize_shadow_trades(evaluate_shadow_traces(traces, history), traces, history)
+    band = report["by_score_band"]["rotation_setup"]
+
+    assert band["ranked"] is False
+    # 不能说成「样本不足」:那会让人以为攒够数据就能分档,而这一层压根没有键。
+    assert "无连续排序键" in band["reason"]
+    assert "样本不足" not in band["reason"]

--- a/workflows/review_report_render.py
+++ b/workflows/review_report_render.py
@@ -28,10 +28,26 @@ def short_code_list(rows: list[dict[str, Any]], limit: int = 8) -> str:
 def build_focus_lines(rows: list[dict[str, Any]], today: date, previous_trade_date: date) -> list[str]:
     total = max(len(rows), 1)
     stage_rows = _group_stage_rows(rows)
-    lines = ["**重点归因**"]
+    lines = ["**重点归因**", _result_selected_caveat()]
     lines.extend(_date_gap_lines(today, previous_trade_date))
     lines.extend(_stage_focus_lines(stage_rows, total))
     return lines
+
+
+def _result_selected_caveat() -> str:
+    """先说清样本是按结果选的,否则下面每一档的只数都会被当成淘汰率读。
+
+    本报告的样本定义是「今日收盘>+7% 且前一日<+3%」——先有结果再回溯原因。
+    被同一道闸门挡住却没涨的票根本不进样本,所以「39 只被基础准入淘汰」这类
+    数字没有分母,不能推出闸门误伤。要检验某车道该不该补强,只能全量打标签 +
+    同动量随机对照,那是 workflows/review_shadow_backtest.py 的事。
+    """
+    return (
+        "- **样本口径**：本报告先按「今日涨幅>+7%」选样、再回溯卡在哪一层，"
+        "被同样阈值挡住却没涨的票不在样本内，因此下面每一档的只数都**没有分母**。"
+        "它只能定位单票卡点，不能作为放宽任何阈值或车道的依据；"
+        "「某车道该不该补强」要走全量打标签 + 同动量随机对照（影子回放）。"
+    )
 
 
 def build_report_lines(
@@ -51,6 +67,9 @@ def build_report_lines(
     if stats:
         if stats.get("context_source"):
             lines.append(f"**归因数据源**: {stats['context_source']}")
+        headline = _buyable_capture_headline(stats)
+        if headline:
+            lines.append(headline)
         stats_line = (
             f"**漏斗全链路追踪**: 前一日候选 {stats['candidate']}/{stats['total']} | "
             f"跟踪表记录 {stats.get('tracked_previous_day', stats['recommended'])}/{stats['total']} | "
@@ -78,6 +97,27 @@ def build_report_lines(
     )
     lines.extend(_detail_lines(rows))
     return lines
+
+
+def _buyable_capture_headline(stats: dict[str, Any]) -> str:
+    """把「可交易样本里前日候选占几只」提到报告头。
+
+    这是全篇唯一分子分母同池的比率:分母是「昨天基础准入通过、今天涨了、且次日
+    还能按≤+4%开盘价买到」的票,分子是其中前一日真在候选池里的。其它数字(影子
+    召回 35/98、可交易 32/35)都是事后命中计数,分母是涨幅筛出来的。
+    实测 2026-09-01 这行是 1/54,而它原先埋在可交易口径的第三段。
+    """
+    if stats.get("execution_available", 0) <= 0:
+        return ""
+    executable = stats.get("open_executable", 0)
+    if executable <= 0:
+        return ""
+    captured = stats.get("candidate_open_executable", 0)
+    rate = captured / executable * 100.0
+    return (
+        f"**可买到且被捕获**: {captured}/{executable}（{rate:.1f}%）"
+        " ← 全篇唯一分母同池的比率：次日开盘还买得到的强势票里，前一日真在候选池的有几只"
+    )
 
 
 def _execution_scope_line(stats: dict[str, Any]) -> str:
@@ -149,10 +189,18 @@ def _risk_focus(rows: list[dict[str, Any]]) -> list[str]:
 
 
 def _trigger_miss_focus(rows: list[dict[str, Any]]) -> list[str]:
+    """不再从这一档提「补强爆发前夜车道」。
+
+    原措辞「适合检查爆发前夜压缩/试盘类车道是否需要补强」是在结果选样的证据上
+    直接提改动方案,而同一份报告的「基础准入淘汰」那档已经写了「不建议为涨停复盘
+    反向放宽」——同样的证据强度,两档结论必须一致。
+    """
     if not rows:
         return []
     return [
-        f"- **买点未确认**：{short_code_list(rows)}。这些票已有结构基础但未触发买点确认，适合检查“爆发前夜压缩/试盘”类车道是否需要补强。"
+        f"- **买点未确认**：{short_code_list(rows)}。已过结构层、买点未触发。"
+        "同口径下没涨的票不在样本内，所以这里看不出买点阈值是松还是紧；"
+        "要判断先跑影子回放取 T+5 超额与同动量对照。"
     ]
 
 

--- a/workflows/review_shadow_backtest.py
+++ b/workflows/review_shadow_backtest.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pandas as pd
 
-from core.review_shadow_lanes import shadow_lane_label, shadow_signal_from_decision
+from core.review_shadow_lanes import ReviewShadowSignal, shadow_lane_label, shadow_signal_from_decision
 from workflows.backtest_data import load_snapshot_hist_map
 
 
@@ -22,7 +22,8 @@ class ShadowTrade:
     code: str
     name: str
     lane: str
-    score: float
+    score: float | None
+    ranked: bool
     entry_open: float
     signal_pct_chg: float | None
     next_pct_chg: float | None
@@ -80,8 +81,7 @@ def evaluate_shadow_traces(
                 next_date,
                 str(code),
                 row,
-                signal.lane,
-                signal.score,
+                signal,
                 history.get(str(code)),
             )
             if trade is not None:
@@ -106,7 +106,40 @@ def summarize_shadow_trades(
         "review_shadow_recall_rate": _ratio(recall["shadow_hits"], recall["review_hits"]),
         "review_candidate_recall_rate": _ratio(recall["candidate_hits"], recall["review_hits"]),
         "by_lane": {lane: _lane_summary([trade for trade in trades if trade.lane == lane]) for lane in lanes},
+        "by_score_band": {lane: _score_band_summary([t for t in trades if t.lane == lane]) for lane in lanes},
         "overall": _lane_summary(trades),
+    }
+
+
+def _score_band_summary(trades: list[ShadowTrade]) -> dict[str, Any]:
+    """按分值三分档拆开,看这个排序键到底有没有单调性。
+
+    v1 的常数分让这张表全落进一个桶——那才是「无法效果检验」的具体形态。
+    不可排序的车道(rotation_setup、缺 watch_score 的老 trace)显式返回
+    ranked=False,不要在这里造一个假的分档结论。
+    """
+    ranked = [t for t in trades if t.ranked and t.score is not None]
+    if not ranked:
+        # 「本层无排序键」和「样本还不够」是两回事:前者攒数据也不会变,
+        # 后者下个月就能重跑。混成一句话会让人以为轮动车道等等就能分档。
+        if trades:
+            return {"ranked": False, "reason": "本层无连续排序键，只作标签，不参与分档", "count": 0}
+        return {"ranked": False, "reason": "无样本", "count": 0}
+    if len(ranked) < 3:
+        return {"ranked": False, "reason": "可排序样本不足 3 只，分档没有意义", "count": len(ranked)}
+    scores = pd.Series([float(t.score) for t in ranked], dtype="float64")
+    if scores.nunique() <= 1:
+        return {"ranked": False, "reason": f"分值全同({scores.iloc[0]:.2f})，排序键无区分度", "count": len(ranked)}
+    lo, hi = float(scores.quantile(1 / 3)), float(scores.quantile(2 / 3))
+    bands = {
+        "low": [t for t in ranked if float(t.score) <= lo],
+        "mid": [t for t in ranked if lo < float(t.score) <= hi],
+        "high": [t for t in ranked if float(t.score) > hi],
+    }
+    return {
+        "ranked": True,
+        "cut_points": [round(lo, 4), round(hi, 4)],
+        "bands": {name: _lane_summary(rows) for name, rows in bands.items()},
     }
 
 
@@ -124,8 +157,7 @@ def _shadow_trade(
     next_date: date,
     code: str,
     row: dict[str, Any],
-    lane: str,
-    score: float,
+    signal: ReviewShadowSignal,
     frame: pd.DataFrame | None,
 ) -> ShadowTrade | None:
     signal_row, future = _signal_and_future_rows(frame, signal_date, next_date)
@@ -150,8 +182,9 @@ def _shadow_trade(
         entry_date=str(future["date"].iloc[0]),
         code=code,
         name=str(row.get("name") or code),
-        lane=lane,
-        score=float(score),
+        lane=signal.lane,
+        score=None if signal.score is None else float(signal.score),
+        ranked=bool(signal.ranked),
         entry_open=entry,
         signal_pct_chg=signal_pct,
         next_pct_chg=next_pct,
@@ -334,7 +367,30 @@ def _markdown_report(report: dict[str, Any]) -> str:
             f"| {shadow_lane_label(lane)} | {summary.get('count', 0)} | {_metric(t1, 'mean')} | "
             f"{_metric(t3, 'mean')} | {_metric(t5, 'mean')} | {_metric(t5, 'win_rate', percent=False)} |"
         )
+    lines.extend(_score_band_lines(report))
     return "\n".join(lines) + "\n"
+
+
+def _score_band_lines(report: dict[str, Any]) -> list[str]:
+    """分档表:排序键有没有单调性,只能靠这张表说话。"""
+    bands = report.get("by_score_band") or {}
+    if not bands:
+        return []
+    lines = ["", "## 排序键分档（低/中/高，看单调性）", ""]
+    for lane, payload in bands.items():
+        label = shadow_lane_label(lane)
+        if not payload.get("ranked"):
+            lines.append(f"- {label}：不可排序 —— {payload.get('reason', '未说明')}（样本 {payload.get('count', 0)}）")
+            continue
+        cuts = payload.get("cut_points") or []
+        cut_text = "/".join(f"{c:.2f}" for c in cuts)
+        parts = []
+        for name in ("low", "mid", "high"):
+            summary = (payload.get("bands") or {}).get(name) or {}
+            t5 = summary.get("ret_t5_pct") or {}
+            parts.append(f"{name} n={summary.get('count', 0)} T+5={_metric(t5, 'mean')}")
+        lines.append(f"- {label}（切点 {cut_text}）：" + " | ".join(parts))
+    return lines
 
 
 def _recall_line(report: dict[str, Any]) -> str:

--- a/workflows/review_trace.py
+++ b/workflows/review_trace.py
@@ -102,9 +102,13 @@ def _decision_rows(inputs: Any, triggers: dict) -> dict[str, dict[str, Any]]:
     entry_map = best_candidate_entry_map(candidates.candidate_entries)
     hit_map = _trigger_labels(triggers)
     blocked = _blocked_exit_map(candidates.exit_signals)
+    # watch_score 落进 trace:pre_breakout 车道的排序键。缺了它影子车道只能给
+    # 常数分,31 只同分就无法做「取前 N 只看超额」的效果检验。
+    # 用 getattr:回放路径自己拼候选对象,不一定带这个字段,缺了就退回不可排序标签。
+    score_map = {str(k): v for k, v in (getattr(candidates, "l3_score_map", None) or {}).items()}
     return {
         code: attach_shadow_signal(
-            _decision_row(code, inputs, l1_set, l2_set, l3_set, entry_map, hit_map, blocked),
+            _decision_row(code, inputs, l1_set, l2_set, l3_set, entry_map, hit_map, blocked, score_map),
             near_l2_max_gap_pct=_SHADOW_NEAR_L2_MAX_GAP_PCT,
         )
         for code in inputs.pool.symbols
@@ -120,6 +124,7 @@ def _decision_row(
     entry_map: dict[str, dict],
     hit_map: dict[str, list[str]],
     blocked: dict[str, dict],
+    score_map: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     name = str(inputs.ref_data.name_map.get(code, code)).strip() or code
     sector = str(inputs.ref_data.sector_map.get(code, "")).strip()
@@ -130,6 +135,7 @@ def _decision_row(
         "l2_eligible": code in l2_set,
         "l3_eligible": code in l3_set,
         "l2_channel": str(inputs.layers.l2_channel_map.get(code, "")),
+        "layer3_quality_score": _score_or_none((score_map or {}).get(code)),
         "trigger_labels": list(hit_map.get(code, [])),
         "risk_signal": str((blocked.get(code) or {}).get("signal") or ""),
     }
@@ -151,6 +157,13 @@ def _decision_row(
     if code in hit_map:
         return {**base, "stage": REVIEW_STAGE_TRIGGER_HIT, "reason": "、".join(hit_map[code])}
     return {**base, "stage": REVIEW_STAGE_TRIGGER_MISS, "reason": "未触发 Spring/LPS/EVR/SOS 等买点确认"}
+
+
+def _score_or_none(value: Any) -> float | None:
+    try:
+        return round(float(value), 6)
+    except (TypeError, ValueError):
+        return None
 
 
 def _l1_rejection_reason(code: str, inputs: Any) -> str:


### PR DESCRIPTION
## 变更摘要 | 结论先说

2026-09-01 那份强势股复盘暴露了三处同源问题，都是「数字读法」而非功能缺失：

1. **报告在按结果选样的证据上提改动方案。** 样本定义是「今日收盘>+7% 且前一日<+3%」——先有结果再回溯原因。被同一道闸门挡住却没涨的票不进样本，所以「39 只被基础准入淘汰」这类数字**没有分母**。「基础准入淘汰」那档已写明「不建议为涨停复盘反向放宽」，而「买点未确认」那档写的是「适合检查爆发前夜车道是否需要补强」——同样的证据强度，两档结论相反。删掉后一句，并在「重点归因」开头补样本口径声明。

2. **唯一分母同池的比率被埋在第四行。** 「可买到且被捕获」的分母是「昨天基础准入通过、今天涨了、次日还能按 ≤+4% 开盘价买到」，分子是其中前一日真在候选池的，实测 **1/54**。其它数字（影子召回 35/98、可交易 32/35）分母都是涨幅筛出来的，是事后命中计数。把 1/54 提到报告头，并注明它是全篇唯一同池比率。

3. **影子车道的分是常数，因此无法效果检验。** `pre_breakout` 恒 78.0、`rotation_setup` 恒 72.0，那 31 只「买点未确认」全同分。同分排不了序，「取前 N 只看超额」这类检验无从下手。

第 3 项的处理不是造分，而是找一个已经存在的连续键：

- `pre_breakout` 改用 `watch_score`。它由 `rank_l3_candidates` 对 L3 全体算过一次（`0.25*q20 + 0.20*q5 + 0.05*q3 + 0.20*dry_q + 0.30*trigger_q ± 加减项`，各 q 项均为 `rank(pct=True)`，取值约 `[0,1]`），已流入 `metrics["layer3_score_map"]`，接进 trace 零新增计算。乘 100 后与 `near_l2` 同量纲。
- `rotation_setup` **不给分**。读过 `core/wyckoff_engine.py:840` 的 `layer3_sector_resonance`，它是纯集合成员判断（`top_sector_set` / `keep_sector_set` / `hot_set` 加强度下限），本层没有缺口指标可拿。置 `score=None, ranked=False`，当标签用；下游要排序时按 `ranked` 过滤，而不是拿它跟别的车道比。
- 老 trace 缺 `watch_score` 字段时同样退回 `ranked=False`，宁可显式说排不了序，也不用常数假装能排。
- 新增按分值三分档的对照表。分值全同时自报 `ranked=False, reason="分值全同(…)，排序键无区分度"` —— 这正是 v1 的形态，让它显形而不是悄悄把全体塞进一个桶。「本层无连续排序键」和「样本不足 3 只」分开报：前者攒数据也不会变，后者下月能重跑，混成一句会让人以为轮动车道等等就能分档。

一并把 `l3_score_map` 用 `getattr` 取，回放路径自拼的候选对象不带这个字段时不会炸。

**这个 PR 本身不改任何阈值、不放宽任何车道。** 它只是让「爆发前夜要不要补强」这个问题变得可检验——真答案要等 trace 持久化后跑全量打标签 + T+5 超额 + 同动量随机对照。

## 验证

- `tests/core/test_review_shadow_lanes.py`：新增 3 例 —— `pre_breakout` 分值随 `watch_score` 单调（0.12 → 0.61 分值递增，且落在 0~100）、缺字段退回 `ranked=False`、`rotation_setup` 恒为 `score=None/ranked=False` 且理由含「无连续排序键」。
- `tests/workflows/test_review_shadow_backtest.py`：新增 3 例 —— 分值全同时分档表自报「分值全同」、有区分度时切点落在样本内且三档只数之和等于样本数、轮动车道标注「无连续排序键」而非「样本不足」。
- `tests/workflows/test_review_list_replay.py`：新增 3 例 —— 1/54 在报告头且排在影子召回之前、「买点未确认」不再含「需要补强」且改指向影子回放、「重点归因」首行是样本口径声明。
- 三个文件合计 **38 passed**。
- 全量 `pytest -q`：**4551 passed, 22 skipped**（119.64s）。
- `ruff check .` 全通过；`ruff format --check .` 955 files already formatted。
- `quality_gate.py --check-functions`：0 active legacy functions over limit。
- `quality_gate.py --check-no-sql`：无 .sql 文件。
- 用 9 只递增分值 + 3 只题材票造样本实跑了一遍 markdown 渲染，确认分档行与不可排序行的措辞：

```
## 排序键分档（低/中/高，看单调性）

- 爆发前夜（切点 69.33/90.67）：low n=3 T+5=+7.00% | mid n=3 T+5=+7.00% | high n=3 T+5=+7.00%
- 轮动待确认：不可排序 —— 本层无连续排序键，只作标签，不参与分档（样本 0）
```

（三档 T+5 相同是因为造数据时给了同一条价格序列，不是排序失效。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
