### PR TITLE
fix(funnel): 随机负控制填了候选收益，候选项相减时精确抵消

### DIFF
--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -14,9 +14,12 @@
 2. **对照组用「T 日已知 20 日涨幅最近邻 1:1 无放回配对」的非候选股**。候选
    天然偏高动量，全市场等权对照会把动量的 beta 混进来。配对后残差动量应接近 0，
    报告里给出实测值供核对。
-3. **随机负控制**：每天从「与候选同动量分位区间」随机抽同样只数。配对超额若
-   落在多种子随机控制的区间内，说明它只是「站在了那个动量位置上」，不含选股
-   信息。这一条照 momentum_regime_eval 的做法固化进每次体检，不可省。
+3. **随机负控制**：每天从「与候选同动量分位区间」随机抽同样只数，**减掉与配对组
+   同一条基准线**（配对篮的收益），得到随机组的超额。配对超额若落在多种子随机
+   控制的区间内，说明它只是「站在了那个动量位置上」，不含选股信息。共用基准这一
+   点是硬要求：若随机组的被测量填成候选自己的收益，候选项在相减时精确抵消，整个
+   否证环节对候选好坏完全不敏感（曾经如此，见 ``random_control_row``）。这一条照
+   momentum_regime_eval 的做法固化进每次体检，不可省。
 
 买点 T+1 开盘（漏斗信号收盘后产出，最早可成交是次日开盘），卖点 T+1+H 收盘，
 扣 ROUND_TRIP_COST_PCT=0.202%，按交易日等权汇总。
