### PR TITLE
fix: Step3 研报主通道改 Efficiency，Gemini 兜底

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ TUSHARE_TOKEN=
 
 # LLM (for step3 / step4)
 # 默认 provider：gemini / openai / openai_compatible / zhipu / deepseek / qwen / volcengine
+# 漏斗 Step3 研报主通道见 STEP3_LLM_PROVIDER（默认 efficiency，Gemini 兜底），不读这里。
 DEFAULT_LLM_PROVIDER=gemini
 GEMINI_API_KEY=
 GEMINI_MODEL=gemini-2.5-flash-lite
@@ -150,6 +151,9 @@ STEP3_SEND_COMPLIANCE_BRIEF=1
 STEP3_COMPLIANCE_FOCUS_LIMIT=5
 # Step3 预演模式：只展示模型输入，不调用模型
 STEP3_SKIP_LLM=0
+# 漏斗 Step3 研报：主通道 Efficiency，Gemini 兜底。DEFAULT_LLM_PROVIDER 不覆盖本角色。
+STEP3_LLM_PROVIDER=efficiency
+STEP3_LLM_FALLBACK_PROVIDERS=gemini
 # 定时任务可选：跳过 Step4 再平衡（用于测试/预演）
 DAILY_JOB_SKIP_STEP4=0
 

--- a/.github/workflows/wyckoff_funnel.yml
+++ b/.github/workflows/wyckoff_funnel.yml
@@ -35,8 +35,8 @@ jobs:
       FUNNEL_BATCH_SLEEP: "0.55"
       END_CALENDAR_DAY: ${{ github.event.inputs.end_calendar_day || '' }}
       DEFAULT_LLM_PROVIDER: ${{ secrets.DEFAULT_LLM_PROVIDER }}
