### PR TITLE
feat(shadow): 影子车道观测落库,信号日动量写进 trace

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -26,6 +26,7 @@ TABLE_SHADOW_POSITIONS = "shadow_positions"
 TABLE_SHADOW_EVENTS = "shadow_events"
 TABLE_SHADOW_NAV_DAILY = "shadow_nav_daily"
 TABLE_SHADOW_TRADE_PLANS = "shadow_trade_plans"
+TABLE_REVIEW_SHADOW_LANE_DAILY = "review_shadow_lane_daily"
 
 # Local SQLite DB path
 from pathlib import Path as _Path

--- a/core/review_shadow_lane_schema.py
+++ b/core/review_shadow_lane_schema.py
@@ -1,0 +1,87 @@
+"""review_shadow_lane_daily 的建表语句。
+
+为什么要落库,而不是继续靠 artifact:
+- trace 只活在 `daily-job-artifacts-*` 里,retention-days: 30(与日志同包),
+  约 20 个交易日。同动量对照的效果检验做不到 20 个观测就收敛。
+- 更要紧的是**补不回来**:回测引擎(workflows/backtest_*)不重放漏斗分层,
+  没有任何路径能从快照倒推出「某日某票卡在哪一层、watch_score 多少」。
+  所以每过一天没留存,就永久少一天样本——这是唯一有时钟压力的部分。
+- 体积不是障碍:全市场约 5000 只的 trace 压缩后约 33KB/日,一年 7.8MB。
+  但这里只落**有影子车道的行**(约 100~200 行/日),把表压到能直接查。
+
+本项目不保留 .sql 文件(scripts/quality_gate.py 会拦),且 Supabase Python SDK 走
+REST 不支持 DDL、环境也无 psycopg2/asyncpg 与连接串,故 schema 以 Python 常量形式
+版本化,由 scripts/print_review_shadow_lane_ddl.py 打印后人工在 SQL Editor 执行一次。
+
+字段设计的两条约束:
+1. **动量必须同期落下来。** 效果检验要的是「同动量随机对照」(见 memory
+   full-market-control-confounds-momentum / uniform-band-control-is-biased):
+   不记录当日 RPS,事后就只能拿全市场当对照,把择时读成选股。rps_fast/rps_slow
+   是 L1 闸门自己算过的值,不额外计算。
+2. **score 可空 + ranked 显式。** rotation_setup 所在的题材共振层是集合成员
+   判断,没有连续键;老 trace 也可能缺 watch_score。宁可存 null 并标
+   ranked=false,也不要用常数占位——那正是 v1 让 31 只票同分、排不了序的原因。
+"""
+
+from __future__ import annotations
+
+from core.constants import TABLE_REVIEW_SHADOW_LANE_DAILY
+
+# 与 integrations.supabase_review_shadow_lane.save_review_shadow_lane_rows 的
+# payload 键一一对应。顺序即建表顺序;测试会校验两者不漂移。
+COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("trade_date", "date not null", "信号日(决策发生的交易日),非写入日"),
+    ("ts_code", "text not null", "股票代码,6 位数字"),
+    ("name", "text", "股票名称,便于人工核对"),
+    ("sector", "text", "所属行业"),
+    ("lane", "text not null", "影子车道:near_l2 / rotation_setup / pre_breakout"),
+    ("stage", "text not null", "当日卡在漏斗哪一层(复盘阶段标签)"),
+    ("score", "numeric(10, 4)", "车道排序键,0~100。无连续键时为 null——不要填常数"),
+    ("ranked", "boolean not null default false", "score 是否可用于排序。false 时该行只作标签"),
+    ("reason", "text", "车道判定理由,含 watch_score 或缺口等具体数值"),
+    ("watch_score", "numeric(10, 6)", "L3 原始 watch_score(约 [0,1]),pre_breakout 的排序键来源"),
+    ("l2_channel", "text", "已通过的结构通道名"),
+    ("l1_eligible", "boolean not null default false", "当日是否过基础准入"),
+    ("l2_eligible", "boolean not null default false", "当日是否过结构强度"),
+    ("l3_eligible", "boolean not null default false", "当日是否过题材共振"),
+    # 动量:同动量对照的必要条件。缺了它只能拿全市场比,那会把择时当选股。
+    ("rps_fast", "numeric(10, 2)", "当日快线 RPS(默认 20 日),L1 闸门同源"),
+    ("rps_slow", "numeric(10, 2)", "当日慢线 RPS(默认 120 日),L1 闸门同源"),
+    ("close", "numeric(14, 4)", "信号日收盘价,用于核对入场价口径"),
+    ("policy_version", "text not null", "影子车道策略版本,如 review_shadow_v2"),
+    ("created_at", "timestamptz not null default now()", "写入时间"),
+)
+
+# 一个信号日一只票在一条车道上只应有一行。重跑同一天覆盖而非累积。
+# 键必须与写入侧 on_conflict 完全一致——见 memory dedup-key-must-match-db-constraint:
+# 键错位会让一行冲突回滚整批,而且是静默的。
+UNIQUE_KEY = ("trade_date", "ts_code", "lane")
+
+
+def payload_keys() -> frozenset[str]:
+    """save_review_shadow_lane_rows 应写入的字段（不含自增 id 与默认 created_at）。"""
+    return frozenset(name for name, _, _ in COLUMNS if name != "created_at")
+
+
+def build_ddl() -> str:
+    """生成完整建表语句。幂等——可重复执行。"""
+    table = TABLE_REVIEW_SHADOW_LANE_DAILY
+    body = ["    id bigserial primary key,"]
+    for name, ddl_type, comment in COLUMNS:
+        body.append(f"    -- {comment}")
+        body.append(f"    {name} {ddl_type},")
+    body.append(f"    constraint {table}_unique unique ({', '.join(UNIQUE_KEY)})")
+    lines = [
+        f"create table if not exists public.{table} (",
+        *body,
+        ");",
+        "",
+        "-- 主查询：某条车道随时间的表现,按信号日倒序取最近样本。",
+        f"create index if not exists {table}_lane_idx",
+        f"    on public.{table} (lane, trade_date desc);",
+        "",
+        "-- 同动量对照要按 (信号日, 动量) 找邻居,单独走一条索引。",
+        f"create index if not exists {table}_momentum_idx",
+        f"    on public.{table} (trade_date, rps_slow);",
+    ]
+    return "\n".join(lines) + "\n"

