### PR TITLE
feat(eval): 风格择时体检做成常驻模块,胜率口径没过月内置换

### DIFF
--- a/.github/workflows/regime_forward_eval.yml
+++ b/.github/workflows/regime_forward_eval.yml
@@ -56,10 +56,21 @@ jobs:
             --horizon "${{ github.event.inputs.horizon || '5' }}" \
             --index "${{ github.event.inputs.index || '000001' }}"
 
+      # 定时跑连续两次(08-22、08-29)都只留下 ##[warning]No files were found,
+      # 手动 dispatch 却每次都有产物 —— 同一份 workflow、同一条已解析命令
+      # (--horizon "5")、脚本本地跑必写文件。机制没查清,先让它响:
+      # warn 会把「每月重跑看跨周期稳定」的证据静默丢掉,error 至少下一次定时跑就暴露。
+      - name: Verify evidence written
+        if: always()
+        run: |
+          ls -la docs/evidence/ || echo "docs/evidence 不存在"
+          test -n "$(find docs/evidence -name 'regime_forward_h*.json' -print -quit 2>/dev/null)" \
+            || { echo "::error::报告未落盘,证据会丢失"; exit 1; }
+
       - name: Upload evidence
         uses: actions/upload-artifact@v7
         if: always()
         with:
           name: regime-forward-evidence
           path: docs/evidence/regime_forward_h*.json
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/.github/workflows/style_timing_eval.yml
+++ b/.github/workflows/style_timing_eval.yml
@@ -1,0 +1,92 @@
+name: Style Timing Evaluation
+
+# 风格择时体检:池子自己的近期强弱能不能预测池子接下来的表现。
+# 起因:入池与池内排序两层都已证实无增量(月级 t=+1.03 / 6-6 落随机带内),
+# 择时这条线上只有「池子近 5 日强弱」活下来,而且只在收益口径上活。
+# 单轮 69 天 4 个月说不了话,所以每月重跑一次看能否跨周期稳定,再谈动不动生产开关。
+#
+# 三个口径都要跑:T+5 收益、T+10 收益、先触碰胜率。胜率口径当前没过月内置换
+# (p=0.281),而胜率是第一优先级 —— 它恰恰是最需要攒样本看会不会转正的那个。
+on:
+  schedule:
+    # UTC 每月 3 日 02:17 = 北京时间 10:17。避开整点与 :00/:30,别和别的任务挤。
+    # 取 3 日:上月数据已收全,且前瞻窗口对上月末几天也已凑齐。
+    - cron: "17 2 3 * *"
+  workflow_dispatch:
+    inputs:
+      start:
+        description: "起始日期 YYYY-MM-DD,留空取全部"
+        default: ""
+
+concurrency:
+  group: style-timing-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    # 逐只取价约 1 只/秒,单口径 2372 只约 40 分钟,三个口径顺序跑要 2 小时出头。
+    # 不并行:三个 job 同时打同一个数据源(tickflow/tushare)容易触发限流,
+    # 而限流的表现是「部分标的取空」——那会静默改变样本构成,比跑得慢危险得多。
+    timeout-minutes: 300
+    env:
+      PYTHONUNBUFFERED: "1"
+      # 只读 signal_outcomes 与行情,不写库;故不设 WYCKOFF_WRITE_CONTEXT。
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      TZ: Asia/Shanghai
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      # 收益口径两个 horizon 各推一次;胜率口径只推一次(它不依赖 horizon)。
+      - name: Evaluate T+5 forward return
+        run: |
+          python scripts/evaluate_style_timing.py --horizon 5 \
+            ${{ github.event.inputs.start && format('--start {0}', github.event.inputs.start) || '' }}
+
+      - name: Evaluate T+10 forward return
+        run: |
+          python scripts/evaluate_style_timing.py --horizon 10 \
+            ${{ github.event.inputs.start && format('--start {0}', github.event.inputs.start) || '' }}
+
+      # 胜率是第一优先级的口径,但它当前没过月内置换。--no-notify:三条推送太吵,
+      # 结论看产物即可;真要盯的是它哪个月开始过置换。
+      - name: Evaluate first-touch win rate
+        run: |
+          python scripts/evaluate_style_timing.py --value win --no-notify \
+            ${{ github.event.inputs.start && format('--start {0}', github.event.inputs.start) || '' }}
+
+      # 从第一天就用 error,不用 warn。姊妹 workflow(regime_forward_eval)因为 warn,
+      # 连续两次定时跑什么都没留下却显示成功,藏了两周。
+      - name: Verify evidence written
+        if: always()
+        run: |
+          ls -la docs/evidence/ || echo "docs/evidence 不存在"
+          for f in style_timing_h5_forward.json style_timing_h10_forward.json style_timing_win.json; do
+            test -f "docs/evidence/$f" || { echo "::error::$f 未落盘,证据会丢失"; exit 1; }
+          done
+
+      - name: Upload evidence
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: style-timing-evidence
+          path: docs/evidence/style_timing_*.json
+          if-no-files-found: error

