### PR TITLE
fix(shadow): on 档不记账，归因闸门被锁成死环

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -27,6 +27,7 @@ TABLE_SHADOW_EVENTS = "shadow_events"
 TABLE_SHADOW_NAV_DAILY = "shadow_nav_daily"
 TABLE_SHADOW_TRADE_PLANS = "shadow_trade_plans"
 TABLE_REVIEW_SHADOW_LANE_DAILY = "review_shadow_lane_daily"
+TABLE_REVIEW_CAPTURE_DAILY = "review_capture_daily"
 
 # Local SQLite DB path
 from pathlib import Path as _Path

--- a/core/review_capture_schema.py
+++ b/core/review_capture_schema.py
@@ -1,0 +1,110 @@
+"""review_capture_daily 的建表语句。
+
+这张表回答一个问题:**漏斗有没有在变得更会挑票**——具体到可检验的形式,是
+「今日 >7% 的强势股里,前一日漏斗捕获了多少,比同日基准率高吗;每道闸门放开
+一层又能多捞到几只,增量精度比基准高吗」。
+
+为什么必须落库,而不是继续看每日报告:
+- 单日样本没有判别力。2026-09-03 那天捕获率 3/63=4.8% vs 基准 4.0%,p=0.740;
+  题材闸放开多捞 6 只、增量精度 1.12% vs 基准 1.37%,p=0.851。两个都是「看不出
+  差别」,不是「没差别」——n=1 天本来就分不出。要 20+ 个交易日才谈得上结论。
+- **补不回来**。复盘行依赖前一日 trace(哪只卡在哪层),trace 只活在
+  `daily-job-artifacts-*` 里(retention-days: 30);复盘自己的产物在
+  `review-list-replay-logs-*` 里只留 7 天。两个都过期后,那一天永久算不出来。
+  所以每过一天没留存就永久少一天样本——这是唯一有时钟压力的部分。
+- 体积不是障碍:强势复盘池每天约 50~70 只,一年不到两万行。
+
+**这张表不能回答什么**(写清楚,否则以后必被误读):
+单日 >7% 的脉冲不是漏斗的目标形态(漏斗奔的是 T+5/T+10 的吸筹到拉升),所以
+「捕获率高」不等于「赚钱」,追这种脉冲甚至可能是负贡献。绝对收益口径由
+`review_shadow_lane_daily` 的 T+5/T+10 同动量对照回答,不要拿这张表代替它。
+
+口径上的两条硬约束:
+1. **基准率必须逐日算再合并,不能全局算一次。** 复盘池本身是按「今日 >7% 且
+   前一日 <3%」挑出来的,即按结果选样;只有拿同一天的同层分母作对照,这个
+   召回率才有意义。所以每行都带当日的 universe/L1/L2/L3/候选 五个分母。
+2. **`gain_pct` 是选样条件,不是前瞻收益。** 它就是「今日涨幅 >7%」里的那个
+   涨幅,拿它当收益去评估会直接构成循环论证(见 memory
+   control-row-must-measure-itself:对照行必须量自己)。
+
+本项目不保留 .sql 文件(scripts/quality_gate.py 会拦),且 Supabase Python SDK 走
+REST 不支持 DDL、环境也无 psycopg2/asyncpg 与连接串,故 schema 以 Python 常量形式
+版本化,由 scripts/print_review_capture_ddl.py 打印后人工在 SQL Editor 执行一次。
+"""
+
+from __future__ import annotations
+
+from core.constants import TABLE_REVIEW_CAPTURE_DAILY
+
+# 与 integrations.supabase_review_capture.build_capture_rows 的 payload 键一一对应。
+# 顺序即建表顺序;测试会校验两者不漂移。
+COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("trade_date", "date not null", "复盘日(今日异动发生的交易日)"),
+    ("previous_trade_date", "date not null", "被复盘的漏斗运行日(前一交易日)"),
+    ("ts_code", "text not null", "股票代码,6 位数字"),
+    ("name", "text", "股票名称,便于人工核对"),
+    # 归因:这只票在前一日漏斗里卡在哪一层。
+    ("stage", "text not null", "级联归因档位。注意档位顺序 != 淘汰原因,见下面的分母说明"),
+    ("reason", "text", "该档位的具体理由,含闸门数值"),
+    ("l1_eligible", "boolean not null default false", "前一日是否过基础准入"),
+    ("l2_eligible", "boolean not null default false", "前一日是否过结构强度"),
+    ("l3_eligible", "boolean not null default false", "前一日是否过题材共振"),
+    ("is_candidate", "boolean not null default false", "前一日是否进入候选池"),
+    ("trigger_labels", "text[]", "买点触发标签。只对候选池内的票有值——触发检测只跑最终候选集"),
+    ("risk_signal", "text", "风控信号名,如 stop_loss"),
+    ("tracked_previous_day", "boolean not null default false", "前一日是否已在推荐跟踪表里"),
+    ("ai_recommended_previous_day", "boolean not null default false", "前一日是否被 AI 推荐"),
+    # 影子车道:与 review_shadow_lane_daily 同源判定,便于两张表对照。
+    ("shadow_lane", "text", "影子车道名,无则 null"),
+    ("shadow_score", "numeric(10, 4)", "影子车道排序键,无连续键时为 null——不要填常数"),
+    # 可执行性:能不能真买到。写入闸与下单闸曾各读一套配置(见 memory
+    # two-gates-must-share-one-source),所以这两个标记必须落下来。
+    ("open_executable", "boolean not null default false", "次日开盘是否可执行(未一字板/未涨停)"),
+    ("intraday_executable", "boolean not null default false", "次日盘中是否可执行"),
+    ("open_gap_pct", "numeric(10, 4)", "次日开盘跳空幅度,百分数"),
+    # 选样条件本身。命名带 gain 而非 return,避免被当成前瞻收益。
+    ("gain_pct", "numeric(10, 4)", "复盘日涨幅(选样条件 >7%),**不是**前瞻收益,不可用于评估"),
+    # 当日分母:基准率必须逐日算再合并,否则按结果选样的召回率没有意义。
+    ("pool_size", "integer not null", "当日复盘池规模(分母)"),
+    ("universe_count", "integer not null", "前一日全市场标的数"),
+    ("l1_count", "integer not null", "前一日过 L1 的数量"),
+    ("l2_count", "integer not null", "前一日过 L2 的数量"),
+    ("l3_count", "integer not null", "前一日过 L3 的数量"),
+    ("candidate_count", "integer not null", "前一日候选池规模"),
+    ("context_source", "text", "前一日漏斗上下文来源:trace 快照还是完整重跑"),
+    ("created_at", "timestamptz not null default now()", "写入时间"),
+)
+
+# 一个复盘日一只票只应有一行。重跑同一天覆盖而非累积。
+# 键必须与写入侧 on_conflict 完全一致——见 memory dedup-key-must-match-db-constraint:
+# 键错位会让一行冲突回滚整批,而且是静默的。
+UNIQUE_KEY = ("trade_date", "ts_code")
+
+
+def payload_keys() -> frozenset[str]:
+    """build_capture_rows 应写入的字段（不含自增 id 与默认 created_at）。"""
+    return frozenset(name for name, _, _ in COLUMNS if name != "created_at")
+
+
+def build_ddl() -> str:
+    """生成完整建表语句。幂等——可重复执行。"""
+    table = TABLE_REVIEW_CAPTURE_DAILY
+    body = ["    id bigserial primary key,"]
+    for name, ddl_type, comment in COLUMNS:
+        body.append(f"    -- {comment}")
+        body.append(f"    {name} {ddl_type},")
+    body.append(f"    constraint {table}_unique unique ({', '.join(UNIQUE_KEY)})")
+    lines = [
+        f"create table if not exists public.{table} (",
+        *body,
+        ");",
+        "",
+        "-- 主查询：按档位随时间聚合,算逐日捕获率与各闸门增量精度。",
+        f"create index if not exists {table}_stage_idx",
+        f"    on public.{table} (trade_date desc, stage);",
+        "",
+        "-- 单票追溯：某只票反复被漏掉时,看它每次卡在哪。",
+        f"create index if not exists {table}_code_idx",
+        f"    on public.{table} (ts_code, trade_date desc);",
+    ]
+    return "\n".join(lines) + "\n"

