### PR TITLE
fix(ci): 周度反思的周几读了墙上时钟，被排队延迟推着漏跑

### DIFF
--- a/.github/workflows/signal_feedback.yml
+++ b/.github/workflows/signal_feedback.yml
@@ -2,8 +2,14 @@ name: Signal Feedback
 
 on:
   schedule:
-    # 北京时间周一到周五 23:30，GitHub Actions 使用 UTC。
-    - cron: "30 15 * * 1-5"
+    # 北京时间周一到周四 23:30，GitHub Actions 使用 UTC；只刷新信号反馈。
+    - cron: "30 15 * * 1-4"
+    # 北京时间周五 23:30，额外跑周度策略反思。
+    # 「今天是不是周五」必须由哪条 cron 触发来决定，不能在步骤里读 date -u：GitHub 的
+    # 排队延迟经常把 run 推后几小时，实测周四那班被推到 08-28T00:29Z（UTC 已跨到周五）
+    # 于是误跑了一次周度反思，周五那班被推到 08-29T00:02Z（UTC 已跨到周六）于是整周静默
+    # 跳过。触发时刻记下的 cron 表达式不受延迟影响。
+    - cron: "30 15 * * 5"
   workflow_dispatch:
     inputs:
       formal_dynamic_approved:
@@ -58,8 +64,12 @@ jobs:
 
       - name: Decide whether to run weekly strategy reflection
         id: reflection_policy
+        env:
+          # github.event.schedule 是「触发这次 run 的那条 cron 表达式」，在排队时刻就定下来了，
+          # 后面延迟多久都不会变。原先这里读 date -u +%u，等于把周几绑在队列延迟上。
+          TRIGGER_CRON: ${{ github.event.schedule }}
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "$(date -u +%u)" = "5" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${TRIGGER_CRON}" = "30 15 * * 5" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/tests/test_ci_policy_gates.py
+++ b/tests/test_ci_policy_gates.py
@@ -155,7 +155,7 @@ def test_weekly_reflection_gate_reads_trigger_cron_not_wall_clock():
     """
     workflow = Path(".github/workflows/signal_feedback.yml").read_text(encoding="utf-8")
 
-    assert '$(date -u +%u)' not in workflow
+    assert "$(date -u +%u)" not in workflow
     assert 'cron: "30 15 * * 1-4"' in workflow
     assert 'cron: "30 15 * * 5"' in workflow
     assert "TRIGGER_CRON: ${{ github.event.schedule }}" in workflow

--- a/tests/test_ci_policy_gates.py
+++ b/tests/test_ci_policy_gates.py
@@ -140,6 +140,28 @@ def test_ci_runs_python_suite_once_and_reuses_it_for_coverage():
     assert "name: coverage-report-${{ github.run_number }}" in workflow
 
 
+def test_weekly_reflection_gate_reads_trigger_cron_not_wall_clock():
+    """周度反思的「今天是不是周五」只能看哪条 cron 触发，不能在步骤里读 date -u。
+
+    原先这里是 ``[ "$(date -u +%u)" = "5" ]``，把周几绑在了 GitHub 的排队延迟上。实测
+    同一周里两头都错了：周四那班 cron 被推到 2026-08-28T00:29Z（UTC 已跨到周五），
+    ``date -u +%u`` 读成 5，于是多跑了一次周度反思；周五那班被推到 2026-08-29T00:02Z
+    （UTC 已跨到周六）读成 6，run 33222336351 的 ``Refresh weekly strategy reflection``
+    被标成 skipped，整周静默丢了一轮。近期 run 起始时间已经从 15:48Z 漂到 18:48~20:56Z，
+    延迟是常态而不是偶发。
+
+    ``github.event.schedule`` 记的是排队那一刻的 cron 表达式，延迟多久都不变，所以周五
+    单独拆一条 cron、按表达式判断才是与调度意图同源的写法。
+    """
+    workflow = Path(".github/workflows/signal_feedback.yml").read_text(encoding="utf-8")
+
+    assert '$(date -u +%u)' not in workflow
+    assert 'cron: "30 15 * * 1-4"' in workflow
+    assert 'cron: "30 15 * * 5"' in workflow
+    assert "TRIGGER_CRON: ${{ github.event.schedule }}" in workflow
+    assert '[ "${TRIGGER_CRON}" = "30 15 * * 5" ]' in workflow
+
+
 def test_review_shadow_backtest_collects_traces_from_failed_funnel_runs_too():
     """影子回测按样本天数攒 trace，不能按 conclusion 过滤掉失败的漏斗运行。
 


### PR DESCRIPTION
## 变更摘要

`signal_feedback.yml` 的周度策略反思用 `[ "$(date -u +%u)" = "5" ]` 判断今天是不是周五，这个值在步骤执行那一刻才取。GitHub 的 schedule 排队延迟经常几小时（近期 run 起始时间已从 15:48Z 漂到 18:48~20:56Z），于是同一周里两头都错：

| cron 档位 | 实际起始 (UTC) | 延迟 | `date -u +%u` | 反思步骤 |
|---|---|---|---|---|
| 周四 15:30 | 2026-08-28T00:29 | +9.0h | 5 | **success**（多跑了不属于它的一轮） |
| 周五 15:30 | 2026-08-29T00:02 | +8.5h | 6 | **skipped**（本该跑的一轮丢了） |

两条都是 `gh run view` 的实测步骤结论，不是从时间戳推的。后果是 `strategy_reflections` / `strategy_policy_candidates` 停在 `as_of 2026-08-28`，此后 08-29、08-31、09-01、09-02、09-03 五次 cron 全部 success 而反思一次没跑，日志层面完全看不出异常。

改法:周五单独拆一条 cron，闸门按 `github.event.schedule`（排队那一刻记下的 cron 表达式，延迟多久都不变）判断，与调度意图同源。手动 `workflow_dispatch` 仍然放行，周一到周四那条只刷新信号反馈，时间点没动。

顺带说明一件容易混淆的事:这批反思行的 `summary.shadow.run_count` 一直是 0、`reflection_text` 写着 `Shadow runs=0, avg_added=0.0, avg_removed=0.0. Keep candidate in review; do not auto-promote.`，那是影子账本在 `on` 档不记账造成的（见 #381），与本次调度问题是两条独立的因。#381 合了以后这里的 `run_count` 才会有真数。

## 验证

- 新增 `test_weekly_reflection_gate_reads_trigger_cron_not_wall_clock`,在旧闸门上 FAIL、修复后 PASS（已实测两侧)
- `pytest tests/` 4636 passed / 22 skipped
- `scripts/check_workflow_hygiene.py` PASS,`scripts/quality_gate.py --check-no-sql` OK,ruff clean
- `yaml.safe_load` 确认两条 cron 解析正常、步骤 `if` 条件不变