--- a/integrations/supabase_review_shadow_lane.py
+++ b/integrations/supabase_review_shadow_lane.py
@@ -1,0 +1,118 @@
+"""影子车道逐日观测落库。
+
+只写 review_shadow_lane_daily 一张表,按 (trade_date, ts_code, lane) upsert,
+重跑同一天覆盖而非累积。建表语句由
+`python scripts/print_review_shadow_lane_ddl.py` 输出。
+
+为什么必须落库:trace 只活在 `daily-job-artifacts-*` 里(retention-days: 30,与日志
+同包),而且**补不回来**——回测引擎不重放漏斗分层,没有任何路径能从快照倒推出
+「某日某票卡在哪一层、watch_score 多少」。每过一天没留存就永久少一天样本。
+
+行来源只有 trace 一处:车道判定走 core.review_shadow_lanes,不在这里重新分类,
+否则报告与落库两套口径会漂移(见 memory two-gates-must-share-one-source)。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.constants import TABLE_REVIEW_SHADOW_LANE_DAILY
+from core.review_shadow_lanes import shadow_signal_from_decision
+from integrations.supabase_base import create_admin_client, require_server_write_context
+
+logger = logging.getLogger(__name__)
+CHUNK = 200
+_CONFLICT_KEY = "trade_date,ts_code,lane"
+
+
+def build_lane_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """从一份 review trace 抽出有影子车道的行。
+
+    全市场约 5000 只里通常只有 100~200 只落在某条车道上,其余(过候选、数据失败、
+    风控拦截)不是观测对象。只落这部分,表才小到能直接查。
+
+    车道判定复用 shadow_signal_from_decision——与复盘报告、影子回放同一个函数。
+    """
+    trade_date = str(payload.get("trade_date") or "").strip()
+    if not trade_date:
+        return []
+    policy = payload.get("policy") or {}
+    gap_cap = _float(policy.get("shadow_near_l2_max_gap_pct"))
+    rows: list[dict[str, Any]] = []
+    for code, raw in (payload.get("symbols") or {}).items():
+        row = dict(raw or {})
+        signal = shadow_signal_from_decision(row, **({} if gap_cap is None else {"near_l2_max_gap_pct": gap_cap}))
+        if signal is None:
+            continue
+        rows.append(_lane_row(trade_date, str(code), row, signal))
+    return rows
+
+
+def _lane_row(trade_date: str, code: str, row: dict[str, Any], signal: Any) -> dict[str, Any]:
+    return {
+        "trade_date": trade_date,
+        "ts_code": code,
+        "name": _text(row.get("name")) or None,
+        "sector": _text(row.get("sector")) or None,
+        "lane": signal.lane,
+        "stage": _text(row.get("stage")),
+        "score": None if signal.score is None else round(float(signal.score), 4),
+        "ranked": bool(signal.ranked),
+        "reason": signal.reason,
+        "watch_score": _float(row.get("layer3_quality_score")),
+        "l2_channel": _text(row.get("l2_channel")) or None,
+        "l1_eligible": bool(row.get("l1_eligible")),
+        "l2_eligible": bool(row.get("l2_eligible")),
+        "l3_eligible": bool(row.get("l3_eligible")),
+        "rps_fast": _float(row.get("rps_fast")),
+        "rps_slow": _float(row.get("rps_slow")),
+        "close": _float(row.get("close")),
+        "policy_version": signal.policy_version,
+    }
+
+
+def save_review_shadow_lane_rows(rows: list[dict[str, Any]]) -> int:
+    """写入一批车道观测,返回成功行数。
+
+    失败只 warning:漏斗主流程不该因为这张观测表写不进去而中断。但**不会**打印
+    「已写入」这类成功句式——见 memory success-shaped-log-hid-total-loss,那让
+    影子账本缺列停摆两个月没人发现。写了几行就说几行,零行显式说零行。
+    """
+    if not rows:
+        return 0
+    require_server_write_context(f"{TABLE_REVIEW_SHADOW_LANE_DAILY} write")
+    client = create_admin_client()
+    written = 0
+    failed = 0
+    for start in range(0, len(rows), CHUNK):
+        batch = rows[start : start + CHUNK]
+        try:
+            client.table(TABLE_REVIEW_SHADOW_LANE_DAILY).upsert(batch, on_conflict=_CONFLICT_KEY).execute()
+            written += len(batch)
+        except Exception as exc:  # noqa: BLE001 - 观测表写失败不中断漏斗
+            failed += len(batch)
+            logger.warning("[shadow-lane] 批次写入失败 rows=%d: %s", len(batch), exc)
+    if failed or written < len(rows):
+        logger.warning(
+            "[shadow-lane] %s 未全部写入: written=%d failed=%d total=%d",
+            TABLE_REVIEW_SHADOW_LANE_DAILY,
+            written,
+            failed,
+            len(rows),
+        )
+    else:
+        logger.info("[shadow-lane] %s written=%d", TABLE_REVIEW_SHADOW_LANE_DAILY, written)
+    return written
+
+
+def _float(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if result != result else result
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()

--- a/scripts/print_review_shadow_lane_ddl.py
+++ b/scripts/print_review_shadow_lane_ddl.py
@@ -1,0 +1,24 @@
+"""打印 review_shadow_lane_daily 建表语句，供人工在 Supabase SQL Editor 执行。
+
+本项目不保留 .sql 文件，且 Supabase Python SDK 走 REST 不支持 DDL，
+故 schema 以 core/review_shadow_lane_schema.py 的常量形式版本化并由此脚本输出。
+
+用法::
+
+    python scripts/print_review_shadow_lane_ddl.py
+"""
+
+from __future__ import annotations
+
+import _bootstrap  # noqa: F401
+
+from core.review_shadow_lane_schema import build_ddl
+
+
+def main() -> int:
+    print(build_ddl())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integrations/test_supabase_review_shadow_lane.py
+++ b/tests/integrations/test_supabase_review_shadow_lane.py
@@ -1,0 +1,113 @@
+"""影子车道落库:行构建与 schema 防漂移。
+
+schema 以 Python 常量版本化(本项目不留 .sql),写入侧和建表侧靠测试对齐,
+不靠人记。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from core.funnel_taxonomy import (
+    REVIEW_STAGE_CANDIDATE_HIT,
+    REVIEW_STAGE_THEME_MISS,
+    REVIEW_STAGE_TRIGGER_MISS,
+)
+from core.review_shadow_lane_schema import UNIQUE_KEY, payload_keys
+from core.review_shadow_lanes import SHADOW_POLICY_VERSION
+from integrations.supabase_review_shadow_lane import build_lane_rows
+
+
+def _trace(symbols: dict) -> dict:
+    return {
+        "trade_date": "2026-09-01",
+        "policy": {"shadow_near_l2_max_gap_pct": 10.0},
+        "symbols": symbols,
+    }
+
+
+def test_only_lane_eligible_symbols_become_rows() -> None:
+    """全市场 5000 只里只有落在车道上的才写:过候选/数据失败的不是观测对象。"""
+    payload = _trace(
+        {
+            "000001": {"stage": REVIEW_STAGE_TRIGGER_MISS, "l3_eligible": True, "layer3_quality_score": 0.5},
+            "000002": {
+                "stage": REVIEW_STAGE_CANDIDATE_HIT,
+                "l1_eligible": True,
+                "l2_eligible": True,
+                "l3_eligible": True,
+            },
+            "000003": {"stage": "数据失败"},
+        }
+    )
+
+    rows = build_lane_rows(payload)
+
+    assert [row["ts_code"] for row in rows] == ["000001"]
+    assert rows[0]["lane"] == "pre_breakout"
+    assert rows[0]["policy_version"] == SHADOW_POLICY_VERSION
+
+
+def test_row_carries_momentum_and_close_for_same_momentum_control() -> None:
+    """同动量对照要的是信号日动量:缺了它只能拿全市场比,会把择时读成选股。"""
+    payload = _trace(
+        {
+            "000001": {
+                "stage": REVIEW_STAGE_TRIGGER_MISS,
+                "l3_eligible": True,
+                "layer3_quality_score": 0.42,
+                "rps_fast": 88.5,
+                "rps_slow": 91.25,
+                "close": 12.34,
+            }
+        }
+    )
+
+    row = build_lane_rows(payload)[0]
+
+    assert row["rps_fast"] == 88.5
+    assert row["rps_slow"] == 91.25
+    assert row["close"] == 12.34
+    assert row["watch_score"] == 0.42
+    assert row["ranked"] is True
+    assert row["score"] is not None
+
+
+def test_unranked_lane_stores_null_score_not_a_constant() -> None:
+    """没有连续键就存 null。填常数会让「取前 N 只」看起来能做,实际全是同分。"""
+    payload = _trace({"000001": {"stage": REVIEW_STAGE_THEME_MISS, "l2_eligible": True, "l2_channel": "主升通道"}})
+
+    row = build_lane_rows(payload)[0]
+
+    assert row["lane"] == "rotation_setup"
+    assert row["score"] is None
+    assert row["ranked"] is False
+
+
+def test_missing_trade_date_yields_no_rows() -> None:
+    symbols = {"000001": {"stage": REVIEW_STAGE_TRIGGER_MISS, "l3_eligible": True}}
+    assert build_lane_rows({"symbols": symbols}) == []
+
+
+def test_payload_keys_match_schema_columns() -> None:
+    """写入字段集必须等于建表字段集(created_at 由 default 填)。"""
+    source = Path("integrations/supabase_review_shadow_lane.py").read_text(encoding="utf-8")
+    block = source.split("def _lane_row(")[1].split("\n\n")[0]
+    written = set(re.findall(r'^\s+"(\w+)":', block, re.M))
+    assert written == set(payload_keys()), sorted(written ^ set(payload_keys()))
+
+
+def test_unique_key_matches_upsert_conflict_target() -> None:
+    """键错位会让一行冲突回滚整批,而且是静默的(memory dedup-key-must-match-db-constraint)。"""
+    source = Path("integrations/supabase_review_shadow_lane.py").read_text(encoding="utf-8")
+    assert f'_CONFLICT_KEY = "{",".join(UNIQUE_KEY)}"' in source
+
+
+def test_ddl_is_idempotent_and_indexes_momentum() -> None:
+    from core.review_shadow_lane_schema import build_ddl
+
+    ddl = build_ddl()
+    assert "create table if not exists" in ddl
+    assert ddl.count("create index if not exists") == 2
+    assert "(trade_date, rps_slow)" in ddl

