### PR TITLE
fix(reflection): 单格 n=26 被当成整条 track 最强，结论翻号

### DIFF
--- a/core/strategy_reflection.py
+++ b/core/strategy_reflection.py
@@ -7,6 +7,10 @@ from typing import Any
 
 from utils.safe import safe_float as _safe_float
 
+# 定「哪条 track 更强」所需的最小样本。低于此数不出结论——「样本不足」和
+# 「已比较过、这条更强」是两回事,后者会被人拿去调车道权重。
+MIN_TRACK_SAMPLES = 30
+
 
 def _done_rows(outcomes: list[dict[str, Any]], horizon_days: int) -> list[dict[str, Any]]:
     horizon = int(horizon_days)
@@ -60,23 +64,72 @@ def summarize_shadow_runs(shadow_runs: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def aggregate_by_track(track_summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """把 (track, regime) 逐格明细按样本数加权合成 track 级汇总。
+
+    ``track_summary`` 的每一行是一个 regime 格子,直接在格子上取 max 会拿单格当结论。
+    这里按 ``sample_count`` 加权还原 track 整体,均值才和「这条车道整体如何」同口径。
+    """
+    agg: dict[str, dict[str, float]] = {}
+    for row in track_summary:
+        n = int(row.get("sample_count") or 0)
+        if n <= 0:
+            continue
+        acc = agg.setdefault(str(row.get("track") or ""), {"n": 0.0, "ret": 0.0, "win": 0.0})
+        acc["n"] += n
+        acc["ret"] += _safe_float(row.get("avg_return_pct")) * n
+        acc["win"] += _safe_float(row.get("win_rate")) * n
+    out = []
+    for track, acc in agg.items():
+        n = acc["n"]
+        out.append(
+            {
+                "track": track,
+                "sample_count": int(n),
+                "win_rate": round(acc["win"] / n, 4),
+                "avg_return_pct": round(acc["ret"] / n, 4),
+            }
+        )
+    return sorted(out, key=lambda row: -row["sample_count"])
+
+
 def _best_track(track_summary: list[dict[str, Any]]) -> str:
-    eligible = [row for row in track_summary if int(row.get("sample_count") or 0) > 0]
+    """样本够的 track 里按胜率优先挑一条;都不够就返回空字符串。
+
+    原先两处都错:①``sample_count > 0`` 等于没有门槛,n=1 的格子也能定结论;
+    ②取 max 的单位是 (track, regime) 单格,却当成「整条 track 最强」写进结论。
+    2026-09-05 那轮就这样翻了号:Accum/CRASH 单格 n=26 / +3.77% 被选中,
+    而按样本加权 Accum 整体 -0.607% / 胜率 38.2%,比 Trend 的 -0.094% / 41.6% 更差,
+    报告却写着「Accum track has the strongest recent outcome profile」。
+
+    排序键用胜率优先(其次平均收益)——第一优先级是胜率,不是幅度。
+    """
+    eligible = [row for row in aggregate_by_track(track_summary) if row["sample_count"] >= MIN_TRACK_SAMPLES]
     if not eligible:
         return ""
-    best = max(eligible, key=lambda row: (_safe_float(row.get("avg_return_pct")), _safe_float(row.get("win_rate"))))
+    best = max(eligible, key=lambda row: (row["win_rate"], row["avg_return_pct"]))
     return str(best.get("track") or "")
 
 
 def _reflection_text(track_summary: list[dict[str, Any]], shadow_summary: dict[str, Any]) -> str:
     if not track_summary:
         return "样本不足，保持 shadow 观察，不调整生产策略。"
-    best = _best_track(track_summary) or "unknown"
-    return (
-        f"{best} track has the strongest recent outcome profile. "
+    shadow_part = (
         f"Shadow runs={shadow_summary.get('run_count', 0)}, "
         f"avg_added={shadow_summary.get('avg_added', 0)}, avg_removed={shadow_summary.get('avg_removed', 0)}. "
         "Keep candidate in review; do not auto-promote."
+    )
+    best = _best_track(track_summary)
+    if not best:
+        # 没有一条 track 够样本。这里必须说「不足」,不能退回 unknown 之类看着像结论的词。
+        return f"No track reaches {MIN_TRACK_SAMPLES} samples; not ranking tracks this round. {shadow_part}"
+    agg = {row["track"]: row for row in aggregate_by_track(track_summary)}
+    hit = agg[best]
+    # 带上数和样本量。两条车道可能都是负的,「最强」只是「亏得少」,不写数就会被读成赚钱。
+    return (
+        f"{best} track leads on win rate ({hit['win_rate'] * 100:.1f}%, "
+        f"avg_return={hit['avg_return_pct']:+.3f}%, n={hit['sample_count']}), "
+        f"sample-weighted across regimes. {shadow_part}"
     )
 
 
@@ -98,6 +151,8 @@ def build_strategy_reflection(
         "status": "SHADOW",
         "summary": {
             "track_performance": track_summary,
+            # 逐格明细容易被拿单格当结论,这里同时落 track 级加权汇总,读的人不用自己算。
+            "track_totals": aggregate_by_track(track_summary),
             "shadow": shadow_summary,
             "preferred_track": _best_track(track_summary),
         },

--- a/tests/test_strategy_reflection.py
+++ b/tests/test_strategy_reflection.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+from core.strategy_reflection import MIN_TRACK_SAMPLES
+
+
+def _rows(track: str, regime: str, count: int, return_pct: float) -> list[dict]:
+    return [
+        {"track": track, "regime": regime, "horizon_days": 5, "status": "done", "return_pct": return_pct}
+        for _ in range(count)
+    ]
+
 
 def test_build_strategy_reflection_and_candidate():
     from core.strategy_reflection import build_policy_candidate, build_strategy_reflection
 
-    outcomes = [
-        {"track": "Trend", "regime": "RISK_ON", "horizon_days": 5, "status": "done", "return_pct": 0.5},
-        {"track": "Accum", "regime": "RISK_ON", "horizon_days": 5, "status": "done", "return_pct": 3.0},
-        {"track": "Accum", "regime": "RISK_ON", "horizon_days": 5, "status": "done", "return_pct": -1.0},
-    ]
+    # 两条 track 都过 MIN_TRACK_SAMPLES,Accum 全胜、Trend 全负,排序键该选 Accum。
+    outcomes = _rows("Trend", "RISK_ON", 40, -1.0) + _rows("Accum", "RISK_ON", 40, 3.0)
     shadow_runs = [{"diff_added": ["000001"], "diff_removed": ["000002", "000003"]}]
 
     reflection = build_strategy_reflection(outcomes, shadow_runs, market="cn", as_of_date="2026-06-12")
@@ -33,11 +39,7 @@ def test_strategy_reflection_job_dry_run_payload(monkeypatch):
         shadow_days=30,
         limit=100,
     )
-    monkeypatch.setattr(
-        job,
-        "load_recent_signal_outcomes",
-        lambda *_args: [{"track": "Trend", "regime": "ALL", "horizon_days": 5, "status": "done", "return_pct": 2}],
-    )
+    monkeypatch.setattr(job, "load_recent_signal_outcomes", lambda *_args: _rows("Trend", "ALL", 40, 2.0))
     monkeypatch.setattr(job, "load_policy_shadow_runs", lambda *_args: [{"diff_added": [], "diff_removed": []}])
 
     reflection, candidate = job.build_strategy_reflection_payloads(request)
@@ -46,3 +48,72 @@ def test_strategy_reflection_job_dry_run_payload(monkeypatch):
     assert reflection["summary"]["preferred_track"] == "Trend"
     assert candidate is not None
     assert candidate["status"] == "READY_FOR_REVIEW"
+
+
+def test_single_strong_regime_cell_does_not_decide_the_track():
+    """真实缺陷的回归:一个小格子不能代表整条 track。
+
+    2026-09-05 那轮 Accum/CRASH 单格 n=26 / +3.77% 被选成「最强 track」,
+    而按样本加权 Accum 整体比 Trend 更差(-0.607% / 38.2% vs -0.094% / 41.6%)。
+    这里复刻那个形状:Accum 有一个亮眼小格 + 一个很差的大格,整体弱于 Trend。
+    """
+    from core.strategy_reflection import build_strategy_reflection
+
+    outcomes = (
+        _rows("Accum", "CRASH", 26, 3.8)  # 亮眼但小
+        + _rows("Accum", "RISK_OFF", 300, -1.0)  # 拖累且大
+        + _rows("Trend", "NEUTRAL", 500, 0.2)  # 平淡但整体更好
+    )
+    reflection = build_strategy_reflection(outcomes, [], market="cn", as_of_date="2026-09-05")
+
+    totals = {row["track"]: row for row in reflection["summary"]["track_totals"]}
+    assert totals["Accum"]["avg_return_pct"] < totals["Trend"]["avg_return_pct"]
+    assert reflection["summary"]["preferred_track"] == "Trend"
+    assert "Accum" not in reflection["reflection_text"]
+
+
+def test_below_sample_floor_reports_insufficient_not_a_winner():
+    """样本不够时必须说「不足」,而不是挑一条出来当结论,也不该生成候选。"""
+    from core.strategy_reflection import build_policy_candidate, build_strategy_reflection
+
+    outcomes = _rows("Trend", "ALL", 3, 5.0) + _rows("Accum", "ALL", 2, -5.0)
+    reflection = build_strategy_reflection(outcomes, [], market="cn", as_of_date="2026-06-12")
+
+    assert reflection["summary"]["preferred_track"] == ""
+    assert f"No track reaches {MIN_TRACK_SAMPLES} samples" in reflection["reflection_text"]
+    assert "strongest" not in reflection["reflection_text"]
+    assert build_policy_candidate(reflection) is None
+
+
+def test_win_rate_leads_the_ranking_key():
+    """排序键是胜率优先——第一优先级是胜率,不是幅度。
+
+    Trend 胜率更高但均值被一次大亏拖低;Accum 均值更高、胜率更低。选 Trend。
+    """
+    from core.strategy_reflection import build_strategy_reflection
+
+    outcomes = (
+        _rows("Trend", "ALL", 39, 1.0)
+        + _rows("Trend", "ALL", 1, -100.0)  # 拉低均值,不改胜率排序
+        + _rows("Accum", "ALL", 20, 12.0)
+        + _rows("Accum", "ALL", 20, -1.0)
+    )
+    reflection = build_strategy_reflection(outcomes, [], market="cn", as_of_date="2026-06-12")
+
+    totals = {row["track"]: row for row in reflection["summary"]["track_totals"]}
+    assert totals["Accum"]["avg_return_pct"] > totals["Trend"]["avg_return_pct"]
+    assert totals["Trend"]["win_rate"] > totals["Accum"]["win_rate"]
+    assert reflection["summary"]["preferred_track"] == "Trend"
+
+
+def test_track_totals_are_sample_weighted_not_cell_averaged():
+    """加权口径校验:两个大小差很多的格子,汇总必须贴近大格子而非两格算术平均。"""
+    from core.strategy_reflection import aggregate_by_track, summarize_track_performance
+
+    outcomes = _rows("Trend", "A", 90, 1.0) + _rows("Trend", "B", 10, -9.0)
+    totals = aggregate_by_track(summarize_track_performance(outcomes, 5))
+
+    assert len(totals) == 1
+    assert totals[0]["sample_count"] == 100
+    assert totals[0]["avg_return_pct"] == 0.0  # (90*1 + 10*-9)/100 = 0.0,算术平均会得 -4.0
+    assert totals[0]["win_rate"] == 0.9


### PR DESCRIPTION
## 问题

周度反思的 `_best_track` 只有四行，里面两处错叠起来会把结论说反：

1. `sample_count > 0` 等于没有样本门槛 — n=1 的格子也能定结论
2. 取 max 的单位是 `(track, regime)` **单格**，却当成「整条 track 最强」写进 `reflection_text` 和 `preferred_track`

2026-09-05 那轮（#382 修好后第一次真正跑起来的周度反思）就翻了号。被选中的是 Accum/CRASH 单格：n=26、+3.77%、胜率 73.1%。而按样本加权的 track 汇总是：

| track | n | 胜率 | 均值 |
|---|---|---|---|
| Trend | 2903 | 41.6% | −0.094% |
| Accum | 353 | 38.2% | −0.607% |

Accum 整体在两个口径上都比 Trend 差，报告却写着 `Accum track has the strongest recent outcome profile`。

旧文案还不带任何数字。两条车道其实都是负的，「strongest」很容易被读成「这条赚钱」。

## 改动

- 新增 `aggregate_by_track`：按 `sample_count` 加权，把逐格明细合成 track 级汇总
- `MIN_TRACK_SAMPLES = 30`。没有 track 够样本就直接说 `No track reaches 30 samples`，不挑一条充当结论 —「样本不足」和「已比较过、这条更强」是两回事。此时 `build_policy_candidate` 本来就返回 `None`，不会写出候选
- 排序键改为**胜率优先**、均值其次 — 第一优先级是胜率，不是幅度
- 文案带上胜率 / 均值 / 样本量
- payload 增加 `track_totals`，读的人不用自己加权

## 验证

真实 09-05 数据重放，`preferred_track` 由 `Accum` 翻为 `Trend`：

```
Trend    n= 2903 win= 41.6% ret=-0.094%
Accum    n=  353 win= 38.2% ret=-0.607%
AFTER: Trend track leads on win rate (41.6%, avg_return=-0.094%, n=2903), sample-weighted across regimes.
```

6 个单测，4 条新增：缺陷形状回归（小亮格 + 大差格，整体弱于对手）、样本门槛（不足时不出赢家也不出候选）、排序键（胜率优先于均值）、加权口径（算术平均会得 −4.0，加权得 0.0）。

`ruff format --check` / `ruff check` / `quality_gate.py --check-no-sql` 全绿；`-k "reflection or policy_governor or strategy"` 113 passed。

## 影响面

`preferred_track` 目前**没有生产消费方**（只有本模块和它自己的单测读），候选表停在 `SHADOW` / `auto_promote=False`。所以这修的是人读的那句结论，不动下单。

修复前已落库的行（09-05 及更早）仍带旧排序，没有回改历史影子记录。