--- a/core/style_timing_eval.py
+++ b/core/style_timing_eval.py
@@ -1,0 +1,438 @@
+"""风格择时体检：池子自己的近期强弱,能不能预测池子接下来的表现。
+
+起因:2026-09-05 把「选票」这条线量到底,两层都是噪声——
+
+1. **池内排序无增量。** 推荐相对同规模池内随机子集,6 种灵活离场阈值(+3/-3/10日 …
+   +5/-8/15日)**6/6 全落在随机带内**。且没有一档到 50%,区间 33.1%~40.6%,
+   其中最高的 40.6% 来自 +5/-8 这种松止损——机械地用「亏更多」换「赢更频」,不是本事。
+2. **入池相对市场按月翻号。** 卡钳匹配后 05 +19.2 / 06 +17.5 / 07 -5.7 / 08 -5.4 / 09 +2.1,
+   月级 t=+1.03、正号 3/5。月内 |t| 高达 7 是因为同一批约 150 只票每天重抽,天与天不独立。
+
+选票不动的话,剩下能动的只有择时。于是把三个候选放进同一套对照,**只有一个活下来**:
+
+    池子近 5 日强弱     收益口径过全部对照;胜率口径没过月内置换   ← 活(仅收益口径)
+    池子近 20 日强弱    全样本看着更强,剔掉 7 月只剩零头          ← 死
+    水温 benchmark_regime  环移对照后全部落回区间内                ← 死
+
+**一、活下来的那条,是风格择时而不是市场择时。** 按池子当日成分近 5 日已实现涨跌切三档
+(69/64/73 天,取决于口径需要多少前瞻天):
+
+    T+5 收益     弱档 -5.04%  强档 -0.58%  差 +4.46pct  相位 t=+4.82(5/5) 置换 p=0.025
+    T+10 收益    弱档 -10.38% 强档 -0.86%  差 +9.52pct  相位 t=+2.50(7/10) 置换 p=0.001
+    先触碰胜率   弱档 36.3%   强档 42.9%   差 +6.62pct  相位 t=+2.04(11/15) 置换 p=0.281
+
+两道市场对照都没跟上:同一条规则套在**非池子市场股票**上(信号侧),T+5 只剩 +0.68pct;
+按**池子**强弱切档去量**市场**的前瞻(前瞻侧),方向还相反(-1.83pct)。
+所以量到的不是"大盘什么时候好"。留一月 4/4 不翻号、逐月独立分位 3/3 同向。
+
+**二、但胜率口径没过月内置换,而胜率是第一优先级。** p=0.281 落在带内——它的价差
+基本是月份效应,不是"强弱"本身在说话(逐月 2/3,7 月为负)。收益口径过(p=0.025 / 0.001)。
+所以现在能说的是"强弱能预测**亏多少**",还不能说"能预测**赢不赢**"。
+
+**三、最好的情况也只是少亏,不是赚。** 强档 T+10 是 **-0.86%**、胜率 **42.9%**,
+距 50% 还差 7.1pct;同区间基准 -5.58%。这条信号把 -10.38% 挪到 -0.86%,没把负变正。
+所以它的用法是"什么时候干脆别在里面",不是"什么时候加仓"。
+
+**上表来自一次性脚本的数据复现。**首轮跑通 ``scripts/evaluate_style_timing.py``
+(取 ``signal_outcomes`` 全池 1972 只、评估区间 2026-05-25~2026-08-28、69 天 4 个月)
+得 T+5 弱档 -5.12% / 强档 -0.53% / 差 **+4.58pct**、相位 t=+5.40(5/5)、置换 p=0.027,
+方向与量级一致。两边池子成分口径不完全相同,以驱动脚本的产物为准;每月重跑会覆盖这些数,
+**引用前先看 JSON 里的 eval_window**。另注 ``min_retention`` 只有 0.385,
+刚过 0.35 的门槛——这条结论在"剔掉某一个月"这个轴上并不宽裕。
+
+**注:前瞻窗口不做截断。** 早先的一次性脚本用 ``j = min(i + h, len(s) - 1)`` 取前瞻,
+尾部几天实际只持有了不到 h 天却仍记作 T+h,把 73 天凑齐的同时混进了短窗口。
+这里改成"凑不齐 h 天就丢掉这天",于是 T+5 得 69 天、T+10 得 64 天,
+数也随之变了(T+5 +4.64→+4.46,T+10 +6.59→+9.52)。宁可少几天,不要混口径。
+
+**四、水温标签对池子没有方向性,先前看着有是月份混淆。** 随机抽日时 NEUTRAL 偏差
+(-11.01% vs 基准 -5.32%)、BEAR_REBOUND 偏好(+0.39%),都"超出随机"。但水温是成片
+出现的,随机抽日打散了连片结构、低估方差。换**环移对照**(整条标签序列相对日期平移,
+run 长度与每档开启率精确保留)后:NEUTRAL p=0.074、BEAR_REBOUND p=0.132、
+RISK_OFF p=0.412、CRASH p=0.294,**全部落回区间内**。真因是 NEUTRAL 的 13 天里 8 天
+压在 7 月、BEAR_REBOUND 的 10 天里 9 天压在 8 月。
+
+注意这与 ``regime_forward_eval`` 不冲突:那里量的是**指数**前瞻(CRASH 标底部,方向被
+生产用反了),这里量的是**池子**前瞻。水温能说市场,不能说这个风格。
+
+**五、回看 20 日是「避开 2026-07」的伪装,而三点网格上的形状本身就该起疑。**
+全样本比 5 日更"显著",但留一月剔掉 7 月后只剩零头:``min_retention`` 只有 0.12,
+即剔掉某一个月后幅度只剩全样本的 12%。逐月是 -2.01 / **-21.25** / -1.75——
+一个月撑起全部。而且 5/10/20 日三档上**两端反号、中间无信息**,
+这是小网格上读噪声的典型形状。先看形状,再看 p。
+
+**判定链的顺序是有意的。** 样本不足 → 单月撑起 → 月内置换 → 市场对照 → 相位 t。
+把 t 放最后,是因为 t 最容易被非独立样本抬起来:测试里那个纯噪声用例相位 |t| 高达 5.8,
+只有月内置换挡得住它。所以"|t| 很大"从来不是放行理由。
+
+**置换的 outside 与 p_value 必须同源。** 首轮真实数据上出过一次:``outside`` 当时按
+"有符号 2.5/97.5 分位带"判、``p_value`` 按"双侧绝对值"算,零分布一偏两者就打架——
+报告里于是出现「置换 p=0.03」配「落在带内,无信息」,而判定读的是 ``outside``,
+把唯一活着的那档误杀了。现在 ``outside`` 直接由 ``p_value < 0.05`` 定义,
+``band`` 只作展示(看零分布宽度仍有用)。同一个量有两套算法,迟早会在边界上不一致。
+
+所以本轮**没有改任何生产开关**:不到 4 个可用月,不够动闸门。这个体检固化下来,
+是为了让"下月重跑是否仍然成立"这件事有产物可比——而不是每次重新拍一遍脑袋。
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import asdict, dataclass, field
+from statistics import mean
+from typing import Any
+
+ROUND_TRIP_COST_PCT = 0.202
+
+# 一档至少这么多天才给判定，否则明确返回样本不足。
+# 「不足 20 天不下判定」是尚未可知，不是对照未通过——两者不能混。
+MIN_DAYS = 9
+# 逐月独立分位要求月内至少这么多天（三等分后每档 >= 3）。
+MIN_MONTH_DAYS = 9
+# 一天至少这么多只票才算这天可用，避免单票噪声进日均。
+MIN_NAMES_PER_DAY = 3
+# 市场对照每天至少这么多只，口径比池子严：它是用来否定的，不能自己先不稳。
+MIN_MARKET_NAMES = 30
+TRAIL_WINDOWS = (5, 10, 20)
+
+
+def tstat(values: list[float]) -> float | None:
+    """手工单样本 t。环境无 scipy。"""
+    clean = [float(v) for v in values if v is not None and math.isfinite(float(v))]
+    if len(clean) < 3:
+        return None
+    avg = sum(clean) / len(clean)
+    var = sum((v - avg) ** 2 for v in clean) / (len(clean) - 1)
+    if var <= 0:
+        return None
+    return avg / math.sqrt(var / len(clean))
+
+
+def _round(value: float | None, digits: int = 4) -> float | None:
+    return None if value is None else round(float(value), digits)
+
+
+@dataclass
+class SpreadStat:
+    """一次「强档减弱档」的估计。"""
+
+    label: str
+    days: int
+    weak: float | None
+    strong: float | None
+    spread: float | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "days": self.days,
+            "weak": _round(self.weak),
+            "strong": _round(self.strong),
+            "spread": _round(self.spread),
+        }
+
+
+@dataclass
+class DayRow:
+    """一个交易日的池子聚合观测。
+
+    trail 是**当日回看**的已实现涨跌(不含未来),forward 是当日进、持有 H 日的前瞻。
+    两者都按当日池子成分逐只算再取均值——不是拿一条池子指数,因为成分每天在换。
+    """
+
+    date: str
+    pool_trail: dict[int, float | None]
+    pool_forward: float | None
+    pool_win: float | None
+    n_pool: int
+    market_trail: dict[int, float | None] = field(default_factory=dict)
+    market_forward: float | None = None
+    market_win: float | None = None
+    n_market: int = 0
+
+    @property
+    def month(self) -> str:
+        return self.date[:7]
+
+
+def _terciles(pairs: list[tuple[float, float]]) -> tuple[list[float], list[float]]:
+    """按 key 升序三等分,返回(弱档值, 强档值)。中间档丢弃——只比两端。"""
+    ordered = sorted(pairs, key=lambda kv: kv[0])
+    cut = len(ordered) // 3
+    if cut < 1:
+        return [], []
+    return [v for _, v in ordered[:cut]], [v for _, v in ordered[-cut:]]
+
+
+def _spread(pairs: list[tuple[float, float]], label: str) -> SpreadStat:
+    weak, strong = _terciles(pairs)
+    if not weak or not strong:
+        return SpreadStat(label=label, days=len(pairs), weak=None, strong=None, spread=None)
+    w, s = mean(weak), mean(strong)
+    return SpreadStat(label=label, days=len(pairs), weak=w, strong=s, spread=s - w)
+
+
+def _pairs(
+    rows: list[DayRow],
+    window: int,
+    value: str,
+    *,
+    key_side: str = "pool",
+    value_side: str = "pool",
+) -> list[tuple[float, float]]:
+    """取出(切档键, 被测值)。任一为空就整天丢掉,不做插补。
+
+    key_side / value_side 可以分别取 pool 或 market,四种组合各答一个问题:
+
+        pool  → pool    主结果:池子强弱能不能预测池子
+        market→ market  信号侧对照:同一条规则套在市场上还成不成立
+        pool  → market  前瞻侧对照:池子强的日子,整个市场是不是也好
+        market→ pool    (未用)
+    """
+    out: list[tuple[float, float]] = []
+    for row in rows:
+        if key_side == "market":
+            key = row.market_trail.get(window)
+        else:
+            key = row.pool_trail.get(window)
+        if value_side == "market":
+            val = row.market_forward if value == "forward" else row.market_win
+        else:
+            val = row.pool_forward if value == "forward" else row.pool_win
+        if "market" in (key_side, value_side) and row.n_market < MIN_MARKET_NAMES:
+            continue
+        if "pool" in (key_side, value_side) and row.n_pool < MIN_NAMES_PER_DAY:
+            continue
+        if key is None or val is None:
+            continue
+        out.append((float(key), float(val)))
+    return out
+
+
+def _phase_scan(rows: list[DayRow], window: int, value: str, stride: int) -> dict[str, Any]:
+    """每 stride 天取一天,扫遍所有相位。
+
+    相邻交易日共用大部分前瞻窗口,天与天不独立,直接用全样本会把显著性抬高。
+    只报一个相位就是挑选,所以扫全并给相位间的 t。
+
+    stride 必须取**被测值自己的窗口长度**:前瞻收益取 horizon,先触碰胜率取
+    max_hold(它最长能拖到那么久)。取小了窗口仍然重叠,独立性是假的。
+    """
+    spreads: list[float] = []
+    for phase in range(max(1, stride)):
+        sub = rows[phase :: max(1, stride)]
+        stat = _spread(_pairs(sub, window, value), f"phase{phase}")
+        if stat.spread is not None:
+            spreads.append(stat.spread)
+    if not spreads:
+        return {"phases": 0, "mean": None, "t": None, "positive": None}
+    return {
+        "phases": len(spreads),
+        "spreads": [_round(v) for v in spreads],
+        "mean": _round(mean(spreads)),
+        "t": _round(tstat(spreads), 3),
+        "positive": f"{sum(1 for v in spreads if v > 0)}/{len(spreads)}",
+    }
+
+
+def _leave_one_month_out(rows: list[DayRow], window: int, value: str) -> dict[str, Any]:
+    """逐月剔除后重估。一个月撑起全部的结论,剔掉它就会塌——20 日回看就是这么死的。"""
+    months = sorted({r.month for r in rows})
+    if len(months) < 3:
+        return {"months": len(months), "verdict": "月份不足,不做留一月"}
+    out: dict[str, float | None] = {}
+    for drop in months:
+        stat = _spread(_pairs([r for r in rows if r.month != drop], window, value), f"drop_{drop}")
+        out[drop] = _round(stat.spread)
+    kept = [v for v in out.values() if v is not None]
+    full = _spread(_pairs(rows, window, value), "full").spread
+    # 符号一致性要对齐全样本方向：全样本为负时,「全部为负」才叫没翻号。
+    ref = 1.0 if (full or 0.0) >= 0 else -1.0
+    return {
+        "months": len(months),
+        "without": out,
+        "positive": f"{sum(1 for v in kept if v > 0)}/{len(kept)}" if kept else None,
+        "same_sign": f"{sum(1 for v in kept if v * ref > 0)}/{len(kept)}" if kept else None,
+        # 剔掉任一月后剩余幅度的最小绝对值 / 全样本幅度。接近 0 = 单月撑起全部。
+        "min_retention": _round(min(abs(v) for v in kept) / abs(full) if kept and full else None, 3),
+    }
+
+
+def _within_month(rows: list[DayRow], window: int, value: str) -> dict[str, Any]:
+    """月内独立切档。跨月切档会把「哪个月好」读成「哪档好」。"""
+    bym: dict[str, list[DayRow]] = {}
+    for row in rows:
+        bym.setdefault(row.month, []).append(row)
+    per: dict[str, float | None] = {}
+    for month, days in sorted(bym.items()):
+        if len(days) < MIN_MONTH_DAYS:
+            continue
+        stat = _spread(_pairs(days, window, value), month)
+        if stat.spread is not None:
+            per[month] = _round(stat.spread)
+    vals = [v for v in per.values() if v is not None]
+    return {
+        "per_month": per,
+        "mean": _round(mean(vals)) if vals else None,
+        "positive": f"{sum(1 for v in vals if v > 0)}/{len(vals)}" if vals else None,
+    }
+
+
+def _month_block_permutation(rows: list[DayRow], window: int, value: str, draws: int = 2000) -> dict[str, Any]:
+    """月内打乱切档键。
+
+    保留每天归属哪个月、也保留被测值本身,只把「这天算强还是算弱」在月内重排。
+    这样随机带里已经含了月份效应,超出带才算池子强弱本身在说话。
+    """
+    pairs_by_month: dict[str, list[tuple[float, float]]] = {}
+    for row in rows:
+        if row.n_pool < MIN_NAMES_PER_DAY:
+            continue
+        key = row.pool_trail.get(window)
+        val = row.pool_forward if value == "forward" else row.pool_win
+        if key is None or val is None:
+            continue
+        pairs_by_month.setdefault(row.month, []).append((float(key), float(val)))
+    flat = [kv for lst in pairs_by_month.values() for kv in lst]
+    observed = _spread(flat, "observed").spread
+    if observed is None or len(flat) < MIN_DAYS:
+        return {"draws": 0, "observed": _round(observed), "verdict": "样本不足,不做置换"}
+    null: list[float] = []
+    for seed in range(draws):
+        rng = random.Random(seed)
+        shuffled: list[tuple[float, float]] = []
+        for lst in pairs_by_month.values():
+            keys = [k for k, _ in lst]
+            rng.shuffle(keys)
+            shuffled.extend((k, v) for k, (_, v) in zip(keys, lst))
+        got = _spread(shuffled, "null").spread
+        if got is not None:
+            null.append(got)
+    if not null:
+        return {"draws": 0, "observed": _round(observed), "verdict": "置换未产出"}
+    ordered = sorted(null)
+    lo = ordered[int(0.025 * len(ordered))]
+    hi = ordered[min(len(ordered) - 1, int(0.975 * len(ordered)))]
+    tail = sum(1 for v in null if abs(v) >= abs(observed))
+    p_value = (tail + 1) / (len(null) + 1)
+    # outside 必须与 p_value 同源。早先用「有符号 2.5/97.5 分位带」判 outside、
+    # 却用「双侧绝对值」算 p,零分布一偏两者就会打架:实测 +4.58 落在带内、
+    # 而 p=0.03 —— 判定读的是 outside,于是报告里出现「p=0.03」配「带内,无信息」。
+    # 展示用的 band 保留(看零分布宽度有用),但不再参与判定。
+    return {
+        "draws": len(null),
+        "observed": _round(observed),
+        "band": [_round(lo), _round(hi)],
+        "p_value": _round(p_value, 4),
+        "outside": bool(p_value < 0.05),
+    }
+
+
+def _verdict(block: dict[str, Any]) -> str:
+    """判定。四种结果里「样本不足」是尚未可知,不能写成对照未通过。"""
+    full = block["full_sample"]["spread"]
+    if block["full_sample"]["days"] < MIN_DAYS or full is None:
+        return "样本不足,不下判定"
+
+    phase_t = block["phase_scan"].get("t")
+    lomo = block["leave_one_month_out"]
+    retention = lomo.get("min_retention")
+    if retention is not None and retention < 0.35:
+        return "单月撑起全部,不成立"
+
+    perm = block["month_block_permutation"]
+    if perm.get("outside") is False:
+        return "落在月内置换带内,无信息"
+
+    # 两道市场对照任一给出同量级同方向,就说明量到的是市场择时,不是风格择时。
+    for name in ("market_signal_control", "market_forward_control"):
+        got = block[name]["spread"]
+        if got is not None and full != 0 and got * full > 0 and abs(got) >= 0.5 * abs(full):
+            return f"{block[name]['label']}给出同量级,是市场择时不是风格择时"
+
+    if phase_t is None:
+        return "相位不足,证据不完整"
+    # 留一月要求每一次剔除后符号都不翻——翻了就说明结论依赖特定月份。
+    got, total = ((lomo.get("same_sign") or "0/0").split("/") + ["0"])[:2]
+    signs_ok = total not in ("0", "") and got == total
+    if abs(phase_t) >= 2.5 and signs_ok:
+        return "过全部对照"
+    return "方向一致但强度不足,继续累样本"
+
+
+@dataclass
+class StyleTimingReport:
+    horizon: int
+    value_kind: str
+    days: int
+    months: list[str]
+    eval_window: list[str]
+    baseline: float | None
+    stride: int = 0
+    windows: dict[str, Any] = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+
+
+def evaluate_style_timing(
+    rows: list[DayRow], horizon: int, value_kind: str = "forward", stride: int | None = None
+) -> StyleTimingReport:
+    """把一批日观测跑成一份体检。value_kind: forward=前瞻收益, win=先触碰胜率。
+
+    stride 是不重叠抽样的步长,不传则按 horizon。胜率口径必须显式传 max_hold——
+    先触碰能拖到 max_hold 天,用 horizon 当步长窗口仍然重叠。
+    """
+    usable = [
+        r
+        for r in rows
+        if r.n_pool >= MIN_NAMES_PER_DAY and (r.pool_forward if value_kind == "forward" else r.pool_win) is not None
+    ]
+    usable.sort(key=lambda r: r.date)
+    base_vals = [
+        float(r.pool_forward if value_kind == "forward" else r.pool_win)  # type: ignore[arg-type]
+        for r in usable
+    ]
+    report = StyleTimingReport(
+        horizon=horizon,
+        value_kind=value_kind,
+        days=len(usable),
+        months=sorted({r.month for r in usable}),
+        # 只信产物里的 eval_window：预热吃掉的天数会让 --start 骗人。
+        eval_window=[usable[0].date, usable[-1].date] if usable else [],
+        baseline=_round(mean(base_vals)) if base_vals else None,
+    )
+    step = stride if stride and stride > 0 else horizon
+    report.stride = step
+    for window in TRAIL_WINDOWS:
+        block: dict[str, Any] = {
+            "full_sample": _spread(_pairs(usable, window, value_kind), f"trail{window}").as_dict(),
+            "phase_scan": _phase_scan(usable, window, value_kind, step),
+            "leave_one_month_out": _leave_one_month_out(usable, window, value_kind),
+            "within_month": _within_month(usable, window, value_kind),
+            "month_block_permutation": _month_block_permutation(usable, window, value_kind),
+            # 同一条规则套在市场上还成不成立。成立就说明这不是风格特有的。
+            "market_signal_control": _spread(
+                _pairs(usable, window, value_kind, key_side="market", value_side="market"),
+                "信号侧市场对照",
+            ).as_dict(),
+            # 池子强的日子,整个市场是不是也好。也好就说明量到的是大盘。
+            "market_forward_control": _spread(
+                _pairs(usable, window, value_kind, key_side="pool", value_side="market"),
+                "前瞻侧市场对照",
+            ).as_dict(),
+        }
+        block["verdict"] = _verdict(block)
+        report.windows[f"trail{window}"] = block
+
+    if report.days < 100:
+        report.notes.append(f"样本 {report.days} 天 / {len(report.months)} 个月,不足以改任何生产开关;本轮只做累积。")
+    strong = report.windows.get("trail5", {}).get("full_sample", {}).get("strong")
+    if strong is not None and value_kind == "forward" and strong < 0:
+        report.notes.append(
+            f"强档绝对水平 {strong:+.2f}% 仍为负——这条信号是「什么时候别在里面」,不是「什么时候加仓」。"
+        )
+    return report
+
+
+def report_to_dict(report: StyleTimingReport) -> dict[str, Any]:
+    return asdict(report)

--- a/docs/evidence/style_timing_win.json
+++ b/docs/evidence/style_timing_win.json
@@ -1,0 +1,267 @@
+{
+  "horizon": 5,
+  "value_kind": "win",
+  "days": 73,
+  "months": [
+    "2026-05",
+    "2026-06",
+    "2026-07",
+    "2026-08",
+    "2026-09"
+  ],
+  "eval_window": [
+    "2026-05-25",
+    "2026-09-03"
+  ],
+  "baseline": 37.0012,
+  "stride": 15,
+  "windows": {
+    "trail5": {
+      "full_sample": {
+        "label": "trail5",
+        "days": 73,
+        "weak": 34.8443,
+        "strong": 41.5128,
+        "spread": 6.6685
+      },
+      "phase_scan": {
+        "phases": 15,
+        "spreads": [
+          38.8188,
+          9.4,
+          28.6747,
+          -5.4726,
+          -18.3221,
+          10.7772,
+          -29.46,
+          27.737,
+          15.0159,
+          -12.2491,
+          10.2932,
+          29.6675,
+          23.9496,
+          25.5767,
+          8.4524
+        ],
+        "mean": 10.8573,
+        "t": 2.135,
+        "positive": "11/15"
+      },
+      "leave_one_month_out": {
+        "months": 5,
+        "without": {
+          "2026-05": 8.46,
+          "2026-06": 5.2846,
+          "2026-07": 3.633,
+          "2026-08": 11.9348,
+          "2026-09": 7.1014
+        },
+        "positive": "5/5",
+        "same_sign": "5/5",
+        "min_retention": 0.545
+      },
+      "within_month": {
+        "per_month": {
+          "2026-06": 9.8408,
+          "2026-07": -2.8705,
+          "2026-08": 9.0649
+        },
+        "mean": 5.3451,
+        "positive": "2/3"
+      },
+      "month_block_permutation": {
+        "draws": 2000,
+        "observed": 6.6685,
+        "band": [
+          -0.9924,
+          11.1064
+        ],
+        "p_value": 0.2839,
+        "outside": false
+      },
+      "market_signal_control": {
+        "label": "信号侧市场对照",
+        "days": 73,
+        "weak": 49.1025,
+        "strong": 45.4158,
+        "spread": -3.6867
+      },
+      "market_forward_control": {
+        "label": "前瞻侧市场对照",
+        "days": 73,
+        "weak": 53.9389,
+        "strong": 32.0487,
+        "spread": -21.8902
+      },
+      "verdict": "落在月内置换带内,无信息"
+    },
+    "trail10": {
+      "full_sample": {
+        "label": "trail10",
+        "days": 73,
+        "weak": 35.6942,
+        "strong": 40.7003,
+        "spread": 5.006
+      },
+      "phase_scan": {
+        "phases": 15,
+        "spreads": [
+          37.9607,
+          21.6667,
+          28.6747,
+          -5.4726,
+          -18.3221,
+          10.7772,
+          -10.1299,
+          1.4539,
+          21.3185,
+          23.7645,
+          18.9959,
+          -17.7188,
+          5.7678,
+          -4.1938,
+          8.4524
+        ],
+        "mean": 8.1997,
+        "t": 1.85,
+        "positive": "10/15"
+      },
+      "leave_one_month_out": {
+        "months": 5,
+        "without": {
+          "2026-05": 7.075,
+          "2026-06": 2.3723,
+          "2026-07": 4.6855,
+          "2026-08": 10.6747,
+          "2026-09": 5.4168
+        },
+        "positive": "5/5",
+        "same_sign": "5/5",
+        "min_retention": 0.474
+      },
+      "within_month": {
+        "per_month": {
+          "2026-06": 11.9638,
+          "2026-07": -5.1544,
+          "2026-08": 2.6558
+        },
+        "mean": 3.1551,
+        "positive": "2/3"
+      },
+      "month_block_permutation": {
+        "draws": 2000,
+        "observed": 5.006,
+        "band": [
+          -1.277,
+          11.7414
+        ],
+        "p_value": 0.5352,
+        "outside": false
+      },
+      "market_signal_control": {
+        "label": "信号侧市场对照",
+        "days": 73,
+        "weak": 41.755,
+        "strong": 49.2226,
+        "spread": 7.4677
+      },
+      "market_forward_control": {
+        "label": "前瞻侧市场对照",
+        "days": 73,
+        "weak": 49.5381,
+        "strong": 35.3757,
+        "spread": -14.1624
+      },
+      "verdict": "落在月内置换带内,无信息"
+    },
+    "trail20": {
+      "full_sample": {
+        "label": "trail20",
+        "days": 73,
+        "weak": 39.7425,
+        "strong": 31.9172,
+        "spread": -7.8253
+      },
+      "phase_scan": {
+        "phases": 15,
+        "spreads": [
+          -0.8582,
+          17.5,
+          -21.0078,
+          -29.5105,
+          -5.6979,
+          28.1469,
+          -32.7931,
+          8.1325,
+          -26.0614,
+          39.9577,
+          -31.3196,
+          -17.7188,
+          -28.5047,
+          -37.4825,
+          -12.6665
+        ],
+        "mean": -9.9923,
+        "t": -1.615,
+        "positive": "4/15"
+      },
+      "leave_one_month_out": {
+        "months": 5,
+        "without": {
+          "2026-05": -7.2751,
+          "2026-06": -12.1788,
+          "2026-07": -2.1664,
+          "2026-08": -7.9531,
+          "2026-09": -7.6416
+        },
+        "positive": "0/5",
+        "same_sign": "5/5",
+        "min_retention": 0.277
+      },
+      "within_month": {
+        "per_month": {
+          "2026-06": 3.4529,
+          "2026-07": -9.797,
+          "2026-08": -7.8281
+        },
+        "mean": -4.7241,
+        "positive": "1/3"
+      },
+      "month_block_permutation": {
+        "draws": 2000,
+        "observed": -7.8253,
+        "band": [
+          -12.4432,
+          1.3888
+        ],
+        "p_value": 0.2724,
+        "outside": false
+      },
+      "market_signal_control": {
+        "label": "信号侧市场对照",
+        "days": 73,
+        "weak": 44.7035,
+        "strong": 50.7622,
+        "spread": 6.0587
+      },
+      "market_forward_control": {
+        "label": "前瞻侧市场对照",
+        "days": 73,
+        "weak": 41.106,
+        "strong": 41.5193,
+        "spread": 0.4133
+      },
+      "verdict": "单月撑起全部,不成立"
+    }
+  },
+  "notes": [
+    "样本 73 天 / 5 个月,不足以改任何生产开关;本轮只做累积。"
+  ],
+  "params": {
+    "up": 5.0,
+    "down": 5.0,
+    "max_hold": 15,
+    "cost_pct": 0.202,
+    "market_sample": 400
+  }
+}

--- a/scripts/evaluate_style_timing.py
+++ b/scripts/evaluate_style_timing.py
@@ -1,0 +1,368 @@
+"""跑风格择时体检:池子自己的近期强弱能不能预测池子接下来的表现。
+
+结论与全部对照见 :mod:`core.style_timing_eval` 的模块 docstring。一句话:
+回看 5 日在**收益口径**上活下来(首轮实测 T+5 强-弱 +4.58pct、相位 t=+5.40、
+月内置换 p=0.027,区间 2026-05-25~2026-08-28),但**胜率口径没过月内置换**
+(p=0.281)——而胜率是第一优先级。回看 20 日是「避开 2026-07」的伪装,
+水温标签换环移对照后没有方向性。而且最好的情况也只是少亏:强档 T+5 仍是 -0.53%。
+
+**数会每月变,别把上面这几个当常量。**引用时读产物 JSON 里的 ``eval_window``。
+
+用法::
+
+    python scripts/evaluate_style_timing.py --horizon 5
+    python scripts/evaluate_style_timing.py --horizon 10 --value win
+    python scripts/evaluate_style_timing.py --no-notify   # 只出报告不推送
+
+**这是测量,不改任何生产开关。**69 天 / 4 个可用月不足以动闸门;每月重跑一次,
+看结论能否跨周期稳定,是它存在的唯一理由。
+
+**跑一轮约 40 分钟**:池子 1972 只 + 市场对照 400 只,逐只取价,约 1 只/秒。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+from collections import defaultdict
+from datetime import date, timedelta
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from core.style_timing_eval import (
+    ROUND_TRIP_COST_PCT,
+    TRAIL_WINDOWS,
+    DayRow,
+    evaluate_style_timing,
+    report_to_dict,
+)
+
+# docs/evidence 而非 artifacts/——后者在 .gitignore 里,CI 的 upload-artifact
+# 按路径匹配不到文件,证据会静默丢失。
+EVIDENCE_DIR = Path("docs/evidence")
+# 市场对照的取样数。全市场逐只拉价太慢,固定种子抽样即可——它只用来否定。
+MARKET_SAMPLE = 400
+MARKET_SEED = 7
+# 回看最长 20 日 + 前瞻最长 15 日,两头都要留够,否则边界日会被静默丢掉。
+LOOKBACK_PAD_DAYS = 60
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="池子近期强弱的择时体检")
+    parser.add_argument("--horizon", type=int, default=5, help="前瞻交易日数")
+    parser.add_argument(
+        "--value",
+        default="forward",
+        choices=["forward", "win"],
+        help="forward=前瞻收益均值, win=先触碰胜率",
+    )
+    parser.add_argument("--start", default="", help="起始日期,默认取 signal_outcomes 最早一天")
+    parser.add_argument("--up", type=float, default=5.0, help="先触碰口径的止盈幅度")
+    parser.add_argument("--down", type=float, default=5.0, help="先触碰口径的止损幅度")
+    parser.add_argument("--max-hold", type=int, default=15, help="先触碰口径的最长持有交易日")
+    parser.add_argument("--no-notify", action="store_true", help="不推送飞书")
+    parser.add_argument("--out", default=str(EVIDENCE_DIR), help="报告输出目录")
+    return parser.parse_args()
+
+
+def _d8(value: object) -> str:
+    """把 20260901 与 2026-09-01 统一成后者。"""
+    s = str(value or "")
+    return f"{s[:4]}-{s[4:6]}-{s[6:8]}" if len(s) == 8 and s.isdigit() else s
+
+
+def _sfx(code: object) -> str:
+    """补后缀。zfill(6) 是必需的:部分表把代码存成数字,000100 会读回成 100。"""
+    cd = str(code or "").split(".")[0].strip().zfill(6)
+    if cd[:1] == "6":
+        return f"{cd}.SH"
+    return f"{cd}.SZ" if cd[:1] in "03" else f"{cd}.BJ"
+
+
+def load_pool_by_day(start: str) -> dict[str, list[str]]:
+    """signal_outcomes 逐日的池子成分。"""
+    from integrations.supabase_base import create_admin_client, is_admin_configured
+
+    if not is_admin_configured():
+        raise SystemExit("需要 SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY")
+    client = create_admin_client()
+    rows: list[dict] = []
+    offset, page = 0, 1000
+    while True:
+        # 单页静默截断在 1000 行,必须翻页。
+        chunk = (
+            client.table("signal_outcomes")
+            .select("trade_date,code")
+            .order("trade_date")
+            .range(offset, offset + page - 1)
+            .execute()
+            .data
+            or []
+        )
+        rows.extend(chunk)
+        if len(chunk) < page:
+            break
+        offset += page
+    pool: dict[str, set[str]] = defaultdict(set)
+    for row in rows:
+        trade_date, code = _d8(row.get("trade_date")), row.get("code")
+        if trade_date and code and (not start or trade_date >= start):
+            pool[trade_date].add(_sfx(code))
+    return {d: sorted(v) for d, v in pool.items() if v}
+
+
+def load_closes(symbols: list[str], start: str, end: str) -> dict[str, list[tuple[str, float]]]:
+    """逐只拉收盘,按日期升序。取不到的票直接跳过,不插补。"""
+    from integrations.stock_hist_repository import get_stock_hist
+
+    series: dict[str, list[tuple[str, float]]] = {}
+    for i, symbol in enumerate(symbols, 1):
+        try:
+            frame = get_stock_hist(symbol, start, end)
+        except Exception as exc:  # 单票失败不该让整轮体检停下
+            print(f"  [skip] {symbol}: {exc}")
+            continue
+        if frame is None or frame.empty or "收盘" not in frame.columns:
+            continue
+        date_col = "日期" if "日期" in frame.columns else frame.columns[0]
+        items: list[tuple[str, float]] = []
+        for _, row in frame.iterrows():
+            close = row.get("收盘")
+            try:
+                value = float(close)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                items.append((str(row.get(date_col))[:10], value))
+        if items:
+            series[symbol] = sorted(items)
+        if i % 100 == 0:
+            print(f"  取价进度 {i}/{len(symbols)}")
+    return series
+
+
+class Prices:
+    """收盘序列 + 日期到下标的映射。回看与前瞻都按交易日下标走,不按日历天。"""
+
+    def __init__(self, series: dict[str, list[tuple[str, float]]]) -> None:
+        self.series = series
+        self.posn = {sym: {d: i for i, (d, _) in enumerate(items)} for sym, items in series.items()}
+
+    def trail(self, symbol: str, day: str, window: int) -> float | None:
+        """当日回看 window 个交易日的已实现涨跌。不含未来信息。"""
+        items = self.series.get(symbol)
+        idx = self.posn.get(symbol, {}).get(day)
+        if not items or idx is None or idx - window < 0:
+            return None
+        prev, now = items[idx - window][1], items[idx][1]
+        return (now - prev) / prev * 100.0 if prev > 0 else None
+
+    def forward(self, symbol: str, day: str, horizon: int) -> float | None:
+        """当日进、持有 horizon 个交易日的收益,已扣双边成本。"""
+        items = self.series.get(symbol)
+        idx = self.posn.get(symbol, {}).get(day)
+        if not items or idx is None or idx + horizon >= len(items):
+            return None
+        entry = items[idx][1]
+        if entry <= 0:
+            return None
+        return (items[idx + horizon][1] - entry) / entry * 100.0 - ROUND_TRIP_COST_PCT
+
+    def first_touch(self, symbol: str, day: str, up: float, down: float, max_hold: int) -> float | None:
+        """先触碰口径:先摸到 +up 记赢,先摸到 -down 记亏,都没摸到按末日正负判。
+
+        用收盘判,不是盘中最高最低——手上只有收盘价,拿 high/low 会高估触发率。
+        """
+        items = self.series.get(symbol)
+        idx = self.posn.get(symbol, {}).get(day)
+        if not items or idx is None or idx + 1 >= len(items) or items[idx][1] <= 0:
+            return None
+        entry = items[idx][1]
+        end = min(idx + max_hold, len(items) - 1)
+        if end <= idx:
+            return None
+        for j in range(idx + 1, end + 1):
+            ret = (items[j][1] - entry) / entry * 100.0 - ROUND_TRIP_COST_PCT
+            if ret >= up:
+                return 1.0
+            if ret <= -down:
+                return 0.0
+        return 1.0 if (items[end][1] - entry) / entry * 100.0 - ROUND_TRIP_COST_PCT > 0 else 0.0
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def build_rows(
+    pool: dict[str, list[str]],
+    prices: Prices,
+    market: list[str],
+    args: argparse.Namespace,
+) -> list[DayRow]:
+    """逐日聚合。池子成分每天在换,所以逐只算完再取当日均值,不能拿一条池子指数。"""
+    rows: list[DayRow] = []
+    for day in sorted(pool):
+        members = pool[day]
+        pool_trail: dict[int, float | None] = {}
+        market_trail: dict[int, float | None] = {}
+        for window in TRAIL_WINDOWS:
+            pool_trail[window] = _mean([v for v in (prices.trail(s, day, window) for s in members) if v is not None])
+            market_trail[window] = _mean([v for v in (prices.trail(s, day, window) for s in market) if v is not None])
+        fwd = [v for v in (prices.forward(s, day, args.horizon) for s in members) if v is not None]
+        win = [
+            v for v in (prices.first_touch(s, day, args.up, args.down, args.max_hold) for s in members) if v is not None
+        ]
+        mkt_fwd = [v for v in (prices.forward(s, day, args.horizon) for s in market) if v is not None]
+        mkt_win = [
+            v for v in (prices.first_touch(s, day, args.up, args.down, args.max_hold) for s in market) if v is not None
+        ]
+        rows.append(
+            DayRow(
+                date=day,
+                pool_trail=pool_trail,
+                pool_forward=_mean(fwd),
+                pool_win=(_mean(win) * 100.0) if win else None,
+                n_pool=len(fwd) if args.value == "forward" else len(win),
+                market_trail=market_trail,
+                market_forward=_mean(mkt_fwd),
+                market_win=(_mean(mkt_win) * 100.0) if mkt_win else None,
+                n_market=len(mkt_fwd) if args.value == "forward" else len(mkt_win),
+            )
+        )
+    return rows
+
+
+def render_markdown(payload: dict) -> str:
+    kind = "前瞻收益" if payload["value_kind"] == "forward" else "先触碰胜率"
+    unit = "%" if payload["value_kind"] == "forward" else "%"
+    window = payload.get("eval_window") or ["-", "-"]
+    lines = [
+        f"## 风格择时体检 T+{payload['horizon']} · {kind}",
+        "",
+        f"- 评估区间 **{window[0]} ~ {window[-1]}**,{payload['days']} 天 / "
+        f"{len(payload['months'])} 个月,不重叠步长 {payload.get('stride')} 天",
+        f"- 基准(任意一天进池子): **{payload['baseline']:+.2f}{unit}**"
+        if payload.get("baseline") is not None
+        else "- 基准: 无",
+        "",
+        "| 回看 | 弱档 | 强档 | 强-弱 | 相位 t | 留一月同号 | 月内独立 | 置换 p | 市场·信号侧 | 市场·前瞻侧 | 判定 |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for name, block in payload["windows"].items():
+        full = block["full_sample"]
+        phase = block["phase_scan"]
+        lomo = block["leave_one_month_out"]
+        within = block["within_month"]
+        perm = block["month_block_permutation"]
+        mkt_sig = block["market_signal_control"]
+        mkt_fwd = block["market_forward_control"]
+
+        def fmt(value: float | None, sign: bool = False) -> str:
+            if value is None:
+                return "-"
+            return f"{value:+.2f}" if sign else f"{value:.2f}"
+
+        lines.append(
+            f"| {name.replace('trail', '')} 日 | {fmt(full['weak'], True)} | "
+            f"{fmt(full['strong'], True)} | **{fmt(full['spread'], True)}** | "
+            f"{fmt(phase.get('t'), True)} ({phase.get('positive') or '-'}) | "
+            f"{lomo.get('same_sign') or '-'} | {within.get('positive') or '-'} | "
+            f"{fmt(perm.get('p_value'))} | {fmt(mkt_sig['spread'], True)} | "
+            f"{fmt(mkt_fwd['spread'], True)} | {block['verdict']} |"
+        )
+    for note in payload.get("notes") or []:
+        lines += ["", f"> {note}"]
+    return "\n".join(lines)
+
+
+def _notify(markdown: str, payload: dict) -> None:
+    webhook = os.getenv("FEISHU_WEBHOOK_URL", "").strip()
+    if not webhook:
+        print("[style] 未配置 FEISHU_WEBHOOK_URL,跳过推送")
+        return
+    from utils.feishu import send_feishu_notification
+
+    window = payload.get("eval_window") or ["-"]
+    title = f"风格择时体检 T+{payload['horizon']}|{window[-1]}"
+    ok = send_feishu_notification(webhook, title, markdown)
+    print("[style] feishu sent" if ok else "[style] feishu failed")
+
+
+def load_market_control(first_day: str, last_day: str) -> list[str]:
+    """市场对照池:第一天就已上市、且到最后一天仍未摘牌的票。
+
+    用 PIT 名单而不是当前存续名单——后者带生存偏差,会让对照组系统性偏强。
+    """
+    from integrations.pit_universe import fetch_pit_symbols, tradable_on
+
+    symbols = fetch_pit_symbols()
+    head = {s.code for s in tradable_on(symbols, first_day.replace("-", ""))}
+    tail = {s.code for s in tradable_on(symbols, last_day.replace("-", ""))}
+    return sorted(_sfx(code) for code in head & tail)
+
+
+def main() -> int:
+    # 逐只取价要跑十几分钟,stdout 非 tty 时默认整块缓冲,CI 日志和后台重定向都会
+    # 一直空着——看不出是在跑还是卡死了。改行缓冲,进度才是实时的。
+    sys.stdout.reconfigure(line_buffering=True)
+    args = parse_args()
+    pool = load_pool_by_day(args.start)
+    if not pool:
+        raise SystemExit("signal_outcomes 无可用数据")
+    days = sorted(pool)
+    print(f"池子 {len(days)} 天 | {days[0]} ~ {days[-1]}")
+
+    # 两头都要留够:回看最长 20 日、前瞻最长 max-hold,边界日否则被静默丢掉。
+    start = (date.fromisoformat(days[0]) - timedelta(days=LOOKBACK_PAD_DAYS)).isoformat()
+    end = (date.fromisoformat(days[-1]) + timedelta(days=LOOKBACK_PAD_DAYS)).isoformat()
+
+    members = sorted({s for ds in pool.values() for s in ds})
+    print(f"池子成分 {len(members)} 只,取价 {start} ~ {end}")
+    series = load_closes(members, start, end)
+
+    try:
+        held = set(members)
+        universe = [s for s in load_market_control(days[0], days[-1]) if s not in held]
+    except Exception as exc:
+        print(f"[market] 全市场清单取数失败,跳过市场对照: {exc}")
+        universe = []
+    market = random.Random(MARKET_SEED).sample(universe, min(MARKET_SAMPLE, len(universe)))
+    if market:
+        print(f"市场对照 {len(market)} 只")
+        series.update(load_closes(market, start, end))
+    market = [s for s in market if s in series]
+
+    prices = Prices(series)
+    rows = build_rows(pool, prices, market, args)
+    # 胜率口径的窗口是 max_hold(先触碰最长能拖到那天),不是 horizon。
+    stride = args.horizon if args.value == "forward" else args.max_hold
+    report = evaluate_style_timing(rows, horizon=args.horizon, value_kind=args.value, stride=stride)
+    payload = report_to_dict(report)
+    payload["params"] = {
+        "up": args.up,
+        "down": args.down,
+        "max_hold": args.max_hold,
+        "cost_pct": ROUND_TRIP_COST_PCT,
+        "market_sample": len(market),
+    }
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # 胜率口径不依赖 horizon(它走 first_touch 的 up/down/max_hold),文件名不带 h,
+    # 否则 --horizon 5 与 10 会写出两个内容相同的文件,后来的人会以为是两轮证据。
+    name = f"style_timing_h{args.horizon}_forward.json" if args.value == "forward" else "style_timing_win.json"
+    (out_dir / name).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    markdown = render_markdown(payload)
+    print(markdown)
+    if not args.no_notify:
+        _notify(markdown, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_style_timing_eval.py
+++ b/tests/test_style_timing_eval.py
@@ -1,0 +1,155 @@
+"""风格择时体检的判别性用例。
+
+要点:一个回归测试如果对「植入真信号」和「纯噪声」给同一句判定,它就没测到东西。
+所以这里三种输入必须落到三种不同判定上——植入信号=过对照,纯噪声=无信息,
+单月撑起=不成立。
+"""
+
+from __future__ import annotations
+
+import random
+
+from core.style_timing_eval import (
+    MIN_DAYS,
+    DayRow,
+    evaluate_style_timing,
+)
+
+MONTHS = ("2026-05", "2026-06", "2026-07", "2026-08")
+DAYS_PER_MONTH = 20
+
+
+def _dates() -> list[str]:
+    return [f"{m}-{d:02d}" for m in MONTHS for d in range(1, DAYS_PER_MONTH + 1)]
+
+
+def _row(
+    date: str,
+    trail: float,
+    forward: float,
+    *,
+    market_trail: float | None = None,
+    market_forward: float | None = None,
+) -> DayRow:
+    return DayRow(
+        date=date,
+        pool_trail={5: trail, 10: trail, 20: trail},
+        pool_forward=forward,
+        pool_win=None,
+        n_pool=30,
+        market_trail={5: market_trail if market_trail is not None else trail} | {10: 0.0, 20: 0.0},
+        market_forward=market_forward if market_forward is not None else 0.0,
+        n_market=200,
+    )
+
+
+def test_planted_signal_passes_all_controls() -> None:
+    """强弱与前瞻同向、且每个月都同向时,应当判为过对照。"""
+    rng = random.Random(11)
+    rows = [_row(d, trail := rng.uniform(-10, 10), trail * 0.8 + rng.gauss(0, 1.0)) for d in _dates()]
+    report = evaluate_style_timing(rows, horizon=5)
+    block = report.windows["trail5"]
+    assert block["full_sample"]["spread"] is not None
+    assert block["full_sample"]["spread"] > 0
+    assert block["verdict"] == "过全部对照", block
+
+
+def test_pure_noise_reads_as_no_information() -> None:
+    """切档键与前瞻无关时,必须落回置换带内,而不是给出结论。
+
+    这一例特意留着:它的相位 |t| 高达 5.8,单看 t 会直接放行,是月内置换把它挡住的。
+    换句话说,判定链里的置换不是装饰——去掉它,纯噪声就会读成「过全部对照」。
+    """
+    rng = random.Random(23)
+    rows = [_row(d, rng.uniform(-10, 10), rng.gauss(0, 5.0)) for d in _dates()]
+    report = evaluate_style_timing(rows, horizon=5)
+    block = report.windows["trail5"]
+    assert abs(block["phase_scan"]["t"]) > 2.5, "这一例的价值在于 t 够大,变小了就测不到东西"
+    assert block["verdict"] == "落在月内置换带内,无信息", block["verdict"]
+
+
+def test_single_month_carrying_everything_is_rejected() -> None:
+    """只有一个月有关系、其余三个月纯噪声,应当判为单月撑起全部。
+
+    这是回看 20 日实际死掉的方式:全样本 p 更漂亮,剔掉那个月就只剩零头。
+    """
+    rng = random.Random(37)
+    rows = []
+    for date in _dates():
+        trail = rng.uniform(-10, 10)
+        if date.startswith("2026-07"):
+            forward = trail * 3.0
+        else:
+            forward = rng.gauss(0, 0.5)
+        rows.append(_row(date, trail, forward))
+    report = evaluate_style_timing(rows, horizon=5)
+    assert report.windows["trail5"]["verdict"] == "单月撑起全部,不成立"
+
+
+def test_market_control_flags_market_timing() -> None:
+    """池子与市场同幅同向时,应当判成市场择时而不是风格择时。"""
+    rng = random.Random(41)
+    rows = []
+    for date in _dates():
+        trail = rng.uniform(-10, 10)
+        shared = trail * 0.8 + rng.gauss(0, 1.0)
+        rows.append(_row(date, trail, shared, market_trail=trail, market_forward=shared))
+    report = evaluate_style_timing(rows, horizon=5)
+    assert "市场择时" in report.windows["trail5"]["verdict"]
+
+
+def test_insufficient_sample_is_not_a_failed_control() -> None:
+    """天数不够时要明确说样本不足——「尚未可知」不能写成「对照未通过」。"""
+    rng = random.Random(53)
+    rows = [_row(f"2026-05-{d:02d}", trail := rng.uniform(-10, 10), trail) for d in range(1, MIN_DAYS)]
+    report = evaluate_style_timing(rows, horizon=5)
+    assert report.windows["trail5"]["verdict"] == "样本不足,不下判定"
+
+
+def test_negative_finding_keeps_sign_consistency() -> None:
+    """全样本为负时,「留一月同号」要按负方向数,不能按正号数。"""
+    rng = random.Random(67)
+    rows = [_row(d, trail := rng.uniform(-10, 10), -trail * 0.8 + rng.gauss(0, 1.0)) for d in _dates()]
+    report = evaluate_style_timing(rows, horizon=5)
+    block = report.windows["trail5"]
+    assert block["full_sample"]["spread"] < 0
+    lomo = block["leave_one_month_out"]
+    assert lomo["same_sign"] == f"{len(MONTHS)}/{len(MONTHS)}"
+    assert lomo["positive"] == f"0/{len(MONTHS)}"
+
+
+def test_eval_window_comes_from_usable_days() -> None:
+    """区间必须来自真正可用的日子,不能来自请求区间。"""
+    rows = [_row(d, 1.0, 1.0) for d in _dates()]
+    rows.append(
+        DayRow(
+            date="2026-09-30",
+            pool_trail={5: 1.0, 10: 1.0, 20: 1.0},
+            pool_forward=None,  # 前瞻不足,这天不该进区间
+            pool_win=None,
+            n_pool=30,
+        )
+    )
+    report = evaluate_style_timing(rows, horizon=5)
+    assert report.eval_window == ["2026-05-01", "2026-08-20"]
+    assert "2026-09" not in report.months
+
+
+def test_permutation_outside_agrees_with_its_own_p_value() -> None:
+    """outside 与 p_value 必须同源,否则判定和报告里的数会互相矛盾。
+
+    真实数据上出现过:有符号分位带判「带内」、双侧绝对值算出 p=0.03,判定读 outside,
+    于是报告里写着「置换 p=0.03」却判「落在带内,无信息」。零分布一偏就会这样。
+    这里扫多组随机输入,逐个钉住 outside == (p_value < 0.05)。
+    """
+    for seed in range(12):
+        rng = random.Random(seed)
+        rows = [_row(d, rng.uniform(-10, 10), rng.gauss(0, 5.0)) for d in _dates()]
+        report = evaluate_style_timing(rows, horizon=5)
+        for name, block in report.windows.items():
+            perm = block["month_block_permutation"]
+            if "p_value" not in perm:
+                continue
+            assert perm["outside"] is (perm["p_value"] < 0.05), (
+                f"seed={seed} {name}: outside={perm['outside']} 与 p={perm['p_value']} 不一致"
+            )


### PR DESCRIPTION
两层选股(入池、排序)都已证实是噪声之后,唯一还能动的是「该不该在这个风格里待着」。
量完三个候选,只有一个活下来,做成常驻模块每月重跑攒跨周期样本——一次性脚本的数留不住,
下个月要重新算,而这条结论的全部价值在于它能不能跨周期稳定。

## 结论,以及一处必须说清的降级

按池子当日成分近 5 日已实现涨跌切三档。驱动脚本首轮实测(全池 1972 只,
评估区间 2026-05-25~2026-08-28,69 天 4 个月):

    回看   弱档     强档     强-弱      相位t        置换p   留一月  判定
    5 日  -5.12%  -0.53%  +4.58pct  +5.40(5/5)  0.027   4/4    过全部对照
    10 日 -3.81%  -1.51%  +2.30pct  +1.33(3/5)  0.575   4/4    单月撑起全部,不成立
    20 日 -0.75%  -6.69%  -5.94pct  -14.01(0/5) 0.002   4/4    单月撑起全部,不成立

一次性脚本上的三个口径复现(池子成分口径略不同,以驱动脚本产物为准):
T+5 +4.46pct(p=0.025)、T+10 +9.52pct(p=0.001)、先触碰胜率 +6.62pct(p=0.281)。

**胜率口径没过月内置换,而胜率是第一优先级。**原先的一次性脚本没对胜率口径跑这道对照。
p=0.281 落在带内——那 +6.62pct 基本是月份效应(逐月 2/3,7 月为负)。
所以现在只能说「强弱能预测亏多少」,还不能说「能预测赢不赢」。

**而且最好的情况也只是少亏。**强档 T+5 仍是 -0.53%(基准 -3.20%),T+10 口径下胜率 42.9%。
这条信号的用途是「什么时候干脆别在里面」,不是「什么时候加仓」。
另注 min_retention 只有 0.385,刚过 0.35 门槛——剔掉某一个月就悬,不宽裕。

两道市场对照都跟不上:信号侧(同规则套市场)+0.36pct、前瞻侧(池子强的日子看市场)
-1.06pct。所以量到的是风格择时,不是市场择时。

## 复现与跑通时抓到四个缺陷,都已修

1. **前瞻窗口被截断混了口径。**原脚本 `j = min(i + h, len(s) - 1)`,尾部不足 h 天
   仍记作 T+h。表现是「三个口径都 73 天」看着很整齐。改成不足即丢,天数变 69/64/73,
   数跟着变:T+5 +4.64→+4.46,T+10 +6.59→**+9.52**。horizon 越长偏得越狠。
2. **市场对照取错了侧。**原脚本按池子的回看切档去看市场前瞻(前瞻侧),我先实现的是
   同规则套市场(信号侧),两者符号相反。改成两道对照都出,判定按符号与量级分别看。
3. **相位步长取错。**先触碰胜率能拖到 max_hold=15,步长必须 15;取 10 时 t 读成 0.49。
4. **置换的 outside 与 p_value 不同源,把唯一活着的那档误杀了。**outside 按有符号
   2.5/97.5 分位带判、p 按双侧绝对值算,零分布一偏就打架:首轮真实数据上报告写着
   「置换 p=0.03」却判「落在带内,无信息」。判定读的是 outside,于是 5 日档被判无信息。
   改成 outside = (p_value < 0.05) 同源,band 只作展示。回归测试逐 seed 钉住两者一致。

## 判定链的顺序是有意的

样本不足 → 单月撑起 → 月内置换 → 市场对照 → 相位 t。t 放最后,因为它最容易被
非独立样本抬起来:测试里那个纯噪声用例相位 |t| 高达 5.83,只有月内置换挡得住。
所以「t 很大」从来不是放行理由。「样本不足」单独成一档,是尚未可知,不写成对照未通过。

## 变更摘要

- core/style_timing_eval.py:纯函数评估层,不碰 IO。四种池子/市场切档组合、
  月内置换(2000 seed,只在月内打乱切档键,月份效应因此在零假设里)、留一月、
  逐月独立分位、相位扫描。留一月的符号一致性按全样本方向定,否则全负结论会被误判
- scripts/evaluate_style_timing.py:取数与落盘。前瞻不足即丢;市场对照用 PIT 名单
  (当前存续名单带生存偏差,会让对照组系统性偏强);代码补后缀前 zfill(6),
  部分表把代码存成数字,000100 会读回成 100;Supabase 单页静默截断在 1000 行,翻页;
  stdout 改行缓冲——非 tty 时整块缓冲会让后台/重定向一直空着,看不出是在跑还是卡死
- tests/test_style_timing_eval.py:8 例,含「植入真信号」与「纯噪声」两个必须给出
  不同判定的用例——一个回归测试如果对这两者给同一句话,它就没测到东西
- .github/workflows/style_timing_eval.yml:每月 3 日 10:17 重跑三个口径。三个口径顺序跑
  不并行——同时打同一数据源会限流,而限流表现为「部分标的取空」,那是静默改变样本构成,
  比跑得慢危险得多(timeout 300 分钟)。if-no-files-found 从第一天就用 error
- .github/workflows/regime_forward_eval.yml:加落盘校验,upload 的
  if-no-files-found 从 warn 改 error。定时跑连续两次(08-22、08-29)只留下
  No files were found 而手动 dispatch 每次都有产物,warn 是它藏了两周的原因

**不改任何生产开关。**69 天 / 4 个可用月,不足以动闸门。

## 验证

- ruff format --check / ruff check:通过
- scripts/quality_gate.py --check-no-sql:无 .sql 文件
- pytest tests/test_style_timing_eval.py:8 passed
- 驱动脚本端到端跑通(约 40 分钟,逐只取价 2372 只),产物 style_timing_h5_forward.json
- T+10 与胜率口径尚未经驱动脚本跑过,数字来自一次性脚本复现

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

