### PR TITLE
fix: 1Route 根地址补 /v1，会话用量不再记成 0

### DIFF
--- a/cli/diagnostic_export.py
+++ b/cli/diagnostic_export.py
@@ -10,9 +10,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from cli.scratchpad import wyckoff_home
+from cli.scratchpad import is_sensitive_key, wyckoff_home
 
-_SENSITIVE_KEY_RE = re.compile(r"(api[_-]?key|token|password|secret|authorization|cookie)", re.IGNORECASE)
 _TEXT_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{20,}"),
     re.compile(r"\bBearer\s+eyJ[A-Za-z0-9_.-]+"),
@@ -46,7 +45,7 @@ def _scrub(value: Any) -> Any:
         cleaned: dict[str, Any] = {}
         for key, item in value.items():
             key_text = str(key)
-            cleaned[key_text] = "***REDACTED***" if _SENSITIVE_KEY_RE.search(key_text) else _scrub(item)
+            cleaned[key_text] = "***REDACTED***" if is_sensitive_key(key_text) else _scrub(item)
         return cleaned
     if isinstance(value, list):
         return [_scrub(item) for item in value]

--- a/cli/providers/openai.py
+++ b/cli/providers/openai.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from collections.abc import Generator
 from dataclasses import dataclass, field
@@ -12,7 +13,12 @@ import httpx
 import openai
 
 from cli.providers.base import LLMProvider
-from cli.usage_metrics import extract_openai_cache_tokens, openai_cache_reported
+from cli.usage_metrics import extract_openai_cache_tokens, extract_openai_usage_tokens, openai_cache_reported
+from integrations._llm_types import normalize_openai_compatible_base_url
+
+logger = logging.getLogger(__name__)
+_FATAL_HTTP = frozenset({401, 403, 429})
+_FATAL_EXC = frozenset({"AuthenticationError", "PermissionDenied", "RateLimitError"})
 
 _TIMEOUT = httpx.Timeout(300.0, connect=60.0)
 