--- a/tests/workflows/test_review_list_replay.py
+++ b/tests/workflows/test_review_list_replay.py
@@ -562,7 +562,10 @@ def test_review_trace_records_as_run_stages_without_ohlcv(tmp_path):
     assert payload["symbols"]["000002"]["stage"] == REVIEW_STAGE_STRENGTH_MISS
     assert payload["symbols"]["000003"]["stage"] == REVIEW_STAGE_BASE_REJECT
     assert "all_df_map" not in payload
-    assert "close" not in payload["symbols"]["000001"]
+    # close 只留信号日一个标量,不能把日线序列整段搬进 trace(那会让单日产物涨几十倍)。
+    assert payload["symbols"]["000001"]["close"] == 10.0
+    # 这个 layers 是 SimpleNamespace,没有 rps_*_map:缺字段要退成 None,不能抛。
+    assert payload["symbols"]["000001"]["rps_fast"] is None
     assert payload["symbols"]["000002"]["shadow_lane"] == "near_l2"
 
     path = write_review_trace_artifact(inputs, {"sos": [("000001", 5.0)]}, {}, str(tmp_path))
@@ -570,6 +573,51 @@ def test_review_trace_records_as_run_stages_without_ohlcv(tmp_path):
     assert loaded["config_digest"] == payload["config_digest"]
     with pytest.raises(ValueError, match="date mismatch"):
         load_review_trace_artifact(path, date(2026, 5, 11))