--- a/integrations/supabase_review_capture.py
+++ b/integrations/supabase_review_capture.py
@@ -1,0 +1,132 @@
+"""强势股复盘捕获率逐日落库。
+
+只写 review_capture_daily 一张表,按 (trade_date, ts_code) upsert,重跑同一天覆盖
+而非累积。建表语句由 `python scripts/print_review_capture_ddl.py` 输出。
+
+为什么必须落库:复盘行依赖前一日 trace(哪只票卡在哪一层),trace 只活在
+`daily-job-artifacts-*` 里(retention-days: 30),复盘自己的产物在
+`review-list-replay-logs-*` 里只留 7 天。两个都过期后那一天就永久算不出来,
+而单日样本又没有判别力(2026-09-03:捕获率 p=0.740,题材闸增量 p=0.851),
+必须靠 20+ 个交易日累积。每过一天没留存就永久少一天样本。
+
+行来源只有 build_replay_rows 一处:档位归因不在这里重新分类,否则报告与落库
+两套口径会漂移(见 memory two-gates-must-share-one-source)。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.constants import TABLE_REVIEW_CAPTURE_DAILY
+from core.funnel_taxonomy import REVIEW_STAGE_CANDIDATE_HIT
+from integrations.supabase_base import create_admin_client, require_server_write_context
+
+logger = logging.getLogger(__name__)
+CHUNK = 200
+_CONFLICT_KEY = "trade_date,ts_code"
+
+
+def build_capture_rows(
+    rows: list[dict[str, Any]],
+    *,
+    trade_date: str,
+    previous_trade_date: str,
+    denominators: dict[str, int],
+    gain_map: dict[str, float | None] | None = None,
+    context_source: str = "",
+) -> list[dict[str, Any]]:
+    """把复盘行转成落库行。
+
+    ``denominators`` 是当日的五个分母(universe/l1/l2/l3/candidate)。基准率必须
+    逐日算再合并:复盘池按「今日 >7% 且前一日 <3%」选出来,本身就是按结果选样,
+    只有拿同一天的同层分母作对照,召回率才有意义。所以分母跟着每一行落下来,
+    而不是事后去 join 一张可能已经过期的 trace。
+    """
+    if not trade_date or not previous_trade_date:
+        return []
+    gains = gain_map or {}
+    pool_size = len(rows)
+    out: list[dict[str, Any]] = []
+    for raw in rows:
+        code = _text((raw or {}).get("code"))
+        if not code:
+            continue
+        out.append(
+            {
+                "trade_date": trade_date,
+                "previous_trade_date": previous_trade_date,
+                "ts_code": code,
+                "name": _text(raw.get("name")) or None,
+                "stage": _text(raw.get("stage")),
+                "reason": _text(raw.get("reason")) or None,
+                "l1_eligible": bool(raw.get("l1_eligible")),
+                "l2_eligible": bool(raw.get("l2_eligible")),
+                "l3_eligible": bool(raw.get("l3_eligible")),
+                "is_candidate": bool(raw.get("stage") == REVIEW_STAGE_CANDIDATE_HIT),
+                "trigger_labels": [str(x) for x in (raw.get("trigger_labels") or [])],
+                "risk_signal": _text(raw.get("risk_signal")) or None,
+                "tracked_previous_day": bool(raw.get("tracked_previous_day")),
+                "ai_recommended_previous_day": bool(raw.get("ai_recommended_previous_day")),
+                "shadow_lane": _text(raw.get("shadow_lane")) or None,
+                "shadow_score": _round(raw.get("shadow_score")),
+                "open_executable": bool(raw.get("open_executable")),
+                "intraday_executable": bool(raw.get("intraday_executable")),
+                "open_gap_pct": _round(raw.get("open_gap_pct")),
+                "gain_pct": _round(gains.get(code)),
+                "pool_size": pool_size,
+                "universe_count": int(denominators.get("universe") or 0),
+                "l1_count": int(denominators.get("l1") or 0),
+                "l2_count": int(denominators.get("l2") or 0),
+                "l3_count": int(denominators.get("l3") or 0),
+                "candidate_count": int(denominators.get("candidate") or 0),
+                "context_source": _text(context_source) or None,
+            }
+        )
+    return out
+
+
+def save_review_capture_rows(rows: list[dict[str, Any]]) -> int:
+    """写入一批复盘捕获行,返回成功行数。
+
+    失败只 warning:复盘主流程不该因为这张观测表写不进去而中断(飞书报告已经发了)。
+    但**不会**打印「已写入」这类成功句式——见 memory success-shaped-log-hid-total-loss,
+    那让影子账本缺列停摆两个月没人发现。写了几行就说几行,零行显式说零行。
+    """
+    if not rows:
+        return 0
+    require_server_write_context(f"{TABLE_REVIEW_CAPTURE_DAILY} write")
+    client = create_admin_client()
+    written = 0
+    failed = 0
+    for start in range(0, len(rows), CHUNK):
+        batch = rows[start : start + CHUNK]
+        try:
+            client.table(TABLE_REVIEW_CAPTURE_DAILY).upsert(batch, on_conflict=_CONFLICT_KEY).execute()
+            written += len(batch)
+        except Exception as exc:  # noqa: BLE001 - 观测表写失败不中断复盘
+            failed += len(batch)
+            logger.warning("[review-capture] 批次写入失败 rows=%d: %s", len(batch), exc)
+    if failed or written < len(rows):
+        logger.warning(
+            "[review-capture] %s 未全部写入: written=%d failed=%d total=%d",
+            TABLE_REVIEW_CAPTURE_DAILY,
+            written,
+            failed,
+            len(rows),
+        )
+    else:
+        logger.info("[review-capture] %s written=%d", TABLE_REVIEW_CAPTURE_DAILY, written)
+    return written
+
+
+def _round(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if result != result else round(result, 4)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()

--- a/scripts/print_review_capture_ddl.py
+++ b/scripts/print_review_capture_ddl.py
@@ -1,0 +1,24 @@
+"""打印 review_capture_daily 建表语句，供人工在 Supabase SQL Editor 执行。
+
+本项目不保留 .sql 文件，且 Supabase Python SDK 走 REST 不支持 DDL，
+故 schema 以 core/review_capture_schema.py 的常量形式版本化并由此脚本输出。
+
+用法::
+
+    python scripts/print_review_capture_ddl.py
+"""
+
+from __future__ import annotations
+
+import _bootstrap  # noqa: F401
+
+from core.review_capture_schema import build_ddl
+
+
+def main() -> int:
+    print(build_ddl())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integrations/test_supabase_review_capture.py
+++ b/tests/integrations/test_supabase_review_capture.py
@@ -1,0 +1,166 @@
+"""复盘捕获率落库:行构建与 schema 防漂移。
+
+schema 以 Python 常量版本化(本项目不留 .sql),写入侧和建表侧靠测试对齐,
+不靠人记。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from core.funnel_taxonomy import (
+    REVIEW_STAGE_CANDIDATE_HIT,
+    REVIEW_STAGE_THEME_MISS,
+)
+from core.review_capture_schema import UNIQUE_KEY, build_ddl, payload_keys
+from integrations.supabase_review_capture import build_capture_rows
+
+_DENOM = {"universe": 5347, "l1": 3442, "l2": 2236, "l3": 654, "candidate": 137}
+
+
+def _build(rows: list[dict], **kwargs):
+    params = {
+        "trade_date": "2026-09-03",
+        "previous_trade_date": "2026-09-02",
+        "denominators": _DENOM,
+        "context_source": "trace_snapshot",
+    }
+    params.update(kwargs)
+    return build_capture_rows(rows, **params)
+
+
+def test_every_row_carries_same_day_denominators() -> None:
+    """基准率必须逐日算再合并。
+
+    复盘池按「今日 >7% 且前一日 <3%」选样,本身就是按结果选样;只有拿同一天的
+    同层分母作对照,召回率才有意义。分母跟着行落下来,而不是事后 join 一张
+    30 天就过期的 trace。
+    """
+    rows = _build(
+        [
+            {"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT},
+            {"code": "000002", "stage": REVIEW_STAGE_THEME_MISS},
+        ]
+    )
+
+    assert len(rows) == 2
+    for row in rows:
+        assert row["universe_count"] == 5347
+        assert row["l1_count"] == 3442
+        assert row["l2_count"] == 2236
+        assert row["l3_count"] == 654
+        assert row["candidate_count"] == 137
+        assert row["pool_size"] == 2
+        assert row["trade_date"] == "2026-09-03"
+        assert row["previous_trade_date"] == "2026-09-02"
+
+
+def test_is_candidate_reads_the_stage_constant_not_a_reclassification() -> None:
+    """判别性用例:候选归属只认档位常量,不在落库侧重新判定。
+
+    重新判定会让报告与落库两套口径漂移(见 memory two-gates-must-share-one-source)。
+    这里两行的 l1/l2/l3 全为真、只有 stage 不同,若落库侧改用闸门标记去推断
+    is_candidate,两行就会同为 true,这个用例会失败。
+    """
+    rows = _build(
+        [
+            {
+                "code": "000001",
+                "stage": REVIEW_STAGE_CANDIDATE_HIT,
+                "l1_eligible": True,
+                "l2_eligible": True,
+                "l3_eligible": True,
+            },
+            {
+                "code": "000002",
+                "stage": REVIEW_STAGE_THEME_MISS,
+                "l1_eligible": True,
+                "l2_eligible": True,
+                "l3_eligible": True,
+            },
+        ]
+    )
+
+    assert [row["is_candidate"] for row in rows] == [True, False]
+
+
+def test_gain_comes_from_the_gain_map_and_is_never_read_off_the_row() -> None:
+    """gain_pct 是选样条件,来源必须是行情帧算出的涨幅。
+
+    复盘行本身不带涨幅——报告里也刻意不展示它,免得被当成前瞻收益读
+    (见 memory control-row-must-measure-itself)。这里给行塞一个假的 gain_pct,
+    落库行仍应取 gain_map 的值。
+    """
+    rows = _build(
+        [{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT, "gain_pct": 99.0}],
+        gain_map={"000001": 7.83},
+    )
+
+    assert rows[0]["gain_pct"] == 7.83
+
+
+def test_missing_gain_stores_null_not_zero() -> None:
+    """缺涨幅存 null:填 0 会把「没量到」读成「没涨」,把分布往下拽。"""
+    rows = _build([{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT}], gain_map={})
+
+    assert rows[0]["gain_pct"] is None
+
+
+def test_trigger_labels_survive_as_a_list() -> None:
+    """买点标签只对候选池内的票有值——触发检测只跑最终候选集,别处是不可测而非零。"""
+    rows = _build(
+        [
+            {"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT, "trigger_labels": ["lps", "sos"]},
+            {"code": "000002", "stage": REVIEW_STAGE_THEME_MISS},
+        ]
+    )
+
+    assert rows[0]["trigger_labels"] == ["lps", "sos"]
+    assert rows[1]["trigger_labels"] == []
+
+
+def test_rows_without_a_code_are_skipped_but_pool_size_keeps_the_pool() -> None:
+    """无代码的行不落库;pool_size 仍是复盘池规模,不能被跳过的行改掉分母。"""
+    rows = _build(
+        [
+            {"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT},
+            {"code": "", "stage": REVIEW_STAGE_THEME_MISS},
+        ]
+    )
+
+    assert [row["ts_code"] for row in rows] == ["000001"]
+    assert rows[0]["pool_size"] == 2
+
+
+def test_missing_dates_yield_no_rows() -> None:
+    """缺日期不写:trade_date 是唯一键的一半,写进去就无法覆盖重跑。"""
+    row = [{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT}]
+
+    assert _build(row, trade_date="") == []
+    assert _build(row, previous_trade_date="") == []
+
+
+def test_payload_keys_match_schema_columns() -> None:
+    """写入键与建表列必须一一对应,漂了就是静默丢字段。"""
+    rows = _build([{"code": "000001", "stage": REVIEW_STAGE_CANDIDATE_HIT}])
+    written = set(rows[0])
+
+    assert written == set(payload_keys()), sorted(written ^ set(payload_keys()))
+
+
+def test_unique_key_matches_upsert_conflict_target() -> None:
+    """键错位会让一行冲突回滚整批,而且是静默的(见 memory dedup-key-must-match-db-constraint)。"""
+    source = Path("integrations/supabase_review_capture.py").read_text(encoding="utf-8")
+
+    assert f'_CONFLICT_KEY = "{",".join(UNIQUE_KEY)}"' in source
+
+
+def test_ddl_is_idempotent_and_indexes_stage_and_code() -> None:
+    """建表语句要能重复执行,并覆盖两条主查询:按档位聚合、按单票追溯。"""
+    ddl = build_ddl()
+
+    assert "create table if not exists public.review_capture_daily" in ddl
+    assert re.search(r"create index if not exists \w+_stage_idx", ddl)
+    assert re.search(r"create index if not exists \w+_code_idx", ddl)
+    assert f"unique ({', '.join(UNIQUE_KEY)})" in ddl

--- a/tests/test_signal_feedback.py
+++ b/tests/test_signal_feedback.py
@@ -938,6 +938,173 @@ def test_attach_shadow_policy_preserves_base_policy():
     assert base["_attribution_signal_weights"] == {}
 
 
+def test_maybe_persist_policy_shadow_run_writes_row_in_on_mode(monkeypatch):
+    """闸门死环的回归用例：on 档必须落一行，否则 run_count 永远到不了 MIN_SHADOW_RUNS。
+
+    这条在修复前必然失败 —— 旧代码首行 ``!= "shadow"`` 直接 return {}，连
+    「写入失败」的告警都不会打，表现为线上日志里两条 shadow 日志一条都没有。
+    """
+    from workflows import funnel_ai_selection as selection
+
+    captured: list[dict] = []
+    monkeypatch.setattr(selection, "upsert_policy_shadow_run", lambda row: captured.append(row) or 1)
+    # 静态反事实：静态档会多挑 000009，少挑实选里的 000003。
+    monkeypatch.setattr(
+        selection,
+        "allocate_ai_candidates",
+        lambda *_args, **_kwargs: (["000001", "000009"], ["000002"], {"000001": 70.0, "000009": 55.0}),
+    )
+
+    static_base = {"trend_quota": 8, "accum_quota": 4, "quota_family": "RISK_ON", "max_per_sector": 2}
+    dynamic = {"trend_quota": 3, "accum_quota": 5, "quota_family": "RISK_ON+DYNAMIC", "max_per_sector": 2}
+    ai_policy = {
+        **dynamic,
+        "_dynamic_mode": "on",
+        "_shadow_policy": dynamic,
+        "_static_base_policy": static_base,
+        "_signal_weights": {"sos": 0.8},
+        "_registry_rows": [],
+        "_health_rows": [],
+    }
+
+    meta = selection.maybe_persist_policy_shadow_run(
+        ai_policy=ai_policy,
+        metrics={"end_trade_date": "2026-09-04", "layer3_symbols": ["000001", "000002", "000003"]},
+        triggers={"sos": [("000001", 70.0), ("000003", 66.0)]},
+        selected_for_ai=["000001", "000002", "000003"],
+        l3_ranked_symbols=["000001", "000002", "000003"],
+        regime="RISK_ON",
+        sector_map={},
+        executed_score_map={"000003": 66.0},
+    )
+
+    assert len(captured) == 1, "on 档必须记账，否则影子样本永远攒不够"
+    row = captured[0]
+    # 实选（动态档）落在 shadow_* 侧，静态反事实落在 base_* 侧。
+    assert row["shadow_selected"] == ["000001", "000002", "000003"]
+    assert row["base_selected"] == ["000001", "000009", "000002"]
+    # diff_added 的含义在两档下一致：动态档比静态档多挑的票。
+    assert row["diff_added"] == ["000003"]
+    assert row["diff_removed"] == ["000009"]
+    assert row["selection_summary"]["executed_side"] == "shadow"
+    assert meta["shadow_written"] == 1
+    assert meta["shadow_executed_side"] == "shadow"
+    # 实选那批码的分数得取实盘那份，不能因为静态 score_map 里没有就记 0.0。
+    assert meta["shadow_score_map"]["000003"] == 66.0
+
+
+def test_maybe_persist_policy_shadow_run_skips_off_mode(monkeypatch):
+    from workflows import funnel_ai_selection as selection
+
+    captured: list[dict] = []
+    monkeypatch.setattr(selection, "upsert_policy_shadow_run", lambda row: captured.append(row) or 1)
+
+    meta = selection.maybe_persist_policy_shadow_run(
+        ai_policy={"_dynamic_mode": "off", "_shadow_policy": {}},
+        metrics={"end_trade_date": "2026-09-04"},
+        triggers={},
+        selected_for_ai=["000001"],
+        l3_ranked_symbols=["000001"],
+        regime="RISK_ON",
+        sector_map={},
+    )
+
+    assert meta == {}
+    assert captured == []
+
+
+def test_attach_shadow_policy_also_attaches_in_on_mode():
+    """on 档也必须挂上影子上下文，否则闸门永远开不了。
+
+    线上 ``FUNNEL_DYNAMIC_POLICY=on``（secret，2026-07-15 起）时原先这里直接 return，
+    于是 signal_policy_shadow_runs 从 2026-07-01 起不再进新行；归因重算的 60 天滚动窗
+    里 run_count=0 < MIN_SHADOW_RUNS=10，判 insufficient_shadow_sample，把 on 档的归因
+    权重挡住；而样本只在 shadow 档才攒 —— 死环。
+    """
+    from workflows.funnel_ai_selection import attach_shadow_policy
+
+    static_base = {"trend_quota": 8, "accum_quota": 4, "quota_family": "RISK_ON"}
+    dynamic = {"trend_quota": 3, "accum_quota": 5, "quota_family": "RISK_ON+DYNAMIC"}
+    # on 档下传进来的 ai_policy 本身就是动态档。
+    ai_policy = dict(dynamic)
+
+    attach_shadow_policy(
+        ai_policy,
+        {"mode": "on", "policy": dynamic, "base_policy": static_base, "weights": {"sos": 0.8}},
+    )
+
+    assert ai_policy["_dynamic_mode"] == "on"
+    assert ai_policy["_shadow_policy"] == dynamic
+    # 静态基线必须单独带出来，否则 base_* 列会被写成动态档。
+    assert ai_policy["_static_base_policy"] == static_base
+
+
+def test_attach_shadow_policy_skips_off_mode():
+    from workflows.funnel_ai_selection import attach_shadow_policy
+
+    ai_policy = {"trend_quota": 8}
+    attach_shadow_policy(ai_policy, {"mode": "off", "policy": {"trend_quota": 3}})
+    assert "_dynamic_mode" not in ai_policy
+
+
+def test_policy_shadow_row_keeps_base_static_in_on_mode():
+    """列语义不能随档位翻转：base_* 恒为静态档，shadow_* 恒为动态档。
+
+    若 on 档把「实际下单的动态档」写进 base_*，diff_added 的含义就会反过来，
+    治理器读到的符号整体翻转。执行侧只能记在 selection_summary 里。
+    """
+    from workflows.funnel_ai_selection import _policy_shadow_row
+
+    static_base = {"trend_quota": 8, "accum_quota": 4, "quota_family": "RISK_ON"}
+    dynamic = {"trend_quota": 3, "accum_quota": 5, "quota_family": "RISK_ON+DYNAMIC"}
+    ai_policy = {
+        **dynamic,
+        "_shadow_policy": dynamic,
+        "_static_base_policy": static_base,
+        "_signal_weights": {"sos": 0.8},
+    }
+
+    row = _policy_shadow_row(
+        ai_policy,
+        {"end_trade_date": "2026-09-04"},
+        ["000001", "000002"],
+        ["000002", "000003"],
+        ["000003"],
+        ["000001"],
+        "RISK_ON",
+        mode="on",
+    )
+
+    assert row["base_policy"]["quota_family"] == "RISK_ON"
+    assert row["shadow_policy"]["quota_family"] == "RISK_ON+DYNAMIC"
+    assert row["base_selected"] == ["000001", "000002"]
+    assert row["shadow_selected"] == ["000002", "000003"]
+    assert row["selection_summary"]["dynamic_mode"] == "on"
+    assert row["selection_summary"]["executed_side"] == "shadow"
+
+
+def test_policy_shadow_row_marks_base_as_executed_in_shadow_mode():
+    from workflows.funnel_ai_selection import _policy_shadow_row
+
+    row = _policy_shadow_row(
+        {
+            "trend_quota": 8,
+            "accum_quota": 4,
+            "quota_family": "RISK_ON",
+            "_shadow_policy": {"trend_quota": 3, "accum_quota": 5, "quota_family": "RISK_ON+DYNAMIC"},
+        },
+        {"end_trade_date": "2026-09-04"},
+        ["000001"],
+        ["000002"],
+        ["000002"],
+        ["000001"],
+        "RISK_ON",
+    )
+
+    assert row["base_policy"]["quota_family"] == "RISK_ON"
+    assert row["selection_summary"]["executed_side"] == "base"
+
+
 def test_load_dynamic_policy_context_merges_attribution_weights(monkeypatch):
     from core.ai_candidate_allocation import AiCandidateAllocationConfig
     from workflows import funnel_ai_selection as selection

--- a/workflows/funnel_ai_selection.py
+++ b/workflows/funnel_ai_selection.py
@@ -577,9 +577,7 @@ def _policy_shadow_row(
         "shadow_selected": shadow_selected,
         "diff_added": diff_added,
         "diff_removed": diff_removed,
-        "selection_summary": _selection_summary(
-            base_selected, shadow_selected, diff_added, diff_removed, mode=mode
-        ),
+        "selection_summary": _selection_summary(base_selected, shadow_selected, diff_added, diff_removed, mode=mode),
         "policy_summary": _policy_summary(
             base_policy,
             shadow_policy,

--- a/workflows/funnel_ai_selection.py
+++ b/workflows/funnel_ai_selection.py
@@ -106,6 +106,9 @@ def select_base_ai_candidates(
         print(f"[funnel] 市场模式 {trade_mode.mode}: {regime} 强制从 full_l4 切换为 quota 选股")
     if use_full_ai_selection:
         result = full_formal_ai_selection(formal_sorted_codes, code_to_best_score, code_to_trigger_keys)
+        # 这里只认 shadow，不放 on：full_l4 下实际下单的是全量正式名单，既不是静态配额
+        # 也不是动态配额，写进影子账本会把 base/shadow 两列标错对象。on 档 + full_l4
+        # 因此仍然不记账（线上走的是下面的 quota 路径，这条分支当前不触发）。
         if dynamic_policy_mode(dynamic_config) == "shadow":
             attach_shadow_policy(
                 result[4],
@@ -231,25 +234,55 @@ def maybe_persist_policy_shadow_run(
     l3_ranked_symbols: list[str],
     regime: str,
     sector_map: dict[str, str],
+    executed_score_map: dict[str, float] | None = None,
 ) -> dict:
-    if ai_policy.get("_dynamic_mode") != "shadow" or not ai_policy.get("_shadow_policy"):
+    mode = str(ai_policy.get("_dynamic_mode") or "")
+    if mode not in {"shadow", "on"} or not ai_policy.get("_shadow_policy"):
         return {}
-    shadow_trend, shadow_accum, score_map = _shadow_selected_codes(
-        metrics,
-        triggers,
-        l3_ranked_symbols,
-        regime,
-        sector_map,
+    if mode == "on":
+        # on 档实际下单的是动态档，所以 shadow_selected 直接取实选，反过来算静态反事实。
+        # 列语义不能随档位翻转：base_* 恒为静态档，shadow_* 恒为动态档。
+        shadow_selected = list(selected_for_ai)
+        base_trend, base_accum, score_map = _static_selected_codes(
+            metrics,
+            triggers,
+            l3_ranked_symbols,
+            regime,
+            sector_map,
+            ai_policy,
+        )
+        base_selected = base_trend + base_accum
+        # shadow_selected 是实选，分数得用实盘那份；静态反事实的 score_map 里没有它们，
+        # 否则这批码在 shadow 观测行里会被记成 0.0 分。
+        if executed_score_map:
+            score_map = {**score_map, **executed_score_map}
+    else:
+        base_selected = list(selected_for_ai)
+        shadow_trend, shadow_accum, score_map = _shadow_selected_codes(
+            metrics,
+            triggers,
+            l3_ranked_symbols,
+            regime,
+            sector_map,
+            ai_policy,
+        )
+        shadow_selected = shadow_trend + shadow_accum
+    diff_added, diff_removed = selection_diff(base_selected, shadow_selected)
+    row = _policy_shadow_row(
         ai_policy,
+        metrics,
+        base_selected,
+        shadow_selected,
+        diff_added,
+        diff_removed,
+        regime,
+        mode=mode,
     )
-    shadow_selected = shadow_trend + shadow_accum
-    diff_added, diff_removed = selection_diff(selected_for_ai, shadow_selected)
-    row = _policy_shadow_row(ai_policy, metrics, selected_for_ai, shadow_selected, diff_added, diff_removed, regime)
     written = upsert_policy_shadow_run(row)
     if written:
         print(
             "[funnel] 动态策略shadow已写入 signal_policy_shadow_runs: "
-            f"written={written}, added={len(diff_added)}, removed={len(diff_removed)}"
+            f"mode={mode}, written={written}, added={len(diff_added)}, removed={len(diff_removed)}"
         )
     else:
         # 原先「已写入 ... written=0」照样打印，读着像正常输出。实测这条就是影子账本
@@ -260,7 +293,7 @@ def maybe_persist_policy_shadow_run(
             "归因重算会持续报 insufficient_shadow_sample；"
             "检查 signal_policy_shadow_runs 是否缺列(scripts/print_signal_policy_shadow_ddl.py)"
         )
-    return _policy_shadow_meta(written, shadow_selected, diff_added, diff_removed, score_map)
+    return _policy_shadow_meta(written, shadow_selected, diff_added, diff_removed, score_map, mode=mode)
 
 
 def full_formal_ai_selection(
@@ -293,20 +326,38 @@ def full_formal_ai_selection(
 
 
 def attach_shadow_policy(ai_policy: dict, dynamic_ctx: dict) -> None:
-    if str(dynamic_ctx.get("mode") or "off") != "shadow" or not dynamic_ctx.get("policy"):
+    """挂上影子账本所需的上下文。shadow 与 on 两档都要挂。
+
+    原先这里只认 shadow 档，于是线上 ``FUNNEL_DYNAMIC_POLICY=on`` 时形成死环：
+    on 档不挂 ``_shadow_policy`` -> ``maybe_persist_policy_shadow_run`` 首行直接
+    返回 -> ``signal_policy_shadow_runs`` 不进新行 -> 归因重算的滚动窗里
+    ``run_count=0 < MIN_SHADOW_RUNS`` -> 判 ``insufficient_shadow_sample`` ->
+    on 档的归因权重被永久挡住，而样本只在 shadow 档才会攒。闸门永远开不了。
+
+    两档都记账后，列语义仍然固定：``base_*`` 永远是静态档，``shadow_*`` 永远是
+    动态档，只有「哪一侧真下单」随档位变（记在 selection_summary 里）。治理器读
+    ``diff_added`` 的符号因此不用改。
+    """
+    mode = str(dynamic_ctx.get("mode") or "off")
+    if mode not in {"shadow", "on"} or not dynamic_ctx.get("policy"):
         return
     shadow_policy = dynamic_ctx["policy"]
-    ai_policy["_dynamic_mode"] = "shadow"
+    ai_policy["_dynamic_mode"] = mode
     ai_policy["_shadow_policy"] = shadow_policy
+    # on 档下 ai_policy 本身已是动态档，静态基线只能从 ctx 拿。
+    ai_policy["_static_base_policy"] = dynamic_ctx.get("base_policy") or {}
     ai_policy["_signal_weights"] = dynamic_ctx.get("weights") or {}
     ai_policy["_registry_rows"] = dynamic_ctx.get("registry") or []
     ai_policy["_health_rows"] = dynamic_ctx.get("health") or []
     ai_policy["_attribution_signal_weights"] = dynamic_ctx.get("attribution_weights") or {}
     ai_policy["_attribution_policy_meta"] = dynamic_ctx.get("attribution_policy_meta") or {}
     ai_policy["_pv_policy_shadow"] = dynamic_ctx.get("pv_policy_shadow") or {}
+    # base 一律读静态档：on 档下 ai_policy 就是动态档，拿它当 base 会打出两边一样。
+    base_for_log = ai_policy.get("_static_base_policy") or ai_policy
+    executed = "shadow" if mode == "on" else "base"
     print(
-        "[funnel] 动态策略shadow: "
-        f"base Trend={ai_policy['trend_quota']}, Accum={ai_policy['accum_quota']} -> "
+        f"[funnel] 动态策略shadow(mode={mode}, 实际下单侧={executed}): "
+        f"base Trend={base_for_log.get('trend_quota')}, Accum={base_for_log.get('accum_quota')} -> "
         f"shadow Trend={shadow_policy['trend_quota']}, Accum={shadow_policy['accum_quota']}"
     )
 
@@ -362,6 +413,9 @@ def _load_dynamic_policy_context(
         "attribution_weights": attribution_weights,
         "attribution_policy_meta": attribution_snapshot.as_dict(),
         "policy": policy,
+        # on 档下 ai_policy 就是 policy（动态档），静态基线取不到，必须单独带出来，
+        # 否则影子账本的 base_* 列会被写成动态档，diff 的符号整体翻转。
+        "base_policy": base_policy,
         "pv_policy_shadow": pv_policy_shadow,
     }
 
@@ -383,6 +437,7 @@ def _dynamic_policy_fallback(mode: str, pv_policy_shadow: dict) -> dict:
         "attribution_weights": {},
         "attribution_policy_meta": {},
         "policy": None,
+        "base_policy": None,
         "pv_policy_shadow": pv_policy_shadow,
     }
 
@@ -464,18 +519,48 @@ def _shadow_selected_codes(
     return trend, accum, score_map
 
 
+def _static_selected_codes(
+    metrics: dict,
+    triggers: dict[str, list[tuple[str, float]]],
+    l3_ranked_symbols: list[str],
+    regime: str,
+    sector_map: dict[str, str],
+    ai_policy: dict,
+) -> tuple[list[str], list[str], dict[str, float]]:
+    """on 档下的静态反事实：不按 registry 过滤触发、不加权、用静态配额。
+
+    与 ``_shadow_selected_codes`` 严格镜像——那边是「静态在跑，问动态会选什么」，
+    这边是「动态在跑，问静态会选什么」。两处都不过 ``_apply_ai_post_filters``，
+    保持与历史行的口径一致（反事实一侧从来不过后置过滤）。
+    """
+    static_policy = ai_policy.get("_static_base_policy") or {}
+    trend, accum, score_map = allocate_ai_candidates(
+        _candidate_result(metrics, triggers),
+        l3_ranked_symbols,
+        regime,
+        sector_map=sector_map,
+        max_per_sector=int(static_policy.get("max_per_sector") or ai_policy.get("max_per_sector") or 2),
+        policy_override=static_policy or None,
+        signal_weight_map=None,
+    )
+    return trend, accum, score_map
+
+
 def _policy_shadow_row(
     ai_policy: dict,
     metrics: dict,
-    selected_for_ai: list[str],
+    base_selected: list[str],
     shadow_selected: list[str],
     diff_added: list[str],
     diff_removed: list[str],
     regime: str,
+    mode: str = "shadow",
 ) -> dict:
     registry_rows = ai_policy.get("_registry_rows") or []
     health_rows = ai_policy.get("_health_rows") or []
-    base_policy = _public_policy(ai_policy)
+    # base_policy 必须是静态档。on 档下 ai_policy 本身就是动态档，直接 _public_policy(ai_policy)
+    # 会把两列写成同一份策略，diff 恒为空，账本看着「一切正常」却什么都没记。
+    base_policy = _public_policy(ai_policy.get("_static_base_policy") or ai_policy)
     shadow_policy = _public_policy(ai_policy.get("_shadow_policy") or {})
     return {
         "market": "cn",
@@ -488,11 +573,13 @@ def _policy_shadow_row(
         "signal_weights": ai_policy.get("_signal_weights") or {},
         "attribution_signal_weights": ai_policy.get("_attribution_signal_weights") or {},
         "attribution_policy_meta": ai_policy.get("_attribution_policy_meta") or {},
-        "base_selected": selected_for_ai,
+        "base_selected": base_selected,
         "shadow_selected": shadow_selected,
         "diff_added": diff_added,
         "diff_removed": diff_removed,
-        "selection_summary": _selection_summary(selected_for_ai, shadow_selected, diff_added, diff_removed),
+        "selection_summary": _selection_summary(
+            base_selected, shadow_selected, diff_added, diff_removed, mode=mode
+        ),
         "policy_summary": _policy_summary(
             base_policy,
             shadow_policy,
@@ -514,10 +601,14 @@ def _policy_shadow_meta(
     diff_added: list[str],
     diff_removed: list[str],
     score_map: dict[str, float],
+    mode: str = "shadow",
 ) -> dict:
     return {
         "shadow_table": "signal_policy_shadow_runs",
         "shadow_written": written,
+        "shadow_dynamic_mode": mode,
+        # on 档下 shadow_* 这批码就是实选，base 才是反事实；shadow 档反过来。
+        "shadow_executed_side": "shadow" if mode == "on" else "base",
         "shadow_added_count": len(diff_added),
         "shadow_removed_count": len(diff_removed),
         "shadow_selected": shadow_selected,
@@ -532,16 +623,21 @@ def _public_policy(policy: dict) -> dict:
 
 
 def _selection_summary(
-    selected_for_ai: list[str],
+    base_selected: list[str],
     shadow_selected: list[str],
     diff_added: list[str],
     diff_removed: list[str],
+    mode: str = "shadow",
 ) -> dict:
-    base_set = set(selected_for_ai)
+    base_set = set(base_selected)
     shadow_set = set(shadow_selected)
     overlap = len(base_set & shadow_set)
     return {
-        "base_count": len(selected_for_ai),
+        # base 恒为静态档、shadow 恒为动态档；executed_side 才是「哪一侧真下了单」。
+        # 少了这个标记，就无法区分同一行是 shadow 档观测还是 on 档实盘。
+        "dynamic_mode": mode,
+        "executed_side": "shadow" if mode == "on" else "base",
+        "base_count": len(base_selected),
         "shadow_count": len(shadow_selected),
         "overlap_count": overlap,
         "diff_added_count": len(diff_added),

--- a/workflows/review_list_replay.py
+++ b/workflows/review_list_replay.py
@@ -33,7 +33,12 @@ from core.wyckoff_engine import (
 )
 from utils.env import env_flag
 from utils.feishu import send_feishu_notification
-from workflows.review_big_gainers import execution_snapshot, is_target_cn_board, load_today_review_pool
+from workflows.review_big_gainers import (
+    execution_snapshot,
+    is_target_cn_board,
+    latest_and_previous_pct,
+    load_today_review_pool,
+)
 from workflows.review_recommendation_lookup import format_recommendation_history, load_recommendation_lookup
 from workflows.review_report_render import build_report_lines
 from workflows.wyckoff_funnel import run_funnel_job
@@ -82,7 +87,8 @@ def run_review_list_replay(webhook: str, log=print) -> int:
         previous_trade_date=dates.previous_trade_date,
     )
     execution_map = {code: execution_snapshot(pool.frames.get(code)) for code in pool.codes}
-    return _run_review_for_codes(webhook, pool.codes, dates, log, execution_map)
+    gain_map = {code: latest_and_previous_pct(pool.frames.get(code))[0] for code in pool.codes}
+    return _run_review_for_codes(webhook, pool.codes, dates, log, execution_map, gain_map)
 
 
 def resolve_review_dates() -> ReviewDates:
@@ -441,6 +447,7 @@ def _run_review_for_codes(
     dates: ReviewDates,
     log,
     execution_map: dict[str, dict[str, object]] | None = None,
+    gain_map: dict[str, float | None] | None = None,
 ) -> int:
     if not review_codes:
         log("[review] 今日无满足收盘涨幅 > 7% 且前一交易日收盘涨幅 < 3% 的股票，跳过")
@@ -459,7 +466,51 @@ def _run_review_for_codes(
     )
     ok = send_replay_report(webhook, rows, stage_counter, dates, ctx.end_trade_date, stats)
     log(f"[review] feishu_sent={ok}")
+    _persist_capture_rows(rows, ctx, dates, stats, gain_map, log=log)
     return 0 if ok else 4
+
+
+def _persist_capture_rows(
+    rows: list[dict[str, Any]],
+    ctx: ReplayContext,
+    dates: ReviewDates,
+    stats: dict[str, Any],
+    gain_map: dict[str, float | None] | None,
+    log=print,
+) -> None:
+    """把逐日档位归属落库,供 20+ 个交易日后算捕获率与各闸门增量精度。
+
+    放在发报告之后:飞书那份是当天要看的,落库是为了以后能做检验,写不进去不该
+    影响前者。artifact 里的复盘产物只留 7 天、前一日 trace 只留 30 天,过期后这
+    一天就永久算不出来,所以本地没有 artifacts 目录也该写,只要处在 server_job
+    写入上下文里。
+    """
+    from integrations.supabase_base import is_server_write_context
+
+    if not is_server_write_context():
+        return
+    from integrations.supabase_review_capture import build_capture_rows, save_review_capture_rows
+
+    try:
+        capture_rows = build_capture_rows(
+            rows,
+            trade_date=dates.today.strftime("%Y-%m-%d"),
+            previous_trade_date=dates.previous_trade_date.strftime("%Y-%m-%d"),
+            denominators={
+                "universe": len(ctx.all_symbol_set),
+                "l1": len(ctx.l1_set),
+                "l2": len(ctx.l2_set),
+                "l3": len(ctx.l3_set),
+                "candidate": len(ctx.candidate_entry_map),
+            },
+            gain_map=gain_map,
+            context_source=str(stats.get("context_source") or ctx.source),
+        )
+        written = save_review_capture_rows(capture_rows)
+    except Exception as exc:  # noqa: BLE001 - 观测表写失败不该影响复盘
+        log(f"[review] 捕获率落库失败: {exc}")
+        return
+    log(f"[review] 捕获率落库: {written}/{len(capture_rows)} 行")
 
 
 def load_previous_context(previous_trade_date: date, log=print) -> ReplayContext | None:

--- a/workflows/wyckoff_funnel.py
+++ b/workflows/wyckoff_funnel.py
@@ -268,6 +268,7 @@ def _select_run_ai_candidates(
         l3_ranked_symbols=l3_ranked_symbols,
         regime=ctx.regime,
         sector_map=ctx.sector_map,
+        executed_score_map=score_map,
     )
     ai_policy.update(shadow_meta)
     return FunnelAiSelection(


### PR DESCRIPTION
## 问题

线上 `FUNNEL_DYNAMIC_POLICY` 是 **repo secret**（2026-07-15 设为 `on`），不是 YAML 默认的 `shadow`。之前只查了 `gh variable list` 没查 secret，误判成「跑的是 shadow 档」。

影子账本只在 `shadow` 档写，于是 2026-07-01 之后 `signal_policy_shadow_runs` 再没进过新行，形成一个自己解不开的环：

```
on 档 → attach_shadow_policy 首行 mode != "shadow" 直接 return
      → maybe_persist_policy_shadow_run 首行返回 {}（成功/失败两条日志一条都不打）
      → signal_policy_shadow_runs 不进新行
      → 归因重算读 --days 60 滚动窗（07-06..09-04）里 0 行
      → run_count=0 < MIN_SHADOW_RUNS=10 → insufficient_sample
      → formal_dynamic_block_reason=insufficient_shadow_sample
      → on 档的归因权重被挡住，而样本只在 shadow 档才攒 → 永远开不了
```

判定 mode 的依据不靠猜被 mask 的字符串：`attribution_weights_for_funnel` 只有一个会打日志的分支（`on` + 未获批），09-01 的日志里就有 `策略归因调权: formal dynamic 未启用归因权重(insufficient_shadow_sample)`，其余三条分支都是静默返回。

顺带纠正我之前的说法：这不是「写入失败」，是**写入根本没被尝试**。7-04 那批缺列导致整行回滚的问题是另一个已经关掉的原因。

同时暴露的观测空洞：`on` 档下反馈权重是真的作用在选股上的（`policy_override=dynamic_policy`，多个信号族权重为 0.0），但全库没有任何一处记下「静态会选什么 / 动态实际选了什么」，所以动态策略对选股的影响此前无法度量。

## 改法

两档都记账，但**列语义不随档位翻转**：

| 列 | 含义（两档一致） |
|---|---|
| `base_selected` / `base_policy` | 恒为静态档 |
| `shadow_selected` / `shadow_policy` | 恒为动态档 |
| `selection_summary.executed_side` | 哪一侧真下了单（shadow 档=base，on 档=shadow） |

这样 `diff_added` 在两档下都是「动态比静态多挑的票」，治理器读的符号不用动。若改成按执行侧摆列，`on` 档的 diff 会整体反号 —— 比不记账更坏。

- `on` 档的静态反事实由 `_static_selected_codes` 计算，与 `_shadow_selected_codes` 严格镜像：不按 registry 过滤、不加权、用静态配额。
- 实选那批码的分数取实盘那份（`executed_score_map`），否则 shadow 观测行会把它们记成 0.0。
- `full_l4` 分支仍只认 shadow：那里实际下单的是全量正式名单，既不是静态配额也不是动态配额，记进账本会把两列标错对象。线上走 quota 路径，该分支当前不触发，已在代码里注明。

**不需要改表结构。**

## 验证

- 新增回归用例在旧代码上实测失败（`on` 档 0 行落库、`_dynamic_mode` 未设置），修复后通过。
- 全量 4635 passed / 22 skipped。
- `quality_gate.py --check-no-sql` OK，ruff OK。

## 需要你定的两件事（我没动）

1. `FUNNEL_DYNAMIC_POLICY` 建议从 **secret 改成 repo variable**，值不变。值本身不敏感，但放在 secret 里会让 GitHub 把 `on` 这两个字符在该 workflow 的**每一行日志**里打码 —— 现在日志里 `accumulati***_ready`、`compressi***`、`horiz***=5` 就是这么来的，整份日志的可读性都被拖累。
2. 线上到底该跑 `on` 还是回 `shadow`，是你的决定。这个 PR 两档都能正常记账，不改档位。