@@ -64,30 +70,47 @@ def _openai_tool_call_payload(tc: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _openai_http_status(exc: BaseException) -> int | None:
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def _reraise_if_fatal_openai(exc: BaseException) -> None:
+    if type(exc).__name__ in _FATAL_EXC or _openai_http_status(exc) in _FATAL_HTTP:
+        raise exc
+
+
 def _create_openai_stream(client: openai.OpenAI, kwargs: dict[str, Any]):
     try:
         return client.chat.completions.create(**kwargs)
-    except Exception:
+    except Exception as exc:
+        _reraise_if_fatal_openai(exc)
+        logger.warning("openai stream create failed; retry without stream_options: %s", exc)
         kwargs.pop("stream_options", None)
         try:
             return client.chat.completions.create(**kwargs)
-        except Exception:
+        except Exception as exc:
+            _reraise_if_fatal_openai(exc)
+            logger.warning("openai stream create failed; retry without extra params: %s", exc)
             kwargs.pop("tool_choice", None)
             kwargs.pop("frequency_penalty", None)
             return client.chat.completions.create(**kwargs)
 
 
 def _apply_usage_from_chunk(state: OpenAIStreamState, chunk: Any) -> None:
-    """Capture usage whenever present — MiniMax/OpenRouter may attach it on a choices chunk."""
+    """Capture usage whenever present — MiniMax/OpenRouter/1Route may attach it on a choices chunk."""
     usage = getattr(chunk, "usage", None)
     if usage is None:
         return
-    prompt = getattr(usage, "prompt_tokens", None)
-    completion = getattr(usage, "completion_tokens", None)
+    prompt, completion = extract_openai_usage_tokens(usage)
     if prompt is not None:
-        state.input_tokens = int(prompt or 0)
+        state.input_tokens = prompt
     if completion is not None:
-        state.output_tokens = int(completion or 0)
+        state.output_tokens = completion
     state.cache_read, state.cache_write = extract_openai_cache_tokens(usage)
     state.cache_reported = state.cache_reported or openai_cache_reported(usage)
 
@@ -197,7 +220,7 @@ class OpenAIProvider(LLMProvider):
     def __init__(self, api_key: str, model: str = "gpt-4o", base_url: str = ""):
         kwargs: dict[str, Any] = {"api_key": api_key, "timeout": _TIMEOUT}
         if base_url:
-            kwargs["base_url"] = base_url.rstrip("/")
+            kwargs["base_url"] = normalize_openai_compatible_base_url(base_url)
         self._client = openai.OpenAI(**kwargs)
         self._model = model
 
@@ -232,9 +255,10 @@ class OpenAIProvider(LLMProvider):
         response = self._client.chat.completions.create(**kwargs)
         result = self._parse_response(response)
         if hasattr(response, "usage") and response.usage:
+            prompt, completion = extract_openai_usage_tokens(response.usage)
             usage: dict[str, Any] = {
-                "input_tokens": response.usage.prompt_tokens or 0,
-                "output_tokens": response.usage.completion_tokens or 0,
+                "input_tokens": prompt or 0,
+                "output_tokens": completion or 0,
             }
             if openai_cache_reported(response.usage):
                 cache_read, cache_write = extract_openai_cache_tokens(response.usage)

--- a/cli/scratchpad.py
+++ b/cli/scratchpad.py
@@ -18,7 +18,29 @@ from typing import Any
 from cli.text_repair import repair_text
 
 _SENSITIVE_KEY_RE = re.compile(r"(api[_-]?key|token|password|secret|authorization|cookie)", re.IGNORECASE)
+_USAGE_COUNT_KEYS = frozenset(
+    {
+        "input_tokens",
+        "output_tokens",
+        "tokens_in",
+        "tokens_out",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+    }
+)
 _MAX_INLINE_STRING = 200_000
+
+
+def is_sensitive_key(key: str) -> bool:
+    """True for credential-like keys; usage counters such as input_tokens stay visible."""
+    key_text = str(key)
+    lowered = key_text.lower()
+    if lowered in _USAGE_COUNT_KEYS or lowered.endswith(("_tokens", "_token_count")):
+        return False
+    return bool(_SENSITIVE_KEY_RE.search(key_text))
 
 
 def wyckoff_home() -> Path:
@@ -38,7 +60,7 @@ def scrub_sensitive_value(value: Any) -> Any:
         cleaned: dict[str, Any] = {}
         for key, item in value.items():
             key_text = str(key)
-            cleaned[key_text] = "***REDACTED***" if _SENSITIVE_KEY_RE.search(key_text) else scrub_sensitive_value(item)
+            cleaned[key_text] = "***REDACTED***" if is_sensitive_key(key_text) else scrub_sensitive_value(item)
         return cleaned
     if isinstance(value, (list, tuple, set)):
         return [scrub_sensitive_value(item) for item in value]

--- a/cli/usage_metrics.py
+++ b/cli/usage_metrics.py
@@ -97,6 +97,20 @@ def openai_cache_reported(usage: Any) -> bool:
     return False
 
 
+def extract_openai_usage_tokens(usage: Any) -> tuple[int | None, int | None]:
+    """Read prompt/completion counts from OpenAI or 1Route-style usage objects."""
+    prompt = _usage_field(usage, "prompt_tokens")
+    if prompt is None:
+        prompt = _usage_field(usage, "input_tokens")
+    completion = _usage_field(usage, "completion_tokens")
+    if completion is None:
+        completion = _usage_field(usage, "output_tokens")
+    return (
+        as_int(prompt) if prompt is not None else None,
+        as_int(completion) if completion is not None else None,
+    )
+
+
 def extract_openai_cache_tokens(usage: Any) -> tuple[int, int]:
     """Return (cache_read, cache_write) from an OpenAI-compatible usage object."""
     hit = _usage_field(usage, "prompt_cache_hit_tokens")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -613,7 +613,7 @@ CREATE TABLE chat_log (
 
 | 文件 / 数据库 | 用途 |
 |-------------|------|
-| `wyckoff.json` | 模型配置（provider / api_key / model / base_url）；可选超时：`stream_chunk_timeout_seconds`（默认 120，模型空闲/首 token）、`tool_timeout_seconds`（默认 60，单工具墙钟）。控制面板 Overview、TUI `/config set`、`wyckoff config` 均可改。 |
+| `wyckoff.json` | 模型配置（provider / api_key / model / base_url）；可选超时：`stream_chunk_timeout_seconds`（默认 120，模型空闲/首 token）、`tool_timeout_seconds`（默认 60，单工具墙钟）。控制面板 Overview、TUI `/config set`、`wyckoff config` 均可改。1Route 的 `base_url` 必须带 `/v1`；只写根域名会打到官网 HTML（HTTP 200、无用量）。运行时会自动补 `/v1`。 |
 | `session.json` | Supabase 登录态（access_token / refresh_token） |
 | `agent.log` | Agent 文件日志 |
 | `wyckoff.db` | SQLite 数据库（下方详述） |

--- a/integrations/_llm_types.py
+++ b/integrations/_llm_types.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 SUPPORTED_PROVIDERS = (
     "1route",
     "gemini",
@@ -36,6 +38,20 @@ GEMINI_MODELS = (
     "gemini-3-pro-preview",
     "gemini-3-flash-preview",
 )
+
+
+def normalize_openai_compatible_base_url(base_url: str) -> str:
+    """1Route 根域名会 200 回官网 HTML，必须落到 /v1。"""
+    text = (base_url or "").strip().rstrip("/")
+    if not text:
+        return ""
+    parsed = urlparse(text)
+    host = (parsed.hostname or "").lower()
+    path = (parsed.path or "").rstrip("/")
+    if host == "api.1route.dev" and path in {"", "/"}:
+        return f"{parsed.scheme}://{parsed.netloc}/v1"
+    return text
+
 
 PROVIDER_LABELS: dict[str, str] = {
     "1route": "1Route（推荐）",

--- a/integrations/llm_client.py
+++ b/integrations/llm_client.py
@@ -18,6 +18,7 @@ from integrations._llm_types import (
     OPENAI_COMPATIBLE_BASE_URLS,
     PROVIDER_LABELS,
     SUPPORTED_PROVIDERS,
+    normalize_openai_compatible_base_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -206,7 +207,7 @@ def _call_native_llm(
             base_url=(base_url or "").strip(),
         )
     if provider in OPENAI_COMPATIBLE_BASE_URLS:
-        base = (base_url or OPENAI_COMPATIBLE_BASE_URLS.get(provider, "") or "").rstrip("/")
+        base = normalize_openai_compatible_base_url(base_url or OPENAI_COMPATIBLE_BASE_URLS.get(provider, "") or "")
         if not base:
             raise ValueError(f"未配置 {provider} 的 base_url")
         return _call_openai_compatible(

--- a/tests/cli/test_diagnostic_export.py
+++ b/tests/cli/test_diagnostic_export.py
@@ -82,6 +82,8 @@ def test_export_diagnostic_package_zip_includes_session_evidence(tmp_path: Path,
             assert "tool-results/other.json" not in names
             chat_log = json.loads(zf.read("chat_log.json").decode("utf-8"))
             assert chat_log[1]["metadata"]["api_key"] == "***REDACTED***"
+            assert chat_log[1]["tokens_in"] == 12
+            assert chat_log[1]["tokens_out"] == 8
             index_lines = zf.read("tool-results/index.jsonl").decode("utf-8").splitlines()
             assert len(index_lines) == 1
             assert json.loads(index_lines[0])["node_id"] == "T_keep"

--- a/tests/cli/test_openai_provider.py
+++ b/tests/cli/test_openai_provider.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cli.providers.openai import (
+    OpenAIProvider,
+    OpenAIStreamState,
+    _apply_usage_from_chunk,
+    _create_openai_stream,
+    _reraise_if_fatal_openai,
+)
+from integrations._llm_types import normalize_openai_compatible_base_url
+
+
+def test_normalize_oneroute_root_url_adds_v1():
+    assert normalize_openai_compatible_base_url("https://api.1route.dev") == "https://api.1route.dev/v1"
+    assert normalize_openai_compatible_base_url("https://api.1route.dev/") == "https://api.1route.dev/v1"
+    assert normalize_openai_compatible_base_url("https://api.1route.dev/v1") == "https://api.1route.dev/v1"
+    assert normalize_openai_compatible_base_url("https://openrouter.ai/api/v1") == "https://openrouter.ai/api/v1"
+
+
+def test_openai_provider_rewrites_oneroute_root_base_url():
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-5.6-luna", base_url="https://api.1route.dev")
+    assert str(provider._client.base_url).rstrip("/") == "https://api.1route.dev/v1"
+
+
+def test_apply_usage_from_chunk_reads_input_output_aliases():
+    state = OpenAIStreamState()
+    _apply_usage_from_chunk(state, SimpleNamespace(usage={"input_tokens": 41, "output_tokens": 7}))
+    assert state.input_tokens == 41
+    assert state.output_tokens == 7
+
+
+def test_reraise_if_fatal_openai_keeps_auth_and_rate_limit():
+    class AuthenticationError(Exception):
+        status_code = 401
+
+    with pytest.raises(AuthenticationError):
+        _reraise_if_fatal_openai(AuthenticationError("invalid api key"))
+
+    class RateLimitError(Exception):
+        status_code = 429
+
+    with pytest.raises(RateLimitError):
+        _reraise_if_fatal_openai(RateLimitError("too many requests"))
+
+
+def test_create_openai_stream_does_not_retry_401():
+    class AuthenticationError(Exception):
+        status_code = 401
+
+    class Client:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+        def _create(self, **_kwargs):
+            self.calls += 1
+            raise AuthenticationError("401 invalid api key")
+
+    client = Client()
+    with pytest.raises(AuthenticationError, match="401"):
+        _create_openai_stream(client, {"model": "gpt-5.6-luna", "stream": True})
+    assert client.calls == 1

--- a/tests/cli/test_scratchpad_and_tool_results.py
+++ b/tests/cli/test_scratchpad_and_tool_results.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from cli.scratchpad import AgentScratchpad
+from cli.scratchpad import AgentScratchpad, is_sensitive_key
 from cli.tool_results import INLINE_TOOL_RESULT_MAX_CHARS, format_tool_result_for_context, serialize_tool_result
 from utils.tool_result_preview import tool_result_brief_lines, tool_result_preview
 
@@ -39,6 +39,12 @@ def test_scratchpad_records_jsonl_and_redacts_secrets(tmp_path):
     assert tool_entry["durationMs"] == 12
     assert lines[2]["contextArchive"]["archive_ref"] == "archive://session_x/ctx_1"
     assert lines[3]["sources"] == []
+    assert lines[4]["usage"]["input_tokens"] == 10
+    assert lines[4]["usage"]["output_tokens"] == 5
+    assert not is_sensitive_key("input_tokens")
+    assert not is_sensitive_key("tokens_in")
+    assert is_sensitive_key("token")
+    assert is_sensitive_key("api_key")
 
 
 def test_tool_result_serialization_replaces_nonfinite_numbers() -> None:

--- a/tests/cli/test_usage_metrics.py
+++ b/tests/cli/test_usage_metrics.py
@@ -5,6 +5,7 @@ from cli.usage_metrics import (
     cache_hit_rate_pct,
     enrich_usage,
     extract_openai_cache_tokens,
+    extract_openai_usage_tokens,
     format_usage_footer,
     generation_seconds,
     normalize_anthropic_usage,
@@ -18,6 +19,14 @@ def test_as_int_respects_default_for_none():
     assert as_int(None) == 0
     assert as_int("12") == 12
     assert as_int("x", default=7) == 7
+
+
+def test_extract_openai_usage_tokens_reads_prompt_and_input_aliases():
+    classic = SimpleNamespace(prompt_tokens=120, completion_tokens=8)
+    assert extract_openai_usage_tokens(classic) == (120, 8)
+    oneroute = {"input_tokens": 64, "output_tokens": 3}
+    assert extract_openai_usage_tokens(oneroute) == (64, 3)
+    assert extract_openai_usage_tokens(SimpleNamespace()) == (None, None)
 
 
 def test_extract_openai_cache_prefers_deepseek_hit_tokens():


### PR DESCRIPTION
## Summary
- 桌面把 `https://api.1route.dev` 打到官网 HTML（HTTP 200、无 401），会话日志用量一直是 `0/0`。运行时自动补 `/v1`。
- OpenAI 兼容网关同时认 `prompt_tokens` / `input_tokens`；`input_tokens` 不再被 scratchpad 当密钥脱敏。
- 401 / 403 / 429 不再被静默重试吞掉。本机探测：正确 `/v1` 返回 `4392/5`，假密钥才是 `401 INVALID_API_KEY`。

## Validation
- [x] `pytest`：`tests/cli/test_openai_provider.py`、`test_usage_metrics.py`、`test_scratchpad_and_tool_results.py`、`test_diagnostic_export.py`
- [x] `ruff check` + `ruff format` + `quality_gate.py --check-functions`
- [x] 用本机 1Route 配置打过真实请求：根地址回 HTML 200；`/v1` 正常回复并带用量；假密钥 401


Made with [Cursor](https://cursor.com)