@@ -351,6 +354,19 @@ def resolve_layer(day: dict, universe: set[str], layer: str) -> tuple[list[str],
     return hits, sorted(universe - wide)
 
 
+@dataclass(frozen=True)
+class MatchedBaseline:
+    """配对对照篮的当日毛收益与平均动量，是配对组与随机组**共用**的那条基准线。
+
+    共用是要点：两组各减同一个基准，相减后基准抵消、剩下的是「漏斗挑的 vs 随机挑
+    的」。若两组减的基准不同（或某一组把候选自己的收益当被测量），差值里就没有候选
+    的位置了，详见 ``random_control_row``。
+    """
+
+    ret: float
+    mom: float
+
+
 def absolute_row(hits: list[str], panels: Panels, ds: str, buy_ds: str, sell_ds: str) -> dict | None:
     """当日绝对收益观测。算在**全部候选**上，与配对成败无关。
 
@@ -376,14 +392,28 @@ def random_control_row(
     ds: str,
     buy_ds: str,
     sell_ds: str,
-    hit_ret: float,
+    baseline: MatchedBaseline,
     *,
     seed: int,
 ) -> dict | None:
-    """单个随机负控制的当日观测。
+    """单个随机负控制的当日观测：把「随机抽的那一篮」放到候选的位置上。
 
-    必须与配对组用同一批候选（``paired_hits``），否则两者分母不同、超额不可直接
-    比较——这是把「配对超额 vs 随机超额」摆在一起的前提。
+    ``net`` 必须是**随机篮自己的收益**，``control`` 必须是配对组减的那同一个
+    ``baseline``。第一版把 ``net`` 填成了候选收益 ``hit_ret``（与配对行同值），于是
+
+        matched.excess = hit - baseline
+        control.excess = hit - baseline'      <- net 也是 hit
+        gap = (hit - baseline) - (hit - baseline') = baseline' - baseline
+
+    候选表现在相减时**精确抵消**，``control_gap`` 只在比「随机篮 vs 最近邻篮」，
+    对候选好坏完全不敏感：实测完美预知的候选（配对超额 +5.79pct，t=+35.6）与纯
+    随机选票（-0.14pct）拿到同一句「不含选股信息」，扫候选收益从 -5% 到 +20%，
+    gap 恒为 +0.0000。正确形状见 ``evaluate_momentum_regime._collect_non_top_control``：
+    每行带自己的 ``inside``、共用一个 ``domain`` 基准。修好后 gap = hit - rand，
+    也就是「同一动量位置上，漏斗挑的这几只有没有跑赢随便挑的几只」。
+
+    必须与配对组用同一批候选（``paired_hits``）定邻域，否则两者分母不同、超额
+    不可直接比较——这是把「配对超额 vs 随机超额」摆在一起的前提。
     """
     band = sample_momentum_band(paired_hits, pool, mom, seed=seed, date=ds)
     if len(band) < MIN_HITS_PER_DAY:
@@ -394,9 +424,10 @@ def random_control_row(
     return {
         "date": ds,
         "size": len(band),
-        "net": hit_ret - ROUND_TRIP_COST_PCT,
-        "control": ctl - ROUND_TRIP_COST_PCT,
-        "residual_mom": mean(mom[h] for h in paired_hits if h in mom) - mean(mom[c] for c in band if c in mom),
+        "net": ctl - ROUND_TRIP_COST_PCT,
+        "control": baseline.ret - ROUND_TRIP_COST_PCT,
+        # 与本行超额（随机篮 - 基准）对齐的中性化检查项，故是随机篮减基准的动量差。
+        "residual_mom": mean(mom[c] for c in band if c in mom) - baseline.mom,
     }
 
 
@@ -441,20 +472,26 @@ def evaluate_daily(
             continue
 
         ctl = panels.gross_return(paired_ctrl, buy_ds, sell_ds)
-        if ctl is not None:
-            rows["matched"].append(
-                {
-                    "date": ds,
-                    "size": len(pairs),
-                    # 两边都扣成本，故超额里成本抵消；net/control 本身仍是净值口径
-                    "net": hit_ret - ROUND_TRIP_COST_PCT,
-                    "control": ctl - ROUND_TRIP_COST_PCT,
-                    "residual_mom": mean(mom[h] for h in paired_hits) - mean(mom[c] for c in paired_ctrl),
-                }
-            )
+        if ctl is None:
+            continue
+
+        # 配对篮既是配对组的对照，也是随机组的基准：两组减同一条线，相减后基准
+        # 抵消，剩下「漏斗挑的 vs 同邻域内随便挑的」。缺了这条共用，gap 就退化成
+        # 两个对照篮互比，与候选无关（见 random_control_row）。
+        baseline = MatchedBaseline(ret=ctl, mom=mean(mom[c] for c in paired_ctrl))
+        rows["matched"].append(
+            {
+                "date": ds,
+                "size": len(pairs),
+                # 两边都扣成本，故超额里成本抵消；net/control 本身仍是净值口径
+                "net": hit_ret - ROUND_TRIP_COST_PCT,
+                "control": baseline.ret - ROUND_TRIP_COST_PCT,
+                "residual_mom": mean(mom[h] for h in paired_hits) - baseline.mom,
+            }
+        )
 
         for seed in seeds:
-            ctrl_row = random_control_row(paired_hits, pool, mom, panels, ds, buy_ds, sell_ds, hit_ret, seed=seed)
+            ctrl_row = random_control_row(paired_hits, pool, mom, panels, ds, buy_ds, sell_ds, baseline, seed=seed)
             if ctrl_row is not None:
                 rows[f"control_{seed}"].append(ctrl_row)
     return rows
@@ -463,9 +500,11 @@ def evaluate_daily(
 def control_gap(matched: GroupStat, controls: list[GroupStat]) -> dict[str, Any]:
     """配对超额相对随机负控制的差距。
 
-    控制组每天从「候选动量区间内」随机抽同样只数，只带动量选位这一条信息。
-    配对超额若落在控制组区间内、或差距小于控制组自身的抽样宽度，就不能说漏斗
-    含选股信息——这是唯一能否掉「漏斗有效」的环节。
+    控制组每天从「候选动量区间内」随机抽同样只数，只带动量选位这一条信息。两组
+    减同一条基准线（配对篮），所以 ``gap = 候选收益 - 随机篮收益``：同一动量位置
+    上，漏斗挑的这几只比随便挑的几只好多少。配对超额若落在控制组区间内、或差距
+    小于控制组自身的抽样宽度，就不能说漏斗含选股信息——这是唯一能否掉「漏斗有效」
+    的环节，所以它必须对候选表现敏感（回归测试守在 ``TestControlGapDiscriminates``）。
     """
     usable = [c.excess_pct for c in controls if c.excess_pct is not None]
     if matched.excess_pct is None or len(usable) < 2:
@@ -473,7 +512,6 @@ def control_gap(matched: GroupStat, controls: list[GroupStat]) -> dict[str, Any]
     avg = mean(usable)
     spread = max(usable) - min(usable)
     gap = matched.excess_pct - avg
-    inside = min(usable) <= matched.excess_pct <= max(usable)
     return {
         "seeds": len(usable),
         "matched_excess": _round(matched.excess_pct),
@@ -482,9 +520,28 @@ def control_gap(matched: GroupStat, controls: list[GroupStat]) -> dict[str, Any]
         "control_excess_max": _round(max(usable)),
         "seed_spread": _round(spread),
         "gap": _round(gap),
-        "verdict": (
-            "配对超额落在随机负控制区间内：边缘仅来自动量选位，不含选股信息"
-            if inside or gap <= spread
-            else "配对超额跑赢随机负控制：含独立选股信息"
-        ),
+        # 只标「有没有高过每个种子」这一件事：报告按它把「没跑赢随机」和「跑赢但
+        # 幅度薄」分开计数。别把「落在区间内」也塞进这个布尔——一个字段两种语义。
+        "beats_band": matched.excess_pct > max(usable),
+        "verdict": _gap_verdict(matched.excess_pct, usable, gap=gap, spread=spread),
     }
+
+
+def _gap_verdict(matched: float, usable: list[float], *, gap: float, spread: float) -> str:
+    """三个否证条件必须分开说，否则会把数读反。
+
+    实测 T+10：配对超额 +2.468pct **高过**种子上界 +2.095，但差距 1.414 小于种子
+    自身宽度 1.555。旧版对这一格印「落在随机负控制区间内」——那句话是错的，读报告
+    的人会以为超额被区间包住了。反过来，低于种子下界（实测 T+5 的 +0.74 vs 下界
+    +0.221 之外的格子）说成「高过上界」同样是读反。三种都不构成证据，但理由不同：
+    随便挑还更好 / 分不出来 / 跑赢的幅度还没超过随机自己的抽样噪声。
+    """
+    if matched < min(usable):
+        return "配对超额低于每个随机负控制种子：同动量位置上随便挑还更好，不含选股信息"
+    if matched <= max(usable):
+        return "配对超额落在随机负控制区间内：边缘仅来自动量选位，不含选股信息"
+    if gap <= spread:
+        return (
+            f"配对超额高过随机负控制上界，但差距 {gap:+.3f}pct 未超过种子宽度 {spread:.3f}pct：证据不足，不能算选股信息"
+        )
+    return "配对超额跑赢随机负控制：含独立选股信息"

--- a/core/funnel_effect_panels.py
+++ b/core/funnel_effect_panels.py
@@ -1,0 +1,103 @@
+"""效果检验用的行情面板构建：流动性池与 T 日已知动量。
+
+从 ``scripts/evaluate_funnel_effect.py`` 抽出来的原因不是复用代码行，而是**动量定义
+必须只有一处**。同动量对照的全部意义在于「两组的 mom20 用同一个尺子量」；漏斗效果
+检验与影子车道效果检验若各自算一遍 20 日涨幅（窗口含不含 T 日、要不要 shift、
+用不用复权），得到的邻域就不是同一个邻域，两份报告的对照组无法互相印证，而这种
+偏差不会报错、只会静默地把结论读偏（见 memory two-gates-must-share-one-source）。
+
+口径固定为：
+
+- **流动性池**：20 日均额 ``shift(1)``，只含 T 日收盘可知的信息。
+- **20 日动量**：按 T 日收盘算（含 T 日），候选与对照同口径，无前视。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from core.funnel_effect_eval import Panels
+
+# 20 日均额下限（万元）。低于此的票进不了对照池——流动性差的票的收益噪声与
+# 候选不可比，把它们放进邻域只会放大控制组的方差。
+DEFAULT_MIN_AMOUNT_WAN = 8000.0
+
+
+def load_market_frame(path: str | Path) -> pd.DataFrame:
+    """兼容两种列名：快照的 date/symbol/amount(元)，与 tushare 的 trade_date/ts_code/amount(千元)。"""
+    text = str(path)
+    compression = "gzip" if text.endswith(".gz") else None
+    head = pd.read_csv(text, nrows=1, compression=compression)
+    if "symbol" in head.columns:
+        frame = pd.read_csv(text, usecols=["date", "open", "close", "amount", "symbol"], compression=compression)
+        frame["code"] = frame.symbol.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
+        frame["ds"] = pd.to_datetime(frame.date).dt.strftime("%Y-%m-%d")
+        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 1e4
+    else:
+        frame = pd.read_csv(text, usecols=["ts_code", "trade_date", "open", "close", "amount"], compression=compression)
+        frame["code"] = frame.ts_code.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
+        frame["ds"] = pd.to_datetime(frame.trade_date.astype(str), format="%Y%m%d").dt.strftime("%Y-%m-%d")
+        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 10.0
+    for col in ("open", "close"):
+        frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    return frame.dropna(subset=["open", "close"]).sort_values(["code", "ds"])
+
+
+def load_benchmark_prices(path: str | Path) -> tuple[dict[str, float], dict[str, float]]:
+    """基准指数的 (开盘, 收盘)。窗口要与候选完全一致，所以两头都要。"""
+    if not str(path or "").strip() or not Path(path).exists():
+        return {}, {}
+    frame = pd.read_csv(path, usecols=["date", "open", "close"])
+    frame["ds"] = pd.to_datetime(frame.date).dt.strftime("%Y-%m-%d")
+    for col in ("open", "close"):
+        frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    frame = frame.dropna(subset=["open", "close"]).drop_duplicates("ds")
+    return (
+        dict(zip(frame.ds, frame.open.astype(float), strict=True)),
+        dict(zip(frame.ds, frame.close.astype(float), strict=True)),
+    )
+
+
+def build_panels(
+    frame: pd.DataFrame,
+    min_amount_wan: float = DEFAULT_MIN_AMOUNT_WAN,
+    benchmark: str | Path = "",
+) -> Panels:
+    """流动性池与 20 日动量都用 shift(1)，只含 T 日收盘可知的信息。"""
+    frame = frame.copy()
+    grouped = frame.groupby("code", sort=False)
+    frame["avg20"] = grouped.amt_wan.transform(lambda s: s.rolling(20, min_periods=10).mean().shift(1))
+    # 20 日涨幅按 T 日收盘算（含 T 日），配对时对候选和对照同口径，无前视。
+    frame["mom20"] = grouped.close.transform(lambda s: 100.0 * (s / s.shift(20) - 1.0))
+    liquid = frame[frame.avg20 >= min_amount_wan]
+    bench_open, bench_close = load_benchmark_prices(benchmark)
+    return Panels(
+        open={ds: dict(zip(g.code, g.open, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
+        close={ds: dict(zip(g.code, g.close, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
+        liquid={ds: set(g.code) for ds, g in liquid.groupby("ds", sort=False)},
+        mom20={
+            ds: dict(zip(g.code, g.mom20, strict=True))
+            for ds, g in frame.dropna(subset=["mom20"]).groupby("ds", sort=False)
+        },
+        dates=sorted(frame.ds.unique()),
+        bench_open=bench_open,
+        bench_close=bench_close,
+    )
+
+
+def build_panels_from_snapshot(
+    snapshot_dir: str | Path,
+    min_amount_wan: float = DEFAULT_MIN_AMOUNT_WAN,
+) -> Panels | None:
+    """从回测快照目录建面板。缺 hist_full.csv.gz 返回 None——效果检验降级为不出对照。
+
+    降级而不抛：影子回测的召回率部分不依赖面板，快照缺失时不该把整份报告拖挂。
+    但降级必须在报告里显式说明，不能让读者以为「没有对照组一节」等于「对照通过了」。
+    """
+    root = Path(snapshot_dir)
+    market = root / "hist_full.csv.gz"
+    if not market.exists():
+        return None
+    return build_panels(load_market_frame(market), min_amount_wan, root / "benchmark_main.csv")

--- a/scripts/evaluate_funnel_effect.py
+++ b/scripts/evaluate_funnel_effect.py
@@ -33,18 +33,17 @@ import argparse
 import json
 
 import _bootstrap  # noqa: F401
-import pandas as pd
 
 from core.funnel_effect_eval import (
     CONTROL_SEEDS,
     MIN_DAYS,
     MOM_MATCH_TOL_PCT,
-    Panels,
     control_gap,
     evaluate_daily,
     summarize_absolute,
     summarize_group,
 )
+from core.funnel_effect_panels import build_panels, load_market_frame
 from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
 
 
@@ -63,62 +62,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--benchmark", default="", help="基准指数 CSV（快照的 benchmark_main.csv），缺省则不出基准差额")
     parser.add_argument("--json-out", default="", help="结构化结果输出路径")
     return parser.parse_args()
-
-
-def load_market(path: str) -> pd.DataFrame:
-    """兼容两种列名：快照的 date/symbol/amount(元)，与 tushare 的 trade_date/ts_code/amount(千元)。"""
-    head = pd.read_csv(path, nrows=1)
-    if "symbol" in head.columns:
-        frame = pd.read_csv(path, usecols=["date", "open", "close", "amount", "symbol"])
-        frame["code"] = frame.symbol.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
-        frame["ds"] = pd.to_datetime(frame.date).dt.strftime("%Y-%m-%d")
-        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 1e4
-    else:
-        frame = pd.read_csv(path, usecols=["ts_code", "trade_date", "open", "close", "amount"])
-        frame["code"] = frame.ts_code.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
-        frame["ds"] = pd.to_datetime(frame.trade_date.astype(str), format="%Y%m%d").dt.strftime("%Y-%m-%d")
-        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 10.0
-    for col in ("open", "close"):
-        frame[col] = pd.to_numeric(frame[col], errors="coerce")
-    return frame.dropna(subset=["open", "close"]).sort_values(["code", "ds"])
-
-
-def load_benchmark(path: str) -> tuple[dict[str, float], dict[str, float]]:
-    """基准指数的 (开盘, 收盘)。窗口要与候选完全一致，所以两头都要。"""
-    if not path:
-        return {}, {}
-    frame = pd.read_csv(path, usecols=["date", "open", "close"])
-    frame["ds"] = pd.to_datetime(frame.date).dt.strftime("%Y-%m-%d")
-    for col in ("open", "close"):
-        frame[col] = pd.to_numeric(frame[col], errors="coerce")
-    frame = frame.dropna(subset=["open", "close"]).drop_duplicates("ds")
-    return (
-        dict(zip(frame.ds, frame.open.astype(float), strict=True)),
-        dict(zip(frame.ds, frame.close.astype(float), strict=True)),
-    )
-
-
-def build_panels(frame: pd.DataFrame, min_amount_wan: float, benchmark: str = "") -> Panels:
-    """流动性池与 20 日动量都用 shift(1)，只含 T 日收盘可知的信息。"""
-    frame = frame.copy()
-    grouped = frame.groupby("code", sort=False)
-    frame["avg20"] = grouped.amt_wan.transform(lambda s: s.rolling(20, min_periods=10).mean().shift(1))
-    # 20 日涨幅按 T 日收盘算（含 T 日），配对时对候选和对照同口径，无前视。
-    frame["mom20"] = grouped.close.transform(lambda s: 100.0 * (s / s.shift(20) - 1.0))
-    liquid = frame[frame.avg20 >= min_amount_wan]
-    bench_open, bench_close = load_benchmark(benchmark)
-    return Panels(
-        open={ds: dict(zip(g.code, g.open, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
-        close={ds: dict(zip(g.code, g.close, strict=True)) for ds, g in frame.groupby("ds", sort=False)},
-        liquid={ds: set(g.code) for ds, g in liquid.groupby("ds", sort=False)},
-        mom20={
-            ds: dict(zip(g.code, g.mom20, strict=True))
-            for ds, g in frame.dropna(subset=["mom20"]).groupby("ds", sort=False)
-        },
-        dates=sorted(frame.ds.unique()),
-        bench_open=bench_open,
-        bench_close=bench_close,
-    )
 
 
 CONTROL_DESC = {
@@ -204,13 +147,20 @@ def render(result: dict, status: str) -> str:
         f"## 随机负控制（{len(CONTROL_SEEDS)} 个种子，逐只在同动量 ±{MOM_MATCH_TOL_PCT:.0f}pct 邻域内随机替换）",
         "",
     ]
-    inside = 0
+    # 「没跑赢随机」和「跑赢上界但幅度小于种子宽度」都不构成证据，但理由不同，分开
+    # 计数：前者是同动量随便挑就有同等超额，后者是跑赢的幅度还没超过随机自己的抽样
+    # 噪声。按 beats_band 分，不要按 verdict 里的字面——句式改了计数就会静默变错。
+    ready = [b["control_gap"] for b in result["horizons"].values() if b["control_gap"].get("verdict") != "样本不足"]
+    inside = sum(1 for gap in ready if not gap.get("beats_band"))
+    thin = sum(1 for gap in ready if gap.get("beats_band") and "证据不足" in gap.get("verdict", ""))
+    # 数「真跑赢的格子」,不要用「没被否证」反推：全部持有期样本不足时 inside 和 thin
+    # 都是 0,反推会印出「含独立选股信息」——零证据宣布有效。
+    won = len(ready) - inside - thin
     for h, block in result["horizons"].items():
         gap = block["control_gap"]
         if gap.get("verdict") == "样本不足":
             lines.append(f"- T+{h}：样本不足")
             continue
-        inside += "落在" in gap["verdict"]
         lines.append(
             f"- T+{h}：配对超额 {gap['matched_excess']:+.3f}pct，"
             f"随机控制 {gap['control_excess_min']:+.3f}~{gap['control_excess_max']:+.3f}pct"
@@ -220,13 +170,20 @@ def render(result: dict, status: str) -> str:
     lines += ["", "## 怎么读", "", *read_absolute_notes(result)]
     if inside:
         lines += [
-            f"- **{inside} 个持有期的配对超额落在随机负控制区间内。**上表的超额和 t 值不能读成选股能力：",
+            f"- **{inside} 个持有期的配对超额没有高过随机负控制的上界。**上表的超额和 t 值不能读成选股能力：",
             "  同动量邻域内随机抽同样只数就能拿到同等甚至更高的超额，说明这部分收益来自"
             "「候选站在动量轴的哪个位置」，而不是「在同一位置上挑中了哪一只」。",
             "- 为正日比例高（如 70%/75%）同样不构成证据——随机控制的为正日比例一样高。",
         ]
-    else:
+    if thin:
+        lines.append(
+            f"- **{thin} 个持有期跑赢了随机控制上界，但幅度小于种子自身的抽样宽度。**"
+            "换 5 个种子就可能翻转，不能当选股能力；要判定得加种子数并取不重叠日。"
+        )
+    if won and not inside and not thin:
         lines.append("- 配对超额跑赢随机负控制，含独立选股信息；仍需在更长样本上按走前口径复核后才可据此改阈值。")
+    if not ready:
+        lines.append("- 所有持有期都样本不足，本轮不给判定：既不能说含选股信息，也不能说不含。")
     lines += [
         f"- 单次往返成本 {ROUND_TRIP_COST_PCT}%：超额小于它时，净收益上看不出差别。",
         "- 残差动量列是配对是否真中性化的检查项；它偏离 0 太多时，超额里混着动量差，整行作废。",
@@ -241,7 +198,7 @@ def render(result: dict, status: str) -> str:
 def main() -> int:
     args = parse_args()
     cands = json.load(open(args.cands, encoding="utf-8"))
-    panels = build_panels(load_market(args.cache), args.min_amount_wan, args.benchmark)
+    panels = build_panels(load_market_frame(args.cache), args.min_amount_wan, args.benchmark)
     horizons = [int(x) for x in args.horizons.split(",") if x.strip()]
 
     result: dict = {"status": args.status, "horizons": {}}

--- a/tests/core/test_funnel_effect_eval.py
+++ b/tests/core/test_funnel_effect_eval.py
@@ -390,6 +390,91 @@ class TestPanels:
         assert (panels.bench_open, panels.bench_close) == ({}, {})
 
 
+def _noisy_panels(n_days: int = 32, n_codes: int = 200) -> Panels:
+    """行情带噪声、动量与噪声独立的面板。
+
+    为什么必须带噪声：最近邻动量配对**天然会杀掉「纯粹由动量决定的」收益差**。
+    ``_panels`` 那种恒定价格的面板里,任何选股都拿不出超额,只能验 null 的一侧,
+    验不出「有边缘」的一侧,也就证不明这套对照有分辨力。这里让每 (票, 日) 的收益
+    是独立噪声、动量是与噪声无关的固定抽样,选股能力才有地方体现。
+    """
+    codes = [f"s{i}" for i in range(n_codes)]
+    dates = [f"2026-06-{i + 1:02d}" for i in range(n_days)]
+    rng = random.Random(19)
+    mom = {c: rng.gauss(5.0, 8.0) for c in codes}
+    close = {d: {c: 100.0 * (1.0 + rng.gauss(0.0, 3.0) / 100.0) for c in codes} for d in dates}
+    return Panels(
+        open={d: dict.fromkeys(codes, 100.0) for d in dates},
+        close=close,
+        liquid={d: set(codes) for d in dates},
+        mom20={d: dict(mom) for d in dates},
+        dates=dates,
+    )
+
+
+def _verdict(cands: dict[str, dict], panels: Panels, horizon: int = 5) -> dict:
+    rows = evaluate_daily(cands, panels, horizon, status="formal_l4")
+    matched = summarize_group("matched", rows["matched"])
+    controls = [summarize_group(f"c{s}", rows[f"control_{s}"]) for s in CONTROL_SEEDS]
+    return {"gap": control_gap(matched, controls), "matched": matched}
+
+
+class TestControlGapDiscriminates:
+    """端到端守住「否证环节对候选好坏敏感」。
+
+    原来的 ``TestControlGap`` 全是手喂 ``GroupStat`` 的超额值,不经 ``evaluate_daily``
+    /``random_control_row``,所以随机组把候选收益当被测量这个 bug 一直没被发现——
+    实测完美预知的候选(配对超额 +5.79pct, t=+35.6)与纯随机选票(-0.14pct)拿到同
+    一句「不含选股信息」,扫候选收益 -5%~+20% 时 gap 恒为 +0.0000。这里必须走完整
+    链路。
+    """
+
+    HORIZON = 5
+    N_HITS = 20
+
+    def _signal_days(self, panels: Panels) -> list[str]:
+        return panels.dates[: -(self.HORIZON + 2)]
+
+    def _foresight(self, panels: Panels) -> dict[str, dict]:
+        """按实际卖出价选票——选股能力的上限。用 sell_ds 而非 buy_ds：后者跟持有
+        期收益无关,选出来的边缘接近 0,那样探针自己就是错的。"""
+        cands: dict[str, dict] = {}
+        for ds in self._signal_days(panels):
+            _buy_ds, sell_ds = panels.window(ds, self.HORIZON)
+            ranked = sorted(panels.close[sell_ds], key=lambda c: -panels.close[sell_ds][c])
+            hits = sorted(ranked[: self.N_HITS])
+            cands[ds] = {"formal_l4": hits, "all": hits}
+        return cands
+
+    def _random_picks(self, panels: Panels) -> dict[str, dict]:
+        cands: dict[str, dict] = {}
+        rng = random.Random(4242)
+        for ds in self._signal_days(panels):
+            hits = sorted(rng.sample(sorted(panels.liquid[ds]), self.N_HITS))
+            cands[ds] = {"formal_l4": hits, "all": hits}
+        return cands
+
+    def test_perfect_foresight_beats_the_random_control(self):
+        panels = _noisy_panels()
+        out = _verdict(self._foresight(panels), panels, self.HORIZON)
+        assert out["matched"].excess_pct > 1.0, out["matched"].excess_pct
+        assert out["gap"]["gap"] > out["gap"]["seed_spread"]
+        assert "含独立选股信息" in out["gap"]["verdict"], out["gap"]
+
+    def test_random_picks_stay_inside_the_random_control(self):
+        panels = _noisy_panels()
+        out = _verdict(self._random_picks(panels), panels, self.HORIZON)
+        assert abs(out["matched"].excess_pct) < 1.0, out["matched"].excess_pct
+        assert "不含选股信息" in out["gap"]["verdict"], out["gap"]
+
+    def test_gap_tracks_candidate_performance(self):
+        """gap 必须随候选收益单调变化。bug 版本下它恒为 +0.0000。"""
+        panels = _noisy_panels()
+        strong = _verdict(self._foresight(panels), panels, self.HORIZON)["gap"]
+        weak = _verdict(self._random_picks(panels), panels, self.HORIZON)["gap"]
+        assert strong["gap"] > weak["gap"] + 1.0, (strong["gap"], weak["gap"])
+
+
 class TestEvaluateDaily:
     def _cands(self, panels: Panels, n_hits: int = 20, n_wide: int = 60) -> dict[str, dict]:
         codes = sorted(next(iter(panels.liquid.values())))
@@ -398,10 +483,12 @@ class TestEvaluateDaily:
             for d in panels.dates[:-25]  # 留出足够的前向窗口
         }
 
-    def test_matched_and_controls_share_the_same_hits(self):
-        """随机控制必须与配对组用同一批候选,否则分母不同、两个超额不可比。
+    def test_matched_and_controls_share_the_same_baseline(self):
+        """两组的 control 栏必须是同一条基准线（配对篮),超额才可直接相减比较。
 
-        这是本轮自己写出来又改掉的 bug：配对失败的候选留在了随机组里。
+        原先这里断言两组的 **net** 相同,那正是 bug 本身：随机组的被测量被填成了
+        候选自己的收益,于是 gap 里候选项精确抵消,整个否证环节对候选好坏不敏感。
+        共用的应该是基准(control),被测量(net)必须各是各的篮子。
         """
         panels = _panels(60)
         rows = evaluate_daily(self._cands(panels), panels, 5, status="formal_l4")
@@ -411,8 +498,23 @@ class TestEvaluateDaily:
             assert ctrl
             by_date = {r["date"]: r for r in ctrl}
             for row in rows["matched"]:
-                # 同一天两边的 net 必须完全相同——它们算的是同一批票。
-                assert by_date[row["date"]]["net"] == pytest.approx(row["net"])
+                assert by_date[row["date"]]["control"] == pytest.approx(row["control"])
+
+    def test_control_net_is_the_random_basket_not_the_candidates(self):
+        """随机组的 net 必须是随机篮自己的收益。恒定行情下两者都等于 -成本,
+        分不出来,所以给命中票加一个边缘再看：net 不应跟着候选动。"""
+        panels = _panels(60)
+        codes = sorted(next(iter(panels.liquid.values())))
+        hits = codes[:20]
+        for ds in panels.dates:
+            closes = panels.close.get(ds) or {}
+            for code in hits:
+                if code in closes:
+                    closes[code] = closes[code] * 1.5
+        rows = evaluate_daily(self._cands(panels), panels, 5, status="formal_l4")
+        matched_net = rows["matched"][0]["net"]
+        ctrl_net = rows[f"control_{CONTROL_SEEDS[0]}"][0]["net"]
+        assert matched_net > ctrl_net + 1.0, "候选被拉高后,随机组的 net 不应跟着涨"
 
     def test_cost_is_deducted_from_both_sides(self):
         """两边同扣往返成本,比较的是选股而非交易频率;超额里成本自然抵消。"""
@@ -484,33 +586,52 @@ class TestEvaluateDaily:
 class TestControlGap:
     """随机负控制：漏斗的超额到底是选股信息,还是只是「站在了某个动量位置上」。
 
-    实测 L4 vs 同动量非 L4 候选 T+10 超额 +4.10pct、t=+3.55、为正日 70%,看着很强;
-    但同口径随机控制给 +4.48~+5.17,配对超额反而在区间之下。缺这个对照就会把
-    动量选位读成选股能力。
+    修好抵消基准（见 ``random_control_row``）后实测 L4 vs 同动量非 L4 候选,71 个信号日
+    2026-05-25~09-01：T+10 配对超额 +2.47pct、t=+1.48,随机控制 +0.54~+2.10,差距
+    +1.414 小于种子宽度 1.555 —— 高过上界但幅度不够,三格都没到「含选股信息」。
+    早先记的 +4.10pct/t=+3.55/在区间之下是抵消基准算出来的,已作废。
+
+    本类每个用例守住 verdict 的一种分支：低于下界 / 区间内 / 高过上界但幅度薄 / 跑赢。
+    三种否证理由不同,句式不能混用,否则报告会把数读反。
     """
 
     def _stat(self, excess: float | None) -> GroupStat:
         return GroupStat("x", 30, 13.7, None, None, excess, 3.55, 70.0, -0.16)
 
     def test_inside_control_range_has_no_selection_value(self):
-        gap = control_gap(self._stat(4.098), [self._stat(e) for e in (4.477, 4.866, 5.165)])
+        """落在种子区间里：分不出漏斗和「同动量随便挑」。取一格真的被包住的数。"""
+        gap = control_gap(self._stat(4.600), [self._stat(e) for e in (4.477, 4.866, 5.165)])
+        assert gap["beats_band"] is False
         assert "落在" in gap["verdict"]
         assert gap["control_excess_min"] == pytest.approx(4.477)
         assert gap["control_excess_max"] == pytest.approx(5.165)
         assert gap["gap"] < 0
 
-    def test_below_every_seed_is_still_not_a_win(self):
-        """配对超额低于所有种子时更不能说有效——gap 为负,必然落进「无选股信息」。"""
-        gap = control_gap(self._stat(1.588), [self._stat(e) for e in (1.594, 1.898, 2.272)])
-        assert "落在" in gap["verdict"]
-        assert gap["gap"] == pytest.approx(1.588 - 1.921, abs=1e-3)
+    def test_below_every_seed_says_random_did_better(self):
+        """低于所有种子要说「随便挑还更好」,不能沿用「落在区间内」的句式。
 
-    def test_gap_within_seed_spread_is_not_a_win(self):
-        """哪怕高于所有种子,只要差距不超过种子间宽度就算不上跑赢。"""
+        4.098 在 4.477 之下,不在 [4.477, 5.165] 里。这两种都不构成证据,但把「比
+        每个种子都差」印成「被区间包住」是把数读反了。
+        """
+        gap = control_gap(self._stat(4.098), [self._stat(e) for e in (4.477, 4.866, 5.165)])
+        assert gap["beats_band"] is False
+        assert "落在" not in gap["verdict"]
+        assert "随便挑还更好" in gap["verdict"]
+        assert gap["gap"] == pytest.approx(4.098 - 4.836, abs=1e-3)
+
+    def test_above_the_band_but_within_spread_says_so_explicitly(self):
+        """高于所有种子、但差距不超过种子宽度：不算跑赢,也**不能说「落在区间内」**。
+
+        旧版对这一格印的是「落在随机负控制区间内」,那句话是错的——超额明明在上界
+        之上。实测 T+10 就是这一格（+2.468 vs 种子上界 +2.095,宽度 1.555）,报告里
+        照旧句式读会以为被区间包住了。两种情况都不构成证据,但理由不同。
+        """
         gap = control_gap(self._stat(0.35), [self._stat(e) for e in (0.10, 0.30)])
         assert gap["gap"] == pytest.approx(0.15)
         assert gap["seed_spread"] == pytest.approx(0.20)
-        assert "落在" in gap["verdict"]
+        assert gap["beats_band"] is True
+        assert "落在" not in gap["verdict"]
+        assert "证据不足" in gap["verdict"]
 
     def test_gap_equal_to_spread_is_not_a_win(self):
         """边界取 <=：刚好等于宽度不算跑赢。
@@ -521,7 +642,7 @@ class TestControlGap:
         # 均值 0.5、宽度 0.5 -> matched=1.0 时 gap 恰好等于 spread。
         gap = control_gap(self._stat(1.0), [self._stat(e) for e in (0.25, 0.75)])
         assert gap["gap"] == pytest.approx(gap["seed_spread"])
-        assert "落在" in gap["verdict"]
+        assert "证据不足" in gap["verdict"]
 
     def test_clear_outperformance_is_flagged(self):
         gap = control_gap(self._stat(2.00), [self._stat(e) for e in (0.10, 0.12)])

--- a/tests/scripts/test_evaluate_funnel_effect_report.py
+++ b/tests/scripts/test_evaluate_funnel_effect_report.py
@@ -1,0 +1,113 @@
+"""漏斗效果报告的结论段：三种否证理由不能混成一句。
+
+这里守的是一个真实读错：修好抵消基准后 T+10 配对超额 +2.468pct **高过**种子上界
++2.095,但差距 1.414 小于种子宽度 1.555。旧版对这一格印「落在随机负控制区间内」,
+读报告的人会以为超额被区间包住了。计数也曾按 verdict 里的「落在」字面来分,句式一改
+计数就静默变错——现在按 ``beats_band`` 分,本文件盯着这条不许退回去。
+"""
+
+from __future__ import annotations
+
+from scripts import evaluate_funnel_effect as mod
+
+
+def _absolute(net: float = -3.82) -> dict:
+    return {
+        "days": 30,
+        "avg_size": 17.2,
+        "net_pct": net,
+        "net_t": -1.97,
+        "positive_day_pct": 43.3,
+        "worst_day_pct": -29.94,
+        "best_day_pct": 18.05,
+        "bench_days": 0,
+        "bench_pct": None,
+        "bench_excess_pct": None,
+        "bench_excess_t": None,
+        "verdict": "绝对收益为负：这批票拿着是亏的",
+    }
+
+
+def _matched(excess: float) -> dict:
+    return {
+        "label": "matched",
+        "days": 30,
+        "avg_size": 15.1,
+        "net_pct": -5.44,
+        "control_pct": -9.56,
+        "excess_pct": excess,
+        "excess_t": 1.48,
+        "positive_day_pct": 60.0,
+        "residual_mom_pct": 0.02,
+    }
+
+
+def _block(excess: float, controls: tuple[float, ...]) -> dict:
+    """单个持有期的结果块,control_gap 走真实实现而不是手搓字典。"""
+    from core.funnel_effect_eval import GroupStat, control_gap
+
+    def stat(e: float) -> GroupStat:
+        return GroupStat("x", 30, 15.1, -5.44, -9.56, e, 1.48, 60.0, 0.02)
+
+    return {
+        "absolute": _absolute(),
+        "matched": _matched(excess),
+        "controls": [],
+        "control_gap": control_gap(stat(excess), [stat(c) for c in controls]),
+    }
+
+
+def _render(excess: float, controls: tuple[float, ...]) -> str:
+    result = {"status": "formal_l4", "horizons": {"10": _block(excess, controls)}}
+    return mod.render(result, "formal_l4")
+
+
+class TestSummaryCountsByBand:
+    def test_above_the_band_but_thin_is_not_called_inside(self) -> None:
+        """实测 T+10 这一格：+2.468 高过上界 +2.095,不能说「落在区间内」。"""
+        out = _render(2.468, (0.540, 1.054, 2.095))
+        assert "幅度小于种子自身的抽样宽度" in out
+        assert "没有高过随机负控制的上界" not in out
+        assert "含独立选股信息；仍需" not in out
+
+    def test_inside_the_band_counts_as_no_outperformance(self) -> None:
+        out = _render(1.500, (0.540, 1.054, 2.095))
+        assert "没有高过随机负控制的上界" in out
+        assert "幅度小于种子自身的抽样宽度" not in out
+
+    def test_below_every_seed_counts_the_same_as_inside(self) -> None:
+        """比每个种子都差,和被区间包住一样都没跑赢,归同一段结论。"""
+        out = _render(0.100, (0.540, 1.054, 2.095))
+        assert "没有高过随机负控制的上界" in out
+        assert "随便挑还更好" in out
+
+    def test_clear_win_gets_the_win_paragraph_only(self) -> None:
+        out = _render(6.000, (0.540, 1.054, 2.095))
+        assert "含独立选股信息；仍需" in out
+        assert "没有高过随机负控制的上界" not in out
+        assert "幅度小于种子自身的抽样宽度" not in out
+
+    def test_insufficient_sample_is_not_counted_as_a_win(self) -> None:
+        """样本不足的格子既不算跑赢也不算否证,不能让它触发「含独立选股信息」。
+
+        旧版结论段是「没被否证就宣布有效」（``not inside and not thin``）,全部持有期
+        样本不足时两个计数都是 0,于是零证据印出「含独立选股信息」。
+        """
+        result = {"status": "formal_l4", "horizons": {"20": _block(2.0, (1.0,))}}
+        out = mod.render(result, "formal_l4")
+        assert result["horizons"]["20"]["control_gap"]["verdict"] == "样本不足"
+        assert "含独立选股信息；仍需" not in out
+        assert "所有持有期都样本不足" in out
+
+    def test_a_thin_cell_does_not_suppress_a_real_win_elsewhere(self) -> None:
+        """一格薄一格真赢时,别把两段都印出来——薄那格已经说明不能下结论。"""
+        result = {
+            "status": "formal_l4",
+            "horizons": {
+                "5": _block(2.468, (0.540, 1.054, 2.095)),
+                "10": _block(6.000, (0.540, 1.054, 2.095)),
+            },
+        }
+        out = mod.render(result, "formal_l4")
+        assert "幅度小于种子自身的抽样宽度" in out
+        assert "含独立选股信息；仍需" not in out

--- a/tests/workflows/test_review_shadow_control.py
+++ b/tests/workflows/test_review_shadow_control.py
@@ -1,0 +1,206 @@
+"""影子车道同动量对照的检验。
+
+重点不是「函数跑通」，而是三件容易静默出错的事：
+1. 样本不足时必须显式降级，不能造一个假判定；
+2. 面板缺失时必须说「没出对照」，不能让读者以为「没这一节」等于「过了」；
+3. 对照真的接上了——一个候选组明显跑赢/跑平同动量同侪时，verdict 要跟着变。
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import pandas as pd
+import pytest
+
+from core.funnel_effect_eval import MIN_DAYS
+from core.funnel_effect_panels import build_panels
+from workflows.review_shadow_backtest import ShadowTrade
+from workflows.review_shadow_control import (
+    control_verdict_lines,
+    evaluate_lane_control,
+    lane_control_summary,
+    lane_day_map,
+)
+
+# 20 天动量预热 + 尾部 T+1+5 窗口都吃掉日子，要过 MIN_DAYS=20 得留够总天数。
+DAYS = 60
+POOL_SIZE = 40
+# 日收益噪声标准差(%)。作用见 _market_frame 的说明：没有噪声，配对会把
+# 「有边缘」那一侧也一并杀掉，fixture 就只能验证 null。
+NOISE_PCT = 1.5
+
+
+def _trade(signal_date: str, code: str, *, lane: str = "pre_breakout") -> ShadowTrade:
+    return ShadowTrade(
+        signal_date=signal_date,
+        entry_date=signal_date,
+        code=code,
+        name=code,
+        lane=lane,
+        score=50.0,
+        ranked=True,
+        entry_open=10.0,
+        signal_pct_chg=1.0,
+        next_pct_chg=1.0,
+        review_hit=False,
+        open_executable=True,
+        intraday_executable=True,
+        ret_t1_pct=1.0,
+        ret_t3_pct=1.0,
+        ret_t5_pct=1.0,
+        mfe_t5_pct=2.0,
+        mae_t5_pct=-1.0,
+    )
+
+
+def _market_frame(*, hit_daily_pct: float, hit_codes: list[str]) -> pd.DataFrame:
+    """构造 DAYS 天全市场行情：日收益带噪声，命中票另加一个固定日边缘。
+
+    为什么必须带噪声：最近邻动量配对**天然会杀掉「纯粹由过去 20 日涨幅决定的」
+    收益差**。若每只票都是恒定日涨幅，过去 20 日涨幅就是未来收益的完美代理，
+    配好的对照与命中票收益必然相同、超额恒为 0——那样这个 fixture 只能验证 null
+    的一侧，永远验不出「有边缘」的那一侧，也就无法证明这套对照有分辨力。
+
+    噪声让过去动量与未来收益解耦：配对按过去动量找同侪，而命中票的
+    ``hit_daily_pct`` 是独立于动量的增量，正是「选股信息」该有的形态。
+    """
+    dates = pd.bdate_range("2026-01-05", periods=DAYS).strftime("%Y-%m-%d")
+    rows: list[dict[str, object]] = []
+    for idx in range(POOL_SIZE):
+        _append_series(rows, f"{idx:06d}", dates, 0.0)
+    for code in hit_codes:
+        _append_series(rows, code, dates, hit_daily_pct)
+    return pd.DataFrame(rows).sort_values(["code", "ds"]).reset_index(drop=True)
+
+
+def _append_series(rows: list[dict[str, object]], code: str, dates: pd.Index, edge_pct: float) -> None:
+    """按 code 定种子，结果可复现；日收益 = 噪声 + 边缘。"""
+    rng = random.Random(f"{code}-fixture")
+    price = 10.0
+    for ds in dates:
+        daily = rng.gauss(0.0, NOISE_PCT) + edge_pct
+        open_price = price * (1.0 + daily / 200.0)
+        price *= 1.0 + daily / 100.0
+        rows.append(
+            {
+                "code": code,
+                "ds": ds,
+                "open": round(open_price, 4),
+                "close": round(price, 4),
+                "amt_wan": 50000.0,
+            }
+        )
+
+
+def _panels_and_trades(*, hit_daily_pct: float) -> tuple[object, list[ShadowTrade]]:
+    hit_codes = [f"9{idx:05d}" for idx in range(5)]
+    panels = build_panels(_market_frame(hit_daily_pct=hit_daily_pct, hit_codes=hit_codes))
+    # 前 20 天没有 mom20（需要 shift(20)），信号日从第 21 天起，尾部留出 T+1+5 的窗口。
+    signal_days = panels.dates[21:-7]
+    trades = [_trade(ds, code) for ds in signal_days for code in hit_codes]
+    return panels, trades
+
+
+def test_lane_day_map_groups_by_signal_date() -> None:
+    trades = [_trade("2026-01-05", "000001"), _trade("2026-01-05", "000002"), _trade("2026-01-06", "000003")]
+
+    assert lane_day_map(trades) == {
+        "2026-01-05": {"formal_l4": ["000001", "000002"], "all": ["000001", "000002"]},
+        "2026-01-06": {"formal_l4": ["000003"], "all": ["000003"]},
+    }
+
+
+def test_lane_control_degrades_when_days_below_minimum() -> None:
+    """4 天的老 fixture 不能出判定,只能说样本不足。"""
+    panels, _ = _panels_and_trades(hit_daily_pct=0.0)
+    trades = [_trade(ds, "900000") for ds in panels.dates[21:24]]
+
+    result = evaluate_lane_control(trades, panels)
+
+    assert result["eligible"] is False
+    assert result["signal_days"] == 3
+    assert str(MIN_DAYS) in result["reason"]
+
+
+def test_lane_control_reports_unavailable_without_panels() -> None:
+    """缺快照要显式说没出对照——不能让「没这一节」被读成「过了」。"""
+    summary = lane_control_summary([_trade("2026-01-05", "000001")], None)
+
+    assert summary["available"] is False
+    assert "无法构建同动量对照" in summary["reason"]
+    assert "未出对照" in "\n".join(control_verdict_lines(summary))
+
+
+def test_lane_control_finds_no_edge_when_hits_match_peers() -> None:
+    """命中票与同动量同侪同收益时,配对超额应≈0 且被随机负控制吃掉。"""
+    panels, trades = _panels_and_trades(hit_daily_pct=0.0)
+
+    result = evaluate_lane_control(trades, panels, horizons=(5,))
+    cell = result["horizons"]["5"]
+
+    assert result["eligible"] is True
+    assert result["signal_days"] >= MIN_DAYS
+    assert cell["matched"]["days"] >= MIN_DAYS
+    assert abs(cell["matched"]["excess_pct"]) < 0.5
+    assert "不含选股信息" in cell["control_gap"]["verdict"]
+
+
+def test_lane_control_detects_edge_beyond_random_control() -> None:
+    """命中票每天多赚 0.5% 时,配对超额要跑赢随机负控制——否则这套对照没有分辨力。"""
+    panels, trades = _panels_and_trades(hit_daily_pct=0.5)
+
+    cell = evaluate_lane_control(trades, panels, horizons=(5,))["horizons"]["5"]
+
+    assert cell["matched"]["excess_pct"] > 1.0
+    assert "含独立选股信息" in cell["control_gap"]["verdict"]
+    # 配对后残差动量不该系统性偏向命中组,否则超额里混着动量 beta。
+    assert abs(cell["matched"]["residual_mom_pct"]) < 3.0
+
+
+def test_lane_control_reports_absolute_and_excess_together() -> None:
+    """两栏分母不同必须同时出:超额为正不等于赚钱。"""
+    panels, trades = _panels_and_trades(hit_daily_pct=0.5)
+
+    cell = evaluate_lane_control(trades, panels, horizons=(5,))["horizons"]["5"]
+    absolute, matched = cell["absolute"], cell["matched"]
+
+    assert absolute["avg_size"] >= matched["avg_size"]
+    assert absolute["net_pct"] is not None
+    assert absolute["verdict"] != "样本不足"
+    assert not math.isnan(float(matched["excess_t"]))
+
+
+def test_control_verdict_lines_render_each_lane() -> None:
+    panels, trades = _panels_and_trades(hit_daily_pct=0.5)
+    summary = lane_control_summary(trades, panels, horizons=(5,))
+
+    text = "\n".join(control_verdict_lines(summary))
+
+    assert "## 同动量对照" in text
+    assert "pre_breakout" in text
+    assert "T+5" in text
+    assert "绝对" in text and "配对超额" in text
+
+
+def test_lane_control_multiple_lanes_are_evaluated_separately() -> None:
+    panels, trades = _panels_and_trades(hit_daily_pct=0.5)
+    tagged = [
+        _trade(t.signal_date, t.code, lane="near_l2" if t.code.endswith(("0", "1")) else "pre_breakout") for t in trades
+    ]
+
+    lanes = lane_control_summary(tagged, panels, horizons=(5,))["lanes"]
+
+    assert set(lanes) == {"near_l2", "pre_breakout"}
+    for block in lanes.values():
+        assert "signal_days" in block
+
+
+@pytest.mark.parametrize("hit_daily_pct", [0.0, 0.5])
+def test_lane_control_horizons_all_present(hit_daily_pct: float) -> None:
+    panels, trades = _panels_and_trades(hit_daily_pct=hit_daily_pct)
+
+    horizons = evaluate_lane_control(trades, panels)["horizons"]
+
+    assert set(horizons) == {"1", "3", "5"}

--- a/workflows/review_shadow_backtest.py
+++ b/workflows/review_shadow_backtest.py
@@ -11,8 +11,10 @@ from typing import Any
 
 import pandas as pd
 
+from core.funnel_effect_panels import build_panels_from_snapshot
 from core.review_shadow_lanes import ReviewShadowSignal, shadow_lane_label, shadow_signal_from_decision
 from workflows.backtest_data import load_snapshot_hist_map
+from workflows.review_shadow_control import control_verdict_lines, lane_control_summary
 
 
 @dataclass(frozen=True)
@@ -41,7 +43,9 @@ def run_shadow_backtest(trace_dir: Path, snapshot_dir: Path, output_dir: Path) -
     traces = load_trace_payloads(trace_dir)
     history, _ = load_snapshot_hist_map(snapshot_dir)
     trades = evaluate_shadow_traces(traces, history)
-    report = summarize_shadow_trades(trades, traces, history)
+    # 同动量对照要全市场面板，与 history 用同一份快照，动量口径由 core 单点定义。
+    panels = build_panels_from_snapshot(snapshot_dir)
+    report = summarize_shadow_trades(trades, traces, history, panels=panels)
     write_shadow_outputs(output_dir, trades, report)
     return report
 
@@ -93,6 +97,8 @@ def summarize_shadow_trades(
     trades: list[ShadowTrade],
     traces: list[dict[str, Any]],
     history: dict[str, pd.DataFrame] | None = None,
+    *,
+    panels: Any | None = None,
 ) -> dict[str, Any]:
     lanes = sorted({trade.lane for trade in trades})
     recall = _review_recall(traces, history or {})
@@ -108,6 +114,8 @@ def summarize_shadow_trades(
         "by_lane": {lane: _lane_summary([trade for trade in trades if trade.lane == lane]) for lane in lanes},
         "by_score_band": {lane: _score_band_summary([t for t in trades if t.lane == lane]) for lane in lanes},
         "overall": _lane_summary(trades),
+        # 裸收益混着动量 beta。「要不要补强」只有配对超额跑赢随机负控制才算是"要"。
+        "momentum_control": lane_control_summary(trades, panels),
     }
 
 
@@ -356,6 +364,8 @@ def _markdown_report(report: dict[str, Any]) -> str:
         "",
         "候选仅由信号日收盘时的生产 trace 生成；T+1/T+3/T+5 行情只用于结果评价。",
         "",
+        "下表是**裸收益**，混着动量 beta，不能单独用来判定「要不要补强」——结论看后面的同动量对照一节。",
+        "",
         _recall_line(report),
         "",
         "| 车道 | 样本 | T+1均值 | T+3均值 | T+5均值 | T+5胜率 |",
@@ -368,6 +378,7 @@ def _markdown_report(report: dict[str, Any]) -> str:
             f"{_metric(t3, 'mean')} | {_metric(t5, 'mean')} | {_metric(t5, 'win_rate', percent=False)} |"
         )
     lines.extend(_score_band_lines(report))
+    lines.extend(["", *control_verdict_lines(report.get("momentum_control") or {})])
     return "\n".join(lines) + "\n"
 
 

--- a/workflows/review_shadow_control.py
+++ b/workflows/review_shadow_control.py
@@ -1,0 +1,136 @@
+"""影子车道的同动量对照：把裸收益换成「相对同动量同侪的超额」。
+
+为什么必须有这一节
+------------------
+``_lane_summary`` 报的是裸 T+1/T+3/T+5 均值与胜率。影子车道天生偏高动量（near_l2
+差一点就过结构强度、pre_breakout 按 watch_score 排序），裸收益里混着动量的 beta。
+2026-06~08 那段样本上全市场大跌，只看裸收益会把「跟跌少一点」读成选股能力——
+full-market-control-confounds-momentum 记的就是这个坑：候选动量 +19% vs 全市场
+-5%，不做最近邻匹配就会把择时读成选股。
+
+所以「爆发前夜要不要补强」这个问题，只有配对超额跑赢**随机负控制**才算是"要"。
+统计全部复用 ``core.funnel_effect_eval``（``match_by_momentum`` / ``sample_momentum_band``
+/ ``control_gap``），这里只做形状适配，不新写一套统计口径。
+
+三栏必须同时读
+--------------
+- ``absolute``：拿着这批票赚不赚钱（分母=全部车道票）。
+- ``matched``：同动量同侪里选得好不好（分母=配对成功的子集，与对照组一致）。
+- ``control_gap``：超额是不是只来自动量选位。这是唯一能否掉「该补强」的一环。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from core.funnel_effect_eval import (
+    CONTROL_SEEDS,
+    MIN_DAYS,
+    MIN_HITS_PER_DAY,
+    control_gap,
+    evaluate_daily,
+    summarize_absolute,
+    summarize_group,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - 仅类型标注，避免运行时强依赖
+    from core.funnel_effect_eval import Panels
+    from workflows.review_shadow_backtest import ShadowTrade
+
+# 对照评估的持有期（交易日）。与影子回测的 ret_t1/t3/t5 对齐，
+# 便于把「裸收益」和「同动量超额」逐格对照，而不是各报一套窗口。
+CONTROL_HORIZONS = (1, 3, 5)
+
+
+def lane_day_map(trades: list[ShadowTrade]) -> dict[str, dict[str, Any]]:
+    """车道票按信号日分组，塞进 resolve_layer 认的形状。
+
+    ``formal_l4`` 与 ``all`` 都填同一批车道票：对 ``status="formal_l4"``，
+    ``resolve_layer`` 取 ``hits=formal_l4``、``pool=universe-all``，正好是
+    「这条车道 vs 同日流动性池里的其它票」。
+    """
+    by_day: dict[str, set[str]] = {}
+    for trade in trades:
+        by_day.setdefault(str(trade.signal_date), set()).add(str(trade.code))
+    return {ds: {"formal_l4": sorted(codes), "all": sorted(codes)} for ds, codes in by_day.items()}
+
+
+def evaluate_lane_control(
+    trades: list[ShadowTrade],
+    panels: Panels,
+    horizons: tuple[int, ...] = CONTROL_HORIZONS,
+) -> dict[str, Any]:
+    """单条车道的绝对收益 + 配对超额 + 随机负控制，按持有期分列。"""
+    cands = lane_day_map(trades)
+    if len(cands) < MIN_DAYS:
+        return {
+            "eligible": False,
+            "reason": f"交易日仅 {len(cands)} 天，不足 {MIN_DAYS} 天，不下判定",
+            "signal_days": len(cands),
+        }
+    result: dict[str, Any] = {"eligible": True, "signal_days": len(cands), "horizons": {}}
+    for horizon in horizons:
+        rows = evaluate_daily(cands, panels, horizon, status="formal_l4")
+        matched = summarize_group("matched", rows["matched"])
+        controls = [summarize_group(f"control_{seed}", rows[f"control_{seed}"]) for seed in CONTROL_SEEDS]
+        result["horizons"][str(horizon)] = {
+            "absolute": summarize_absolute(rows["absolute"]).as_dict(),
+            "matched": matched.as_dict(),
+            "controls": [c.as_dict() for c in controls],
+            "control_gap": control_gap(matched, controls),
+        }
+    return result
+
+
+def lane_control_summary(
+    trades: list[ShadowTrade],
+    panels: Panels | None,
+    horizons: tuple[int, ...] = CONTROL_HORIZONS,
+) -> dict[str, Any]:
+    """全部车道的对照结果。缺面板时显式降级，不能让读者以为「没这一节」等于「过了」。"""
+    if panels is None:
+        return {
+            "available": False,
+            "reason": "快照缺 hist_full.csv.gz，无法构建同动量对照；本次只有裸收益，不可据此判定选股能力",
+        }
+    lanes = sorted({trade.lane for trade in trades})
+    return {
+        "available": True,
+        "note": (
+            f"对照池=同日流动性池内非本车道票，按 T 日已知 20 日涨幅 1:1 无放回最近邻配对；"
+            f"随机负控制 {len(CONTROL_SEEDS)} 个种子。持有期重叠，所有 t 值都被高估。"
+            f"每日最少 {MIN_HITS_PER_DAY} 只、最少 {MIN_DAYS} 个交易日才下判定。"
+        ),
+        "lanes": {
+            lane: evaluate_lane_control([t for t in trades if t.lane == lane], panels, horizons) for lane in lanes
+        },
+    }
+
+
+def control_verdict_lines(summary: dict[str, Any]) -> list[str]:
+    """报告里的对照小节。裸收益那张表旁边必须有这几行，否则动量选位会被读成选股。"""
+    if not summary.get("available"):
+        return ["## 同动量对照", "", f"未出对照：{summary.get('reason') or '未知原因'}", ""]
+    lines = ["## 同动量对照", "", summary.get("note") or "", ""]
+    for lane, block in (summary.get("lanes") or {}).items():
+        if not block.get("eligible"):
+            lines += [f"- **{lane}**：{block.get('reason') or '样本不足'}"]
+            continue
+        lines.append(f"- **{lane}**（{block.get('signal_days')} 个信号日）")
+        for horizon, cell in (block.get("horizons") or {}).items():
+            lines.append(f"  - T+{horizon} {_cell_line(cell)}")
+    return [*lines, ""]
+
+
+def _cell_line(cell: dict[str, Any]) -> str:
+    """绝对与超额同时出：任何一栏单看都会得出相反结论。"""
+    absolute = cell.get("absolute") or {}
+    matched = cell.get("matched") or {}
+    gap = cell.get("control_gap") or {}
+    abs_txt = f"绝对 {_num(absolute.get('net_pct'))}%（胜率 {_num(absolute.get('positive_day_pct'))}%，{absolute.get('verdict')}）"
+    exc_txt = f"配对超额 {_num(matched.get('excess_pct'))}pct（t={_num(matched.get('excess_t'))}）"
+    return f"{abs_txt}；{exc_txt}；{gap.get('verdict') or '样本不足'}"
+
+
+def _num(value: Any) -> str:
+    return "—" if value is None else f"{float(value):+.2f}"


### PR DESCRIPTION
## 问题

随机负控制的对照行把**候选**收益填进了 `net`，于是

```
matched.excess = hit - nn_ctl
random.excess  = hit - rand_ctl      ← 错：填的是候选收益
gap = matched.excess - random.excess = rand_ctl - nn_ctl   ← hit 精确抵消
```

量出来的只是「随机篮 vs 配对篮」，与候选表现完全无关。这是唯一能否掉「漏斗有效」的
环节，它却对候选表现不敏感：完美先知候选（+5.79pct、t=+35.6）与纯随机选票
（-0.14pct）拿到**同一句判定**；扫候选收益 -5%→+20%，gap 恒为 +0.0000。

缺陷不报错、不让测试变红，只让否证环节永久输出「无信息」——每次结论都是安全的否定，
所以两个月没被发现。原测试还断言了两组 `net` 相等，断言本身就是 bug 的镜像。

## 变更摘要

- **共用基准**：新增 `MatchedBaseline`，配对组与随机组减同一条线（配对篮的收益与平均
  动量），每行量自己那一篮。正确形态本已存在于
  `evaluate_momentum_regime._collect_non_top_control`，这里对齐它。
- **判定分三句**：`control_gap` 原先把「落在区间内」「低于下界」「高过上界但幅度小于
  种子宽度」印成同一句。实测 T+10 超额 +2.468 **高过**种子上界 +2.095，旧版却印
  「落在随机负控制区间内」，读报告的人会以为被区间包住了。
- **结论段不再反推**：原先按「没被否证」判有效（`not inside and not thin`），全部持有期
  样本不足时两个计数都是 0，于是零证据印出「含独立选股信息」。改为数真跑赢的格子，
  并按 `beats_band` 分类而不是匹配 verdict 里的「落在」字面（句式一改计数会静默变错）。
- **影子车道接上同一套对照**（`workflows/review_shadow_control.py`）：裸 T+1/T+3/T+5 收益
  混着动量 beta，「爆发前夜要不要补强」只有配对超额跑赢随机负控制才算是"要"。
- **动量口径单点定义**（`core/funnel_effect_panels.py`）：两份报告若各算一遍 20 日涨幅
  （含不含 T 日、要不要 shift），邻域就不是同一个邻域，对照组无法互相印证。

## 验证

判别性回归（`TestControlGapDiscriminates`）——只断言结构对齐挡不住抵消，必须验判别力：

- 完美先知候选必须跑赢随机控制
- 纯随机选票必须**不**跑赢
- gap 随候选表现单调变化（强候选的 gap 比弱候选高 1pct 以上）

匹配用的 fixture 带与匹配变量独立的噪声：常数漂移面板上 20 日涨幅是远期收益的完美
代理，配对超额恒为 0，那种 fixture 只能验空侧。

`tests/workflows/test_review_shadow_control.py::test_lane_control_detects_edge_beyond_random_control`
在**不放宽断言**的前提下由红转绿——确认原先是缺陷，不是 fixture 的问题。

全量：`4579 passed, 22 skipped`（+6 为新增报告结论段用例）。`ruff check` / `ruff format
--check` / `quality_gate.py --check-functions --check-no-sql` 全绿。

修正后实测（71 个信号日 2026-05-25~09-01，978 行 formal_l4，行情 573K 行）：

| 层 | H | 超额 | t | 随机带 | 差距 | 种子宽度 | 判定 |
|---|---|---|---|---|---|---|---|
| `formal_l4` | 5 | +0.74pct | +0.62 | +0.22~+1.65 | -0.08 | 1.43 | 落在带内 |
| `formal_l4` | 10 | +2.47pct | +1.48 | +0.54~+2.10 | +1.41 | 1.56 | 高过上界但幅度<宽度 |
| `formal_l4` | 20 | +2.37pct | +1.12 | +1.18~+2.63 | +0.45 | 1.45 | 落在带内 |
| `l4_vs_rest` | 10 | +4.12pct | +3.67 | -1.52~-0.01 | +4.90 | 1.51 | 跑赢随机带 |

结构逐格核对：每个持有期只有一条共用 `control_pct`，5 个种子的 `net_pct` 各不相同
（-9.57/-10.40/-11.08/-10.50/-10.14），对照残差动量在 ±0.17pct 内。

**三个持有期绝对收益全为负**（-2.36% / -3.82% / -4.45%，胜率 46% / 43% / 30%）：配对超额
为正只说明同动量同侪亏得更多，仓位实亏照样是实亏。样本一个季度、持有窗重叠导致 t 被
高估，**不足以据此改阈值**。

先前记录的「L4 T+10 超额 +4.10pct、t=+3.55、为正日 70% 全被随机控制吃掉」出自抵消
基准，已作废。