+
+
+def test_review_trace_records_signal_day_momentum() -> None:
+    """L2 算过的 RPS 必须落进 trace。
+
+    同动量随机对照要的就是这两个数;不留下来,事后只能拿全市场当对照,
+    会把择时读成选股(memory full-market-control-confounds-momentum)。
+    """
+    frame = pd.DataFrame(
+        {
+            "date": pd.bdate_range("2025-08-01", periods=220),
+            "close": [10.0] * 219 + [13.5],
+            "amount": [100_000_000.0] * 220,
+        }
+    )
+    inputs = SimpleNamespace(
+        cfg=FunnelConfig(),
+        window=SimpleNamespace(end_trade_date=date(2026, 5, 12)),
+        pool=SimpleNamespace(symbols=["000001"]),
+        ref_data=SimpleNamespace(
+            name_map={"000001": "平安银行"},
+            sector_map={"000001": "银行"},
+            market_cap_map={"000001": 100.0},
+            financial_map={},
+        ),
+        all_df_map={"000001": frame},
+        layers=SimpleNamespace(
+            l1_passed=["000001"],
+            l2_passed=["000001"],
+            l3_passed=["000001"],
+            l2_channel_map={"000001": "主升通道"},
+            l2_rejections={},
+            rps_fast_map={"000001": 92.5},
+            rps_slow_map={"000001": 88.125},
+        ),
+        candidates=SimpleNamespace(candidate_entries=[], exit_signals={}, l3_score_map={"000001": 0.63}),
+    )
+
+    row = build_review_trace(inputs, {}, {})["symbols"]["000001"]
+
+    assert row["rps_fast"] == 92.5
+    assert row["rps_slow"] == 88.125
+    assert row["close"] == 13.5
+    assert row["layer3_quality_score"] == 0.63
+    assert row["shadow_lane"] == "pre_breakout"
 
 
 def test_replay_context_from_trace_uses_recorded_decision_reason():

