### PR TITLE
feat(review): 逐日落库强势股复盘的档位归属

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -27,6 +27,7 @@ TABLE_SHADOW_EVENTS = "shadow_events"
 TABLE_SHADOW_NAV_DAILY = "shadow_nav_daily"
 TABLE_SHADOW_TRADE_PLANS = "shadow_trade_plans"
 TABLE_REVIEW_SHADOW_LANE_DAILY = "review_shadow_lane_daily"
+TABLE_REVIEW_CAPTURE_DAILY = "review_capture_daily"
 
 # Local SQLite DB path
 from pathlib import Path as _Path

--- a/core/review_capture_schema.py
+++ b/core/review_capture_schema.py
@@ -1,0 +1,110 @@
+"""review_capture_daily 的建表语句。
+
+这张表回答一个问题:**漏斗有没有在变得更会挑票**——具体到可检验的形式,是
+「今日 >7% 的强势股里,前一日漏斗捕获了多少,比同日基准率高吗;每道闸门放开
+一层又能多捞到几只,增量精度比基准高吗」。
+
+为什么必须落库,而不是继续看每日报告:
+- 单日样本没有判别力。2026-09-03 那天捕获率 3/63=4.8% vs 基准 4.0%,p=0.740;
+  题材闸放开多捞 6 只、增量精度 1.12% vs 基准 1.37%,p=0.851。两个都是「看不出
+  差别」,不是「没差别」——n=1 天本来就分不出。要 20+ 个交易日才谈得上结论。
+- **补不回来**。复盘行依赖前一日 trace(哪只卡在哪层),trace 只活在
+  `daily-job-artifacts-*` 里(retention-days: 30);复盘自己的产物在
+  `review-list-replay-logs-*` 里只留 7 天。两个都过期后,那一天永久算不出来。
+  所以每过一天没留存就永久少一天样本——这是唯一有时钟压力的部分。
+- 体积不是障碍:强势复盘池每天约 50~70 只,一年不到两万行。
+
+**这张表不能回答什么**(写清楚,否则以后必被误读):
+单日 >7% 的脉冲不是漏斗的目标形态(漏斗奔的是 T+5/T+10 的吸筹到拉升),所以
+「捕获率高」不等于「赚钱」,追这种脉冲甚至可能是负贡献。绝对收益口径由
+`review_shadow_lane_daily` 的 T+5/T+10 同动量对照回答,不要拿这张表代替它。
+
+口径上的两条硬约束:
+1. **基准率必须逐日算再合并,不能全局算一次。** 复盘池本身是按「今日 >7% 且
+   前一日 <3%」挑出来的,即按结果选样;只有拿同一天的同层分母作对照,这个
+   召回率才有意义。所以每行都带当日的 universe/L1/L2/L3/候选 五个分母。
+2. **`gain_pct` 是选样条件,不是前瞻收益。** 它就是「今日涨幅 >7%」里的那个
+   涨幅,拿它当收益去评估会直接构成循环论证(见 memory
+   control-row-must-measure-itself:对照行必须量自己)。
+
+本项目不保留 .sql 文件(scripts/quality_gate.py 会拦),且 Supabase Python SDK 走
+REST 不支持 DDL、环境也无 psycopg2/asyncpg 与连接串,故 schema 以 Python 常量形式
+版本化,由 scripts/print_review_capture_ddl.py 打印后人工在 SQL Editor 执行一次。
+"""
+
+from __future__ import annotations
+
+from core.constants import TABLE_REVIEW_CAPTURE_DAILY
+
+# 与 integrations.supabase_review_capture.build_capture_rows 的 payload 键一一对应。
+# 顺序即建表顺序;测试会校验两者不漂移。
+COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("trade_date", "date not null", "复盘日(今日异动发生的交易日)"),
+    ("previous_trade_date", "date not null", "被复盘的漏斗运行日(前一交易日)"),
+    ("ts_code", "text not null", "股票代码,6 位数字"),
+    ("name", "text", "股票名称,便于人工核对"),
+    # 归因:这只票在前一日漏斗里卡在哪一层。
+    ("stage", "text not null", "级联归因档位。注意档位顺序 != 淘汰原因,见下面的分母说明"),
+    ("reason", "text", "该档位的具体理由,含闸门数值"),
+    ("l1_eligible", "boolean not null default false", "前一日是否过基础准入"),
+    ("l2_eligible", "boolean not null default false", "前一日是否过结构强度"),
+    ("l3_eligible", "boolean not null default false", "前一日是否过题材共振"),
+    ("is_candidate", "boolean not null default false", "前一日是否进入候选池"),
+    ("trigger_labels", "text[]", "买点触发标签。只对候选池内的票有值——触发检测只跑最终候选集"),
+    ("risk_signal", "text", "风控信号名,如 stop_loss"),
+    ("tracked_previous_day", "boolean not null default false", "前一日是否已在推荐跟踪表里"),
+    ("ai_recommended_previous_day", "boolean not null default false", "前一日是否被 AI 推荐"),
+    # 影子车道:与 review_shadow_lane_daily 同源判定,便于两张表对照。
+    ("shadow_lane", "text", "影子车道名,无则 null"),
+    ("shadow_score", "numeric(10, 4)", "影子车道排序键,无连续键时为 null——不要填常数"),
+    # 可执行性:能不能真买到。写入闸与下单闸曾各读一套配置(见 memory
+    # two-gates-must-share-one-source),所以这两个标记必须落下来。
+    ("open_executable", "boolean not null default false", "次日开盘是否可执行(未一字板/未涨停)"),
+    ("intraday_executable", "boolean not null default false", "次日盘中是否可执行"),
+    ("open_gap_pct", "numeric(10, 4)", "次日开盘跳空幅度,百分数"),
+    # 选样条件本身。命名带 gain 而非 return,避免被当成前瞻收益。
+    ("gain_pct", "numeric(10, 4)", "复盘日涨幅(选样条件 >7%),**不是**前瞻收益,不可用于评估"),
+    # 当日分母:基准率必须逐日算再合并,否则按结果选样的召回率没有意义。
+    ("pool_size", "integer not null", "当日复盘池规模(分母)"),
+    ("universe_count", "integer not null", "前一日全市场标的数"),
+    ("l1_count", "integer not null", "前一日过 L1 的数量"),
+    ("l2_count", "integer not null", "前一日过 L2 的数量"),
+    ("l3_count", "integer not null", "前一日过 L3 的数量"),
+    ("candidate_count", "integer not null", "前一日候选池规模"),
+    ("context_source", "text", "前一日漏斗上下文来源:trace 快照还是完整重跑"),
+    ("created_at", "timestamptz not null default now()", "写入时间"),
+)
+
+# 一个复盘日一只票只应有一行。重跑同一天覆盖而非累积。
+# 键必须与写入侧 on_conflict 完全一致——见 memory dedup-key-must-match-db-constraint:
+# 键错位会让一行冲突回滚整批,而且是静默的。
+UNIQUE_KEY = ("trade_date", "ts_code")
+
+
+def payload_keys() -> frozenset[str]:
+    """build_capture_rows 应写入的字段（不含自增 id 与默认 created_at）。"""
+    return frozenset(name for name, _, _ in COLUMNS if name != "created_at")
+
+
+def build_ddl() -> str:
+    """生成完整建表语句。幂等——可重复执行。"""
+    table = TABLE_REVIEW_CAPTURE_DAILY
+    body = ["    id bigserial primary key,"]
+    for name, ddl_type, comment in COLUMNS:
+        body.append(f"    -- {comment}")
+        body.append(f"    {name} {ddl_type},")
+    body.append(f"    constraint {table}_unique unique ({', '.join(UNIQUE_KEY)})")
+    lines = [
+        f"create table if not exists public.{table} (",
+        *body,
+        ");",
+        "",
+        "-- 主查询：按档位随时间聚合,算逐日捕获率与各闸门增量精度。",
+        f"create index if not exists {table}_stage_idx",
+        f"    on public.{table} (trade_date desc, stage);",
+        "",
+        "-- 单票追溯：某只票反复被漏掉时,看它每次卡在哪。",
+        f"create index if not exists {table}_code_idx",
+        f"    on public.{table} (ts_code, trade_date desc);",
+    ]
+    return "\n".join(lines) + "\n"