-      STEP3_LLM_PROVIDER: ${{ vars.STEP3_LLM_PROVIDER || secrets.STEP3_LLM_PROVIDER || 'gemini' }}
-      STEP3_LLM_FALLBACK_PROVIDERS: ${{ vars.STEP3_LLM_FALLBACK_PROVIDERS || secrets.STEP3_LLM_FALLBACK_PROVIDERS || 'efficiency' }}
+      STEP3_LLM_PROVIDER: ${{ vars.STEP3_LLM_PROVIDER || secrets.STEP3_LLM_PROVIDER || 'efficiency' }}
+      STEP3_LLM_FALLBACK_PROVIDERS: ${{ vars.STEP3_LLM_FALLBACK_PROVIDERS || secrets.STEP3_LLM_FALLBACK_PROVIDERS || 'gemini' }}
       STEP3_SEND_COMPLIANCE_BRIEF: "1"
       STEP4_LLM_PROVIDER: ${{ vars.STEP4_LLM_PROVIDER || secrets.STEP4_LLM_PROVIDER || 'efficiency' }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -240,6 +240,7 @@ watch_score = 0.25 × q20 + 0.20 × q5 + 0.05 × q3
 | **OMS 人民币口径** | OMS CNY Cash Path | Step4 的 `total_equity` / `free_cash` / 工单 `amount` 按人民币计；港美报价与止损间距先乘汇率再定仓与回笼，避免把美元/港元裸加进人民币预算 |
 | **成交回填汇率** | Trade Fill FX | `record_trade_fill` / `portfolio fill` 对港美成交按报价币→CNY 汇率改 `free_cash`，成本价仍记本币；缺汇率 fail-closed，禁止把外币名义金额写入人民币现金 |
 | **LLM 决策注释** | LLM Decision Note | `llmdoc/` 中经过版本控制、按工作流/股票代码/有效期选择的咨询性上下文；只能提醒模型复核遗漏风险，不得覆盖实时数据、硬止损、市场闸门、候选准入或 OMS |
+| **Step3 研报模型** | Step3 LLM | 漏斗研报主通道默认 Efficiency（低成本兼容通道），失败再试 Gemini（谷歌大模型）；可用 `STEP3_LLM_PROVIDER` / `STEP3_LLM_FALLBACK_PROVIDERS` 覆盖。研报分类不是买入许可 |
 
 ---
 

--- a/docs/A_SHARE_FUNNEL_FLOW.md
+++ b/docs/A_SHARE_FUNNEL_FLOW.md
@@ -341,7 +341,7 @@ flowchart LR
 
 **LLM 配置**（workflow 默认）：
 
-- Step3：`STEP3_LLM_PROVIDER=gemini`，fallback `efficiency`
+- Step3：`STEP3_LLM_PROVIDER=efficiency`，fallback `gemini`
 - 输入不是原始 K 线，而是压缩后的结构特征
 - Step3 总输入默认最多 5 只：跨日 `VALIDATED` 候选优先保留最多 3 席，其余席位按漏斗顺序从当日 `selected_for_ai` 填充；当日不足时，未使用的保留席不会浪费。市场修复模式不再从另一条“起跳板补位”路径私自换名单
 - 合规版市场观察简报默认发送；只有显式设置 `STEP3_SEND_COMPLIANCE_BRIEF=0` 才关闭

--- a/tests/integrations/test_llm_routing.py
+++ b/tests/integrations/test_llm_routing.py
@@ -30,7 +30,14 @@ def test_resolve_provider_name_uses_role_before_global(monkeypatch):
     monkeypatch.setenv("DEFAULT_LLM_PROVIDER", "gemini")
     monkeypatch.setenv("STEP3_LLM_PROVIDER", "efficiency")
 
-    assert resolve_provider_name("STEP3_LLM_PROVIDER", "gemini") == "efficiency"
+    assert resolve_provider_name("STEP3_LLM_PROVIDER", "efficiency") == "efficiency"
+
+
+def test_resolve_step3_provider_defaults_to_efficiency(monkeypatch):
+    monkeypatch.delenv("STEP3_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("DEFAULT_LLM_PROVIDER", raising=False)
+
+    assert resolve_provider_name("STEP3_LLM_PROVIDER", "efficiency") == "efficiency"
 
 
 def test_provider_fallbacks_empty_by_default(monkeypatch):

--- a/tests/workflows/test_daily_job_replay_isolation.py
+++ b/tests/workflows/test_daily_job_replay_isolation.py
@@ -47,6 +47,40 @@ def test_explicit_end_calendar_day_forces_step4_off(monkeypatch, tmp_path) -> No
     assert cfg.skip_step4 is True
 
 
+def test_resolve_daily_job_config_defaults_step3_to_efficiency(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("STEP3_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("DEFAULT_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("STEP4_LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("EFFICIENCY_API_KEY", "eff-key")
+    monkeypatch.setenv("EFFICIENCY_MODEL", "eff-model")
+    monkeypatch.setenv("EFFICIENCY_BASE_URL", "https://efficiency.example/v1")
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-key")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-main")
+
+    cfg = resolve_daily_job_config(Namespace(logs=str(tmp_path / "daily.log")))
+
+    assert cfg.provider == "efficiency"
+    assert cfg.step4_provider == "efficiency"
+
+
+def test_log_llm_config_announces_gemini_fallback(monkeypatch) -> None:
+    from workflows.daily_job_runtime import log_llm_config
+
+    logs: list[str] = []
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-key")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-main")
+
+    log_llm_config(
+        "efficiency",
+        "https://efficiency.example/v1",
+        "EFFICIENCY_BASE_URL",
+        None,
+        lambda msg, _path: logs.append(msg),
+    )
+
+    assert any("Gemini 兜底已配置: model=gemini-main" in msg for msg in logs)
+
+
 def test_live_job_keeps_step4_enabled(monkeypatch, tmp_path) -> None:
     _stub_provider_config(monkeypatch)
     monkeypatch.delenv("END_CALENDAR_DAY", raising=False)

--- a/tests/workflows/test_step3_llm_fallback.py
+++ b/tests/workflows/test_step3_llm_fallback.py
@@ -44,6 +44,62 @@ def test_call_track_report_falls_back_to_efficiency_after_gemini_failure(monkeyp
     ]
 
 
+def test_call_track_report_falls_back_to_gemini_after_efficiency_failure(monkeypatch):
+    import workflows.step3_llm as step3_llm
+    from workflows.step3_llm import call_track_report
+    from workflows.step3_runtime_config import Step3RuntimeConfig
+
+    calls: list[tuple[str, str, str | None]] = []
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-key")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-main")
+
+    def fake_call_llm(**kwargs):
+        calls.append((kwargs["provider"], kwargs["model"], kwargs.get("base_url")))
+        if kwargs["provider"] == "efficiency":
+            raise RuntimeError("efficiency unavailable")
+        return "## 💀 逻辑破产\n- 无\n\n## ⏳ 储备营地\n- 无\n\n## 🏹 处于起跳板\n- 000001"
+
+    monkeypatch.setattr(step3_llm, "call_llm", fake_call_llm)
+
+    ok, report, used_model = call_track_report(
+        track="Trend",
+        system_prompt="system",
+        user_message="user",
+        model="eff-model",
+        api_key="eff-key",
+        selected_codes=["000001"],
+        selected_df=pd.DataFrame([{"code": "000001"}]),
+        provider="efficiency",
+        llm_base_url="https://efficiency.example/v1",
+        runtime_config=Step3RuntimeConfig(),
+    )
+
+    assert ok is True
+    assert "处于起跳板" in report
+    assert used_model == "Gemini:gemini-main"
+    assert calls == [
+        ("efficiency", "eff-model", "https://efficiency.example/v1"),
+        ("gemini", "gemini-main", None),
+    ]
+
+
+def test_step3_llm_routes_include_gemini_when_efficiency_primary(monkeypatch):
+    from workflows.step3_llm import build_step3_llm_routes
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-key")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-main")
+
+    routes = build_step3_llm_routes(
+        provider="efficiency",
+        model="eff-model",
+        api_key="eff-key",
+        llm_base_url="https://efficiency.example/v1",
+    )
+
+    assert [route["provider"] for route in routes] == ["efficiency", "gemini"]
+    assert routes[1]["model"] == "gemini-main"
+
+
 def test_step3_llm_routes_allow_efficiency_when_gemini_key_missing(monkeypatch):
     from workflows.step3_llm import build_step3_llm_routes
 

--- a/workflows/daily_job_runtime.py
+++ b/workflows/daily_job_runtime.py
@@ -49,7 +49,7 @@ def default_daily_job_logs_path() -> str:
 
 
 def resolve_daily_job_config(args: argparse.Namespace) -> DailyJobConfig:
-    provider = resolve_provider_name("STEP3_LLM_PROVIDER", "gemini")
+    provider = resolve_provider_name("STEP3_LLM_PROVIDER", "efficiency")
     api_key, model, llm_base_url = get_provider_credentials(provider)
     step4_provider = resolve_provider_name("STEP4_LLM_PROVIDER", "efficiency")
     step4_api_key, step4_model, step4_base_url = get_provider_credentials(step4_provider)
@@ -117,9 +117,11 @@ def missing_llm_config(provider: str, step3_skip_llm: bool, skip_step4: bool, st
 def log_llm_config(provider: str, llm_base_url: str, base_url_env_key: str, logs_path: str | None, log_fn) -> None:
     if provider in OPENAI_COMPATIBLE_BASE_URLS:
         log_fn(f"LLM base_url: {llm_base_url or '(empty)'} (env={base_url_env_key})", logs_path)
-    efficiency_model = _efficiency_fallback_model()
-    if provider == "gemini" and efficiency_model:
-        log_fn(f"Step3 Efficiency 兜底已配置: model={efficiency_model}", logs_path)
+    fallback = _step3_fallback_default(provider)
+    if _provider_ready(fallback):
+        _, model, _ = get_provider_credentials(fallback)
+        label = {"gemini": "Gemini", "efficiency": "Efficiency"}.get(fallback, fallback)
+        log_fn(f"Step3 {label} 兜底已配置: model={model}", logs_path)
 
 
 def daily_job_preflight_exit_code(args: argparse.Namespace, cfg: DailyJobConfig, log_fn: Callable) -> int | None:
@@ -142,13 +144,6 @@ def daily_job_preflight_exit_code(args: argparse.Namespace, cfg: DailyJobConfig,
     log_llm_config(cfg.provider, cfg.llm_base_url, cfg.base_url_env_key, cfg.logs_path, log_fn)
     log_fn(f"Step4 LLM: provider={cfg.step4_provider}, model={cfg.step4_model or '(missing)'}", cfg.logs_path)
     return None
-
-
-def _efficiency_fallback_model() -> str:
-    api_key = os.getenv("EFFICIENCY_API_KEY", "").strip()
-    model = os.getenv("EFFICIENCY_MODEL", "").strip()
-    base_url = os.getenv("EFFICIENCY_BASE_URL", "").strip()
-    return model if api_key and model and base_url else ""
 
 
 def _provider_ready(provider: str) -> bool:

--- a/workflows/recommendation_backfill.py
+++ b/workflows/recommendation_backfill.py
@@ -155,7 +155,7 @@ def _run_step3_if_needed(
     from integrations.llm_client import get_provider_credentials, resolve_provider_name
     from workflows.step3_batch_report import run as run_step3
 
-    provider = resolve_provider_name("STEP3_LLM_PROVIDER", "gemini")
+    provider = resolve_provider_name("STEP3_LLM_PROVIDER", "efficiency")
     api_key, model, base_url = get_provider_credentials(provider)
     ok, reason, report_text = run_step3(
         write_symbols,

--- a/workflows/step3_batch_report.py
+++ b/workflows/step3_batch_report.py
@@ -164,7 +164,7 @@ def run(
     benchmark_context: dict | None = None,
     *,
     notify: bool = True,
-    provider: str = "gemini",
+    provider: str = "efficiency",
     llm_base_url: str = "",
     wecom_webhook: str = "",
     dingtalk_webhook: str = "",

--- a/workflows/step3_llm.py
+++ b/workflows/step3_llm.py
@@ -29,7 +29,7 @@ def build_step3_llm_routes(
 ) -> list[dict[str, str]]:
     cfg = runtime_config or Step3RuntimeConfig()
     routes: list[dict[str, str]] = []
-    provider = str(provider or "gemini").strip().lower() or "gemini"
+    provider = str(provider or "efficiency").strip().lower() or "efficiency"
     _append_llm_route(routes, provider=provider, model=model, api_key=api_key, base_url=llm_base_url)
     gemini_fallback = cfg.gemini_model_fallback
     if provider == "gemini" and gemini_fallback and model != gemini_fallback:
@@ -52,7 +52,7 @@ def call_track_report(
     api_key: str,
     selected_codes: list[str],
     selected_df: pd.DataFrame,
-    provider: str = "gemini",
+    provider: str = "efficiency",
     llm_base_url: str = "",
     runtime_config: Step3RuntimeConfig | None = None,
 ) -> tuple[bool, str, str]:
@@ -198,7 +198,7 @@ def _repair_report_structure(
     api_key: str,
     selected_codes: list[str],
     *,
-    provider: str = "gemini",
+    provider: str = "efficiency",
     llm_base_url: str = "",
     max_output_tokens: int = 32768,
 ) -> str:


### PR DESCRIPTION
## Summary
- 漏斗 Step3 默认主通道从 Gemini（谷歌大模型）改为 Efficiency（低成本兼容通道），失败再回落 Gemini。
- 同步 workflow、daily job、回填脚本和文档；Step4 与漏斗阈值未改。

## Validation
- `ruff check` / `ruff format` 通过
- `pytest`：`test_step3_llm_fallback.py`、`test_llm_routing.py`、`test_daily_job_replay_isolation.py`、`test_step3_empty_report.py` 共 22 项通过
- `scripts/quality_gate.py --check-functions` 与 `scripts/check_workflow_hygiene.py` 通过

Made with [Cursor](https://cursor.com)