--- a/workflows/funnel_layers.py
+++ b/workflows/funnel_layers.py
@@ -17,6 +17,7 @@ from core.theme_activity import build_theme_activity_snapshot
 from core.theme_radar import build_theme_radar_snapshot
 from core.wyckoff_engine import (
     FunnelConfig,
+    build_layer2_evaluation_context,
     detect_leader_radar,
     layer1_filter,
     layer2_strength_detailed,
@@ -61,6 +62,11 @@ class FunnelLayerOutputs:
     mainline_candidates: list[dict]
     mainline_ai_cap: int
     rps_universe_count: int
+    # L2 算过的 RPS 快/慢线,原本用完即弃。留下来是为了写进 trace:影子车道的效果
+    # 检验要「同动量随机对照」,不记录当日动量,事后就只能拿全市场当对照,会把择时
+    # 读成选股(见 memory full-market-control-confounds-momentum)。
+    rps_fast_map: dict[str, float]
+    rps_slow_map: dict[str, float]
 
 
 def run_base_funnel_layers(
@@ -75,9 +81,9 @@ def run_base_funnel_layers(
     print("[funnel] 开始执行全量漏斗筛选...")
     _report_progress("漏斗筛选", "L1~L4 计算中", 0.85)
     l1_input = list(all_df_map.keys())
-    l1_passed, l2_passed, l2_channel_map, l2_rejections = _run_strength_layers(
-        l1_input, all_df_map, bench_df, cfg, ref_data
-    )
+    strength = _run_strength_layers(l1_input, all_df_map, bench_df, cfg, ref_data)
+    l1_passed, l2_passed = strength.l1_passed, strength.l2_passed
+    l2_channel_map = strength.l2_channel_map
     theme_activity = _build_theme_activity(window, ref_data, all_df_map)
     l3_passed, top_sectors, sector_rotation = _run_sector_layer(
         l1_passed,
@@ -108,10 +114,7 @@ def run_base_funnel_layers(
     )
     return _build_funnel_layer_outputs(
         l1_input=l1_input,
-        l1_passed=l1_passed,
-        l2_passed=l2_passed,
-        l2_channel_map=l2_channel_map,
-        l2_rejections=l2_rejections,
+        strength=strength,
         l3_passed=l3_passed,
         top_sectors=top_sectors,
         sector_rotation=sector_rotation,
@@ -129,10 +132,7 @@ def run_base_funnel_layers(
 
 def _build_funnel_layer_outputs(
     l1_input: list[str],
-    l1_passed: list[str],
-    l2_passed: list[str],
-    l2_channel_map: dict[str, str],
-    l2_rejections: dict[str, str],
+    strength: _StrengthLayerResult,
     l3_passed: list[str],
     top_sectors: list[str],
     sector_rotation: dict,
@@ -147,11 +147,11 @@ def _build_funnel_layer_outputs(
     mainline_cfg: Any,
 ) -> FunnelLayerOutputs:
     return FunnelLayerOutputs(
-        l1_passed=l1_passed,
-        l2_passed=l2_passed,
-        l2_channel_map=l2_channel_map,
-        l2_rejections=l2_rejections,
-        l2_counts=_l2_channel_counts(l2_channel_map),
+        l1_passed=strength.l1_passed,
+        l2_passed=strength.l2_passed,
+        l2_channel_map=strength.l2_channel_map,
+        l2_rejections=strength.l2_rejections,
+        l2_counts=_l2_channel_counts(strength.l2_channel_map),
         l3_passed=l3_passed,
         top_sectors=top_sectors,
         sector_rotation=sector_rotation,
@@ -167,6 +167,8 @@ def _build_funnel_layer_outputs(
         mainline_candidates=mainline_candidates,
         mainline_ai_cap=mainline_cfg.max_ai_candidates,
         rps_universe_count=len(l1_input),
+        rps_fast_map=strength.rps_fast_map,
+        rps_slow_map=strength.rps_slow_map,
     )
 
 
@@ -190,17 +192,30 @@ def _structure_shadow(
         }
 
 
+@dataclass(frozen=True)
+class _StrengthLayerResult:
+    l1_passed: list[str]
+    l2_passed: list[str]
+    l2_channel_map: dict[str, str]
+    l2_rejections: dict[str, str]
+    rps_fast_map: dict[str, float]
+    rps_slow_map: dict[str, float]
+
+
 def _run_strength_layers(
     l1_input: list[str],
     all_df_map: dict[str, pd.DataFrame],
     bench_df: pd.DataFrame | None,
     cfg: FunnelConfig,
     ref_data: FunnelReferenceData,
-) -> tuple[list[str], list[str], dict[str, str], dict[str, str]]:
+) -> _StrengthLayerResult:
     l1_passed = layer1_filter(
         l1_input, ref_data.name_map, ref_data.market_cap_map, all_df_map, cfg, financial_map=ref_data.financial_map
     )
     l2_rejections: dict[str, str] = {}
+    # 显式建 context 而不是让 layer2 内部建:RPS 快/慢线在里面算过一次,不接出来
+    # 就只能事后重算一遍(或者干脆没有动量,同动量对照做不成)。
+    context = build_layer2_evaluation_context(l1_passed, all_df_map, bench_df, cfg, rps_universe=l1_input)
     l2_passed, l2_channel_map, _pre_ignition = layer2_strength_detailed(
         l1_passed,
         all_df_map,
@@ -208,8 +223,16 @@ def _run_strength_layers(
         cfg,
         rps_universe=l1_input,
         rejections=l2_rejections,
+        evaluation_context=context,
     )
-    return l1_passed, l2_passed, l2_channel_map, l2_rejections
+    return _StrengthLayerResult(
+        l1_passed=l1_passed,
+        l2_passed=l2_passed,
+        l2_channel_map=l2_channel_map,
+        l2_rejections=l2_rejections,
+        rps_fast_map=dict(context.rps.fast or {}),
+        rps_slow_map=dict(context.rps.slow or {}),
+    )
 
 
 def _run_sector_layer(

--- a/workflows/review_trace.py
+++ b/workflows/review_trace.py
@@ -37,7 +37,16 @@ _SHADOW_NEAR_L2_MAX_GAP_PCT = 10.0
 def write_review_trace_artifact(inputs: Any, triggers: dict, metrics: dict, output_dir: str) -> Path | None:
     if not str(output_dir or "").strip():
         return None
-    payload = build_review_trace(inputs, triggers, metrics)
+    return dump_review_trace_artifact(build_review_trace(inputs, triggers, metrics), output_dir)
+
+
+def dump_review_trace_artifact(payload: dict[str, Any], output_dir: str) -> Path | None:
+    """落盘一份已构建好的 trace。
+
+    与 build 分开:落库和落盘用同一份 payload,不重复走一遍全量决策行构建。
+    """
+    if not str(output_dir or "").strip():
+        return None
     path = Path(output_dir) / f"review_trace_{payload['trade_date'].replace('-', '')}.json.gz"
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = path.with_suffix(path.suffix + ".tmp")
@@ -138,6 +147,7 @@ def _decision_row(
         "layer3_quality_score": _score_or_none((score_map or {}).get(code)),
         "trigger_labels": list(hit_map.get(code, [])),
         "risk_signal": str((blocked.get(code) or {}).get("signal") or ""),
+        **_market_state(code, inputs),
     }
     if code not in inputs.all_df_map:
         return {**base, "stage": "数据失败", "reason": "日线拉取失败/超时"}
@@ -164,6 +174,28 @@ def _score_or_none(value: Any) -> float | None:
         return round(float(value), 6)
     except (TypeError, ValueError):
         return None
+
+
+def _market_state(code: str, inputs: Any) -> dict[str, float | None]:
+    """记录信号当日的动量与收盘价。
+
+    效果检验要的是「同动量随机对照」:不留下当日 RPS,事后只能拿全市场当对照,
+    会把择时读成选股(memory full-market-control-confounds-momentum)。RPS 在 L2
+    已经算过,这里只是把它接出来,不重算。用 getattr:回放路径自己拼 layers 对象。
+    """
+    layers = inputs.layers
+    return {
+        "rps_fast": _score_or_none((getattr(layers, "rps_fast_map", None) or {}).get(code)),
+        "rps_slow": _score_or_none((getattr(layers, "rps_slow_map", None) or {}).get(code)),
+        "close": _last_close(inputs.all_df_map.get(code)),
+    }
+
+
+def _last_close(frame: pd.DataFrame | None) -> float | None:
+    if frame is None or getattr(frame, "empty", True):
+        return None
+    close = pd.to_numeric(sort_by_date_if_needed(frame).get("close"), errors="coerce").dropna()
+    return None if close.empty else round(float(close.iloc[-1]), 4)
 
 
 def _l1_rejection_reason(code: str, inputs: Any) -> str:

--- a/workflows/wyckoff_funnel.py
+++ b/workflows/wyckoff_funnel.py
@@ -750,14 +750,37 @@ def _attach_funnel_debug_context(metrics: dict, inputs: FunnelMetricsInputs, inc
 
 
 def _write_review_trace(inputs: FunnelMetricsInputs, triggers: dict, metrics: dict) -> None:
-    output_dir = os.getenv("DAILY_JOB_ARTIFACTS_DIR", "").strip()
-    if not output_dir:
-        return
-    from workflows.review_trace import write_review_trace_artifact
+    from workflows.review_trace import build_review_trace, dump_review_trace_artifact
 
-    path = write_review_trace_artifact(inputs, triggers, metrics, output_dir)
-    if path is not None:
-        print(f"[funnel] Review trace artifact: {path}")
+    payload = build_review_trace(inputs, triggers, metrics)
+    output_dir = os.getenv("DAILY_JOB_ARTIFACTS_DIR", "").strip()
+    if output_dir:
+        path = dump_review_trace_artifact(payload, output_dir)
+        if path is not None:
+            print(f"[funnel] Review trace artifact: {path}")
+    _persist_shadow_lanes(payload)
+
+
+def _persist_shadow_lanes(payload: dict) -> None:
+    """把影子车道观测落库。
+
+    artifact 的 retention 只有 30 天,而漏斗层级无法事后回放(回测引擎不重跑
+    L1~L4),过期即永久丢失。所以落库不跟 DAILY_JOB_ARTIFACTS_DIR 绑定:本地
+    没有 artifacts 目录也该写,只要处在 server_job 写入上下文里。
+    """
+    from integrations.supabase_base import is_server_write_context
+
+    if not is_server_write_context():
+        return
+    from integrations.supabase_review_shadow_lane import build_lane_rows, save_review_shadow_lane_rows
+
+    try:
+        rows = build_lane_rows(payload)
+        written = save_review_shadow_lane_rows(rows)
+    except Exception as exc:  # noqa: BLE001 - 观测表写失败不该中断漏斗
+        print(f"[funnel] 影子车道落库失败: {exc}")
+        return
+    print(f"[funnel] 影子车道落库: {written}/{len(rows)} 行")
 
 
 def _log_funnel_summary(metrics: dict, inputs: FunnelMetricsInputs) -> None:


### PR DESCRIPTION
## 问题

影子车道跑了但**没有留下可检验的记录**。两个原因叠在一起:

1. `daily-job-artifacts-*` 的 `retention-days: 30`,过期即删。
2. 漏斗层级**无法事后回放**——`backtest_strategy_replay.py` 只 import `dollar_volume_series`,没有任何回测路径重跑 L1~L4。所以「某票在 D 日卡在哪一层、watch_score 多少」不能从快照反推。

两条合起来:每一个没落库的交易日都是永久数据丢失。这是先做持久化、再接 CI 效果检验的原因。

## 改了什么

**新表 `review_shadow_lane_daily`**(建表语句由 `scripts/print_review_shadow_lane_ddl.py` 输出,已手工在 Supabase 执行)。落库条件是 `is_server_write_context()`,**不是** `DAILY_JOB_ARTIFACTS_DIR`——artifacts 目录管的是落盘,把落库也绑在它上面等于「没有目录的那天静默不留记录」,正是这张表要防的失败模式。

**信号日动量进 trace**。效果检验要的是「同动量随机对照」;不记录当日 RPS,事后只能拿全市场当对照,会把择时读成选股(候选动量 +19% vs 全市场 -5%,那次差点把择时读成选股能力)。RPS 在 L2 已经算过,这里把 `build_layer2_evaluation_context` 的结果留下来而不是重算。`close` 只留信号日一个标量,不把日线序列搬进 trace(会让单日产物涨几十倍)。

合成的 5000 只全市场 trace:裸 1908KB,gzip **33KB/天**,**7.8MB/年**;车道行约 244KB/年。体积不是约束。

## 几处刻意的选择

- **唯一键 `(trade_date, ts_code, lane)` 与写入侧 `on_conflict` 同源**,带正则漂移测试。键错位会让一行冲突静默回滚整批——上次这么丢了 8-31 的 140 条触发信号。
- **无连续排序键的车道存 `null`,不填常数分**。`rotation_setup` 的 L3 判定是纯集合成员,没有排序键;填常数会让「取前 N 只看超额」看起来能做,实际全是同分。v1 硬编码 `pre_breakout = 78.0` 让 31 只票并列,就是这个形态。「本层无排序键」和「样本不够」是两回事,前者攒数据也不会变。
- `build_lane_rows` 复用 `shadow_signal_from_decision`,与报告侧、回放侧同一个判定函数,不另写一套。
- 落库失败只打日志不中断漏斗;**零行不打成功句式的日志**——「已写入 … written=0」那种句式让影子账本缺列停摆了两个月,归因一直误报样本不足。
- `_build_review_trace` 的 build/dump 拆开,落库和落盘用同一份 payload,不重复走一遍全量决策行构建。

## 验证

- 全量 `4559 passed, 22 skipped`
- `ruff check` / `ruff format --check` 干净
- `quality_gate.py --check-functions --check-no-sql`: 0 violations
- 新增 7 个测试覆盖:只有车道票成行、动量与 close 落地、不可排序存 null、缺 trade_date 不写、payload 键与 schema 一致、唯一键与 conflict target 一致、DDL 幂等且索引动量

## 下一步(不在本 PR)

`workflows/review_shadow_backtest.py` 的 `_lane_summary` 目前报的是裸 T+1/T+3/T+5 收益,**没有对照组**。接 CI 时要把车道交易喂进 `core/funnel_effect_eval.py` 已有的 `match_by_momentum` / `sample_momentum_band` / `control_gap` / `summarize_absolute`,而不是新写一套统计——不然「爆发前夜要不要补强」还是会把动量选位读成选股能力。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