--- a/integrations/supabase_review_capture.py
+++ b/integrations/supabase_review_capture.py
@@ -1,0 +1,132 @@
+"""强势股复盘捕获率逐日落库。
+
+只写 review_capture_daily 一张表,按 (trade_date, ts_code) upsert,重跑同一天覆盖
+而非累积。建表语句由 `python scripts/print_review_capture_ddl.py` 输出。
+
+为什么必须落库:复盘行依赖前一日 trace(哪只票卡在哪一层),trace 只活在
+`daily-job-artifacts-*` 里(retention-days: 30),复盘自己的产物在
+`review-list-replay-logs-*` 里只留 7 天。两个都过期后那一天就永久算不出来,
+而单日样本又没有判别力(2026-09-03:捕获率 p=0.740,题材闸增量 p=0.851),
+必须靠 20+ 个交易日累积。每过一天没留存就永久少一天样本。
+
+行来源只有 build_replay_rows 一处:档位归因不在这里重新分类,否则报告与落库
+两套口径会漂移(见 memory two-gates-must-share-one-source)。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.constants import TABLE_REVIEW_CAPTURE_DAILY
+from core.funnel_taxonomy import REVIEW_STAGE_CANDIDATE_HIT
+from integrations.supabase_base import create_admin_client, require_server_write_context
+
+logger = logging.getLogger(__name__)
+CHUNK = 200
+_CONFLICT_KEY = "trade_date,ts_code"
+
+
+def build_capture_rows(
+    rows: list[dict[str, Any]],
+    *,
+    trade_date: str,
+    previous_trade_date: str,
+    denominators: dict[str, int],
+    gain_map: dict[str, float | None] | None = None,
+    context_source: str = "",
+) -> list[dict[str, Any]]:
+    """把复盘行转成落库行。
+
+    ``denominators`` 是当日的五个分母(universe/l1/l2/l3/candidate)。基准率必须
+    逐日算再合并:复盘池按「今日 >7% 且前一日 <3%」选出来,本身就是按结果选样,
+    只有拿同一天的同层分母作对照,召回率才有意义。所以分母跟着每一行落下来,
+    而不是事后去 join 一张可能已经过期的 trace。
+    """
+    if not trade_date or not previous_trade_date:
+        return []
+    gains = gain_map or {}
+    pool_size = len(rows)
+    out: list[dict[str, Any]] = []
+    for raw in rows:
+        code = _text((raw or {}).get("code"))
+        if not code:
+            continue
+        out.append(
+            {
+                "trade_date": trade_date,
+                "previous_trade_date": previous_trade_date,
+                "ts_code": code,
+                "name": _text(raw.get("name")) or None,
+                "stage": _text(raw.get("stage")),
+                "reason": _text(raw.get("reason")) or None,
+                "l1_eligible": bool(raw.get("l1_eligible")),
+                "l2_eligible": bool(raw.get("l2_eligible")),
+                "l3_eligible": bool(raw.get("l3_eligible")),
+                "is_candidate": bool(raw.get("stage") == REVIEW_STAGE_CANDIDATE_HIT),
+                "trigger_labels": [str(x) for x in (raw.get("trigger_labels") or [])],
+                "risk_signal": _text(raw.get("risk_signal")) or None,
+                "tracked_previous_day": bool(raw.get("tracked_previous_day")),
+                "ai_recommended_previous_day": bool(raw.get("ai_recommended_previous_day")),
+                "shadow_lane": _text(raw.get("shadow_lane")) or None,
+                "shadow_score": _round(raw.get("shadow_score")),
+                "open_executable": bool(raw.get("open_executable")),
+                "intraday_executable": bool(raw.get("intraday_executable")),
+                "open_gap_pct": _round(raw.get("open_gap_pct")),
+                "gain_pct": _round(gains.get(code)),
+                "pool_size": pool_size,
+                "universe_count": int(denominators.get("universe") or 0),
+                "l1_count": int(denominators.get("l1") or 0),
+                "l2_count": int(denominators.get("l2") or 0),
+                "l3_count": int(denominators.get("l3") or 0),
+                "candidate_count": int(denominators.get("candidate") or 0),
+                "context_source": _text(context_source) or None,
+            }
+        )
+    return out
+
+
+def save_review_capture_rows(rows: list[dict[str, Any]]) -> int:
+    """写入一批复盘捕获行,返回成功行数。
+
+    失败只 warning:复盘主流程不该因为这张观测表写不进去而中断(飞书报告已经发了)。
+    但**不会**打印「已写入」这类成功句式——见 memory success-shaped-log-hid-total-loss,
+    那让影子账本缺列停摆两个月没人发现。写了几行就说几行,零行显式说零行。
+    """
+    if not rows:
+        return 0
+    require_server_write_context(f"{TABLE_REVIEW_CAPTURE_DAILY} write")
+    client = create_admin_client()
+    written = 0
+    failed = 0
+    for start in range(0, len(rows), CHUNK):
+        batch = rows[start : start + CHUNK]
+        try:
+            client.table(TABLE_REVIEW_CAPTURE_DAILY).upsert(batch, on_conflict=_CONFLICT_KEY).execute()
+            written += len(batch)
+        except Exception as exc:  # noqa: BLE001 - 观测表写失败不中断复盘
+            failed += len(batch)
+            logger.warning("[review-capture] 批次写入失败 rows=%d: %s", len(batch), exc)
+    if failed or written < len(rows):
+        logger.warning(
+            "[review-capture] %s 未全部写入: written=%d failed=%d total=%d",
+            TABLE_REVIEW_CAPTURE_DAILY,
+            written,
+            failed,
+            len(rows),
+        )
+    else:
+        logger.info("[review-capture] %s written=%d", TABLE_REVIEW_CAPTURE_DAILY, written)
+    return written
+
+
+def _round(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if result != result else round(result, 4)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()

--- a/scripts/print_review_capture_ddl.py
+++ b/scripts/print_review_capture_ddl.py
@@ -1,0 +1,24 @@
+"""打印 review_capture_daily 建表语句，供人工在 Supabase SQL Editor 执行。
+
+本项目不保留 .sql 文件，且 Supabase Python SDK 走 REST 不支持 DDL，
+故 schema 以 core/review_capture_schema.py 的常量形式版本化并由此脚本输出。
+
+用法::
+
+    python scripts/print_review_capture_ddl.py
+"""
+
+from __future__ import annotations
+
+import _bootstrap  # noqa: F401
+
+from core.review_capture_schema import build_ddl
+
+
+def main() -> int:
+    print(build_ddl())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integrations/test_supabase_review_capture.py
+++ b/tests/integrations/test_supabase_review_capture.py
@@ -1,0 +1,166 @@
+"""复盘捕获率落库:行构建与 schema 防漂移。
+
+schema 以 Python 常量版本化(本项目不留 .sql),写入侧和建表侧靠测试对齐,
+不靠人记。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from core.funnel_taxonomy import (
+    REVIEW_STAGE_CANDIDATE_HIT,
+    REVIEW_STAGE_THEME_MISS,
+)
+from core.review_capture_schema import UNIQUE_KEY, build_ddl, payload_keys
+from integrations.supabase_review_capture import build_capture_rows
+
+_DENOM = {"universe": 5347, "l1": 3442, "l2": 2236, "l3": 654, "candidate": 137}
+
+
+def _build(rows: list[dict], **kwargs):
+    params = {
+        "trade_date": "2026-09-03",
+        "previous_trade_date": "2026-09-02",
+        "denominators": _DENOM,
+        "context_source": "trace_snapshot",
+    }
+    params.update(kwargs)
+    return build_capture_rows(rows, **params)
+
+
+def test_every_row_carries_same_day_denominators() -> None:
+    """基准率必须逐日算再合并。
+
+    复盘池按「今日 >7% 且前一日 <3%」选样,本身就是按结果选样;只有拿同一天的
+    同层分母作对照,召回率才有意义。分母跟着行落下来,而不是事后 join 一张
+    30 天就过期的 trace。
+    """
+    rows = _build(
+        [
+            {"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT},
+            {"code": "000002", "stage": REVIEW_STAGE_THEME_MISS},
+        ]
+    )
+
+    assert len(rows) == 2
+    for row in rows:
+        assert row["universe_count"] == 5347
+        assert row["l1_count"] == 3442
+        assert row["l2_count"] == 2236
+        assert row["l3_count"] == 654
+        assert row["candidate_count"] == 137
+        assert row["pool_size"] == 2
+        assert row["trade_date"] == "2026-09-03"
+        assert row["previous_trade_date"] == "2026-09-02"
+
+
+def test_is_candidate_reads_the_stage_constant_not_a_reclassification() -> None:
+    """判别性用例:候选归属只认档位常量,不在落库侧重新判定。
+
+    重新判定会让报告与落库两套口径漂移(见 memory two-gates-must-share-one-source)。
+    这里两行的 l1/l2/l3 全为真、只有 stage 不同,若落库侧改用闸门标记去推断
+    is_candidate,两行就会同为 true,这个用例会失败。
+    """
+    rows = _build(
+        [
+            {
+                "code": "000001",
+                "stage": REVIEW_STAGE_CANDIDATE_HIT,
+                "l1_eligible": True,
+                "l2_eligible": True,
+                "l3_eligible": True,
+            },
+            {
+                "code": "000002",
+                "stage": REVIEW_STAGE_THEME_MISS,
+                "l1_eligible": True,
+                "l2_eligible": True,
+                "l3_eligible": True,
+            },
+        ]
+    )
+
+    assert [row["is_candidate"] for row in rows] == [True, False]
+
+
+def test_gain_comes_from_the_gain_map_and_is_never_read_off_the_row() -> None:
+    """gain_pct 是选样条件,来源必须是行情帧算出的涨幅。
+
+    复盘行本身不带涨幅——报告里也刻意不展示它,免得被当成前瞻收益读
+    (见 memory control-row-must-measure-itself)。这里给行塞一个假的 gain_pct,
+    落库行仍应取 gain_map 的值。
+    """
+    rows = _build(
+        [{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT, "gain_pct": 99.0}],
+        gain_map={"000001": 7.83},
+    )
+
+    assert rows[0]["gain_pct"] == 7.83
+
+
+def test_missing_gain_stores_null_not_zero() -> None:
+    """缺涨幅存 null:填 0 会把「没量到」读成「没涨」,把分布往下拽。"""
+    rows = _build([{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT}], gain_map={})
+
+    assert rows[0]["gain_pct"] is None
+
+
+def test_trigger_labels_survive_as_a_list() -> None:
+    """买点标签只对候选池内的票有值——触发检测只跑最终候选集,别处是不可测而非零。"""
+    rows = _build(
+        [
+            {"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT, "trigger_labels": ["lps", "sos"]},
+            {"code": "000002", "stage": REVIEW_STAGE_THEME_MISS},
+        ]
+    )
+
+    assert rows[0]["trigger_labels"] == ["lps", "sos"]
+    assert rows[1]["trigger_labels"] == []
+
+
+def test_rows_without_a_code_are_skipped_but_pool_size_keeps_the_pool() -> None:
+    """无代码的行不落库;pool_size 仍是复盘池规模,不能被跳过的行改掉分母。"""
+    rows = _build(
+        [
+            {"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT},
+            {"code": "", "stage": REVIEW_STAGE_THEME_MISS},
+        ]
+    )
+
+    assert [row["ts_code"] for row in rows] == ["000001"]
+    assert rows[0]["pool_size"] == 2
+
+
+def test_missing_dates_yield_no_rows() -> None:
+    """缺日期不写:trade_date 是唯一键的一半,写进去就无法覆盖重跑。"""
+    row = [{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT}]
+
+    assert _build(row, trade_date="") == []
+    assert _build(row, previous_trade_date="") == []
+
+
+def test_payload_keys_match_schema_columns() -> None:
+    """写入键与建表列必须一一对应,漂了就是静默丢字段。"""
+    rows = _build([{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT}])
+    written = set(rows[0])
+
+    assert written == set(payload_keys()), sorted(written ^ set(payload_keys()))
+
+
+def test_unique_key_matches_upsert_conflict_target() -> None:
+    """键错位会让一行冲突回滚整批,而且是静默的(见 memory dedup-key-must-match-db-constraint)。"""
+    source = Path("integrations/supabase_review_capture.py").read_text(encoding="utf-8")
+
+    assert f'_CONFLICT_KEY = "{",".join(UNIQUE_KEY)}"' in source
+
+
+def test_ddl_is_idempotent_and_indexes_stage_and_code() -> None:
+    """建表语句要能重复执行,并覆盖两条主查询:按档位聚合、按单票追溯。"""
+    ddl = build_ddl()
+
+    assert "create table if not exists public.review_capture_daily" in ddl
+    assert re.search(r"create index if not exists \w+_stage_idx", ddl)
+    assert re.search(r"create index if not exists \w+_code_idx", ddl)
+    assert f"unique ({', '.join(UNIQUE_KEY)})" in ddl

--- a/workflows/review_list_replay.py
+++ b/workflows/review_list_replay.py
@@ -33,7 +33,12 @@ from core.wyckoff_engine import (
 )
 from utils.env import env_flag
 from utils.feishu import send_feishu_notification
-from workflows.review_big_gainers import execution_snapshot, is_target_cn_board, load_today_review_pool
+from workflows.review_big_gainers import (
+    execution_snapshot,
+    is_target_cn_board,
+    latest_and_previous_pct,
+    load_today_review_pool,
+)
 from workflows.review_recommendation_lookup import format_recommendation_history, load_recommendation_lookup
 from workflows.review_report_render import build_report_lines
 from workflows.wyckoff_funnel import run_funnel_job
@@ -82,7 +87,8 @@ def run_review_list_replay(webhook: str, log=print) -> int:
         previous_trade_date=dates.previous_trade_date,
     )
     execution_map = {code: execution_snapshot(pool.frames.get(code)) for code in pool.codes}
-    return _run_review_for_codes(webhook, pool.codes, dates, log, execution_map)
+    gain_map = {code: latest_and_previous_pct(pool.frames.get(code))[0] for code in pool.codes}
+    return _run_review_for_codes(webhook, pool.codes, dates, log, execution_map, gain_map)
 
 
 def resolve_review_dates() -> ReviewDates:
@@ -441,6 +447,7 @@ def _run_review_for_codes(
     dates: ReviewDates,
     log,
     execution_map: dict[str, dict[str, object]] | None = None,
+    gain_map: dict[str, float | None] | None = None,
 ) -> int:
     if not review_codes:
         log("[review] 今日无满足收盘涨幅 > 7% 且前一交易日收盘涨幅 < 3% 的股票，跳过")
@@ -459,7 +466,51 @@ def _run_review_for_codes(
     )
     ok = send_replay_report(webhook, rows, stage_counter, dates, ctx.end_trade_date, stats)
     log(f"[review] feishu_sent={ok}")
+    _persist_capture_rows(rows, ctx, dates, stats, gain_map, log=log)
     return 0 if ok else 4
+
+
+def _persist_capture_rows(
+    rows: list[dict[str, Any]],
+    ctx: ReplayContext,
+    dates: ReviewDates,
+    stats: dict[str, Any],
+    gain_map: dict[str, float | None] | None,
+    log=print,
+) -> None:
+    """把逐日档位归属落库,供 20+ 个交易日后算捕获率与各闸门增量精度。
+
+    放在发报告之后:飞书那份是当天要看的,落库是为了以后能做检验,写不进去不该
+    影响前者。artifact 里的复盘产物只留 7 天、前一日 trace 只留 30 天,过期后这
+    一天就永久算不出来,所以本地没有 artifacts 目录也该写,只要处在 server_job
+    写入上下文里。
+    """
+    from integrations.supabase_base import is_server_write_context
+
+    if not is_server_write_context():
+        return
+    from integrations.supabase_review_capture import build_capture_rows, save_review_capture_rows
+
+    try:
+        capture_rows = build_capture_rows(
+            rows,
+            trade_date=dates.today.strftime("%Y-%m-%d"),
+            previous_trade_date=dates.previous_trade_date.strftime("%Y-%m-%d"),
+            denominators={
+                "universe": len(ctx.all_symbol_set),
+                "l1": len(ctx.l1_set),
+                "l2": len(ctx.l2_set),
+                "l3": len(ctx.l3_set),
+                "candidate": len(ctx.candidate_entry_map),
+            },
+            gain_map=gain_map,
+            context_source=str(stats.get("context_source") or ctx.source),
+        )
+        written = save_review_capture_rows(capture_rows)
+    except Exception as exc:  # noqa: BLE001 - 观测表写失败不该影响复盘
+        log(f"[review] 捕获率落库失败: {exc}")
+        return
+    log(f"[review] 捕获率落库: {written}/{len(capture_rows)} 行")
 
 
 def load_previous_context(previous_trade_date: date, log=print) -> ReplayContext | None:


### PR DESCRIPTION
## 变更摘要

新增 `review_capture_daily` 表与逐日写入,把强势股复盘的「今日 >7% 的票,前一日卡在漏斗哪一层」这个结论落库,不再只存在于 30 天过期的 artifact 里。表结构以 Python 常量形式声明（不留 .sql 文件),DDL 已由人工在 Supabase 执行。

下面是这张表存在的理由、口径约束、以及它明确不能回答的问题。

## 为什么必须落库

复盘流程已经算出了要的东西——「今日 >7% 的强势股,前一日卡在漏斗哪一层」——但留不住:

| 产物 | 保留 |
|---|---|
| `review-list-replay-logs-*`(复盘自己的产物) | **7 天** |
| `daily-job-artifacts-*`(它依赖的前一日 trace) | 30 天 |

两个都过期后,那一天的档位归属**永久算不出来**:回测引擎不重放漏斗分层。这和当初 `review_shadow_lane_daily` 落库是同一个理由。

而单日样本没有判别力。2026-09-03 那天:

- 捕获率 3/63 = 4.8% vs 同日基准 4.0%,**p=0.740**
- 题材闸放开多捞 6 只,增量精度 1.12% vs 基准 1.37%,**p=0.851**

两个都是「看不出差别」,不是「没差别」——n=1 天本来就分不出(见 memory `insufficient-sample-is-not-failed-control`)。要 20+ 个交易日才谈得上结论,所以**每过一天没留存就永久少一天样本**。这是唯一有时钟压力的部分。

体积不是障碍:强势复盘池每天约 50~70 只,一年不到两万行。

## 两条口径硬约束(写进了 schema docstring)

**1. 五个分母跟着每一行落,不事后 join。** 复盘池是按「今日 >7% 且前一日 <3%」挑出来的,即按结果选样;只有拿**同一天**的同层分母作对照,召回率才有意义。基准率必须逐日算再合并,不能全局算一次。而要 join 的那张 trace 会过期。所以每行带 `universe_count` / `l1_count` / `l2_count` / `l3_count` / `candidate_count` / `pool_size`。

**2. `gain_pct` 是选样条件,不是前瞻收益。** 它就是「今日涨幅 >7%」里那个涨幅,拿它当收益去评估直接构成循环论证(见 memory `control-row-must-measure-itself`)。所以:命名带 `gain` 而非 `return`、docstring 标注不可用于评估、复盘行本身不带它(报告里也刻意不展示)、只在落库路径单独传入。

## 这张表不能回答什么

单日 >7% 的脉冲**不是漏斗的目标形态**(漏斗奔的是 T+5/T+10 的吸筹到拉升),所以「捕获率高」不等于「赚钱」,追这种脉冲甚至可能是负贡献。绝对收益口径由 `review_shadow_lane_daily` 的 T+5/T+10 同动量对照回答,不要拿这张表代替它。写在 docstring 里,否则以后必被误读。

## 防漂移

- `is_candidate` 只认 `REVIEW_STAGE_CANDIDATE_HIT` 常量,不在落库侧用闸门标记重新推断——否则报告与落库两套口径会漂移(memory `two-gates-must-share-one-source`)。
- `_CONFLICT_KEY` 与 `UNIQUE_KEY` 由测试 grep 源码钉住——键错位会让一行冲突静默回滚整批(memory `dedup-key-must-match-db-constraint`)。
- 写入只 warning(不该因观测表写不进去中断复盘),但**不打「已写入」这类成功句式**,零行显式说零行(memory `success-shaped-log-hid-total-loss`)。
- 落库放在飞书报告发出**之后**,gate 在 `is_server_write_context()`,本地跑不会写生产。

## 不留 .sql

Supabase Python SDK 走 REST 不支持 DDL,环境也无 psycopg2/asyncpg。schema 以 `core/review_capture_schema.py` 的常量形式版本化,由 `scripts/print_review_capture_ddl.py` 打印后人工在 SQL Editor 执行一次。`scripts/quality_gate.py --check-no-sql` 通过。

## 验证

- 新增 10 tests passed
- **三个变异各自只打掉该打掉的用例**:`is_candidate` 改读 `l3_eligible` → 档位常量用例失败;`gain_pct` 改读行上字段 → gain_map 用例失败(99.0 != 7.83);`pool_size` 改 `len(out)+1` → 分母与跳过行两个用例失败
- `tests/ -k review` 176 passed;`tests/test_architecture_boundaries.py` 17 passed;ruff clean
- 假 `ReplayContext` 空跑产出两行正确(候选命中行带 `trigger_labels: ["lps"]`;题材共振不足行带 `risk_signal: stop_loss`、`shadow_lane: pre_breakout`),本地无写入上下文时正确跳过

建表后按 memory `verify-new-table-before-first-live-write` 先用哨兵行验唯一约束/列类型/`text[]`/CHUNK 边界,验完删掉再让它上生产。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
