### PR TITLE
feat(funnel): 漏斗效果评估补上股级胜率，并给它自己的随机负控制

### DIFF
--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -80,6 +80,11 @@ class GroupStat:
     positive_day_pct: float | None
     residual_mom_pct: float | None
     by_quarter: dict[int, float] = field(default_factory=dict)
+    # 股级胜率一栏。``positive_day_pct`` 是「超额为正的日子占比」，与这一栏无关。
+    stock_win_pct: float | None = None
+    stock_win_control_pct: float | None = None
+    stock_win_excess_pct: float | None = None
+    stock_win_excess_t: float | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -93,6 +98,10 @@ class GroupStat:
             "positive_day_pct": _round(self.positive_day_pct, 1),
             "residual_mom_pct": _round(self.residual_mom_pct, 3),
             "by_quarter": {str(q): _round(v, 3) for q, v in sorted(self.by_quarter.items())},
+            "stock_win_pct": _round(self.stock_win_pct, 1),
+            "stock_win_control_pct": _round(self.stock_win_control_pct, 1),
+            "stock_win_excess_pct": _round(self.stock_win_excess_pct, 2),
+            "stock_win_excess_t": _round(self.stock_win_excess_t, 2),
         }
 
 
@@ -111,6 +120,14 @@ def summarize_group(label: str, daily: list[dict[str, float]]) -> GroupStat:
     by_quarter: dict[int, list[float]] = {}
     for row, diff in zip(usable, diffs, strict=True):
         by_quarter.setdefault(_quarter_of(str(row["date"])), []).append(diff)
+    # 胜率的配对差只用**两栏都在**的日子，缺一栏不按 0 补——那会把「没算出胜率」
+    # 当成「胜率 0%」，凭空造出负超额。
+    win_pairs = [
+        (float(r["stock_win"]), float(r["stock_win_control"]))
+        for r in usable
+        if r.get("stock_win") is not None and r.get("stock_win_control") is not None
+    ]
+    win_diffs = [h - c for h, c in win_pairs]
     return GroupStat(
         label=label,
         days=len(usable),
@@ -122,6 +139,10 @@ def summarize_group(label: str, daily: list[dict[str, float]]) -> GroupStat:
         positive_day_pct=100.0 * sum(1 for d in diffs if d > 0) / len(diffs),
         residual_mom_pct=mean(moms) if moms else None,
         by_quarter={q: mean(v) for q, v in by_quarter.items()},
+        stock_win_pct=mean(h for h, _ in win_pairs) if len(win_pairs) >= MIN_DAYS else None,
+        stock_win_control_pct=mean(c for _, c in win_pairs) if len(win_pairs) >= MIN_DAYS else None,
+        stock_win_excess_pct=mean(win_diffs) if len(win_pairs) >= MIN_DAYS else None,
+        stock_win_excess_t=tstat(win_diffs) if len(win_pairs) >= MIN_DAYS else None,
     )
 
 
@@ -153,6 +174,10 @@ class AbsoluteStat:
     bench_excess_pct: float | None
     bench_excess_t: float | None
     bench_days: int = 0
+    # 股级胜率：这批票里有多少只自己赚了钱。与上面的 positive_day_pct（正收益**日**
+    # 占比）是两个口径，一篮 3 只 +20% / 7 只 -5% 在日级算赢、股级只有 30%。
+    stock_win_pct: float | None = None
+    stock_win_days: int = 0
 
     @property
     def verdict(self) -> str:
@@ -177,6 +202,8 @@ class AbsoluteStat:
             "bench_pct": _round(self.bench_pct),
             "bench_excess_pct": _round(self.bench_excess_pct),
             "bench_excess_t": _round(self.bench_excess_t, 2),
+            "stock_win_pct": _round(self.stock_win_pct, 1),
+            "stock_win_days": self.stock_win_days,
             "verdict": self.verdict,
         }
 
@@ -193,6 +220,9 @@ def summarize_absolute(daily: list[dict[str, float]]) -> AbsoluteStat:
     nets = [float(row["net_abs"]) for row in usable]
     paired = [(float(r["net_abs"]), float(r["bench"])) for r in usable if r.get("bench") is not None]
     bench_diffs = [net - bench for net, bench in paired]
+    # 股级胜率按**交易日等权**平均，不是把所有票混成一个大池：命中只数多的日子
+    # 不该主导胜率，与 net_pct 的等权口径保持一致。
+    wins = [float(r["stock_win_abs"]) for r in usable if r.get("stock_win_abs") is not None]
     return AbsoluteStat(
         days=len(usable),
         avg_size=mean(float(row.get("size_abs") or 0) for row in usable),
@@ -205,6 +235,8 @@ def summarize_absolute(daily: list[dict[str, float]]) -> AbsoluteStat:
         bench_pct=mean(b for _, b in paired) if paired else None,
         bench_excess_pct=mean(bench_diffs) if len(bench_diffs) >= MIN_DAYS else None,
         bench_excess_t=tstat(bench_diffs) if len(bench_diffs) >= MIN_DAYS else None,
+        stock_win_pct=mean(wins) if len(wins) >= MIN_DAYS else None,
+        stock_win_days=len(wins),
     )
 
 
@@ -326,13 +358,34 @@ class Panels:
 
     def gross_return(self, codes: list[str], buy_ds: str, sell_ds: str) -> float | None:
         """等权毛收益（%），未扣成本。"""
+        rets = self.per_stock_returns(codes, buy_ds, sell_ds)
+        return mean(rets) if rets else None
+
+    def per_stock_returns(self, codes: list[str], buy_ds: str, sell_ds: str) -> list[float]:
+        """逐只毛收益（%），未扣成本。缺开盘或收盘的票直接不收录。"""
         opens, closes = self.open.get(buy_ds, {}), self.close.get(sell_ds, {})
         rets = []
         for code in codes:
             o, c = opens.get(code), closes.get(code)
             if o and c and o > 0:
                 rets.append(100.0 * (c / o - 1.0))
-        return mean(rets) if rets else None
+        return rets
+
+    def stock_win_rate(self, codes: list[str], buy_ds: str, sell_ds: str) -> float | None:
+        """**逐只**净收益为正的占比（%）。
+
+        与 ``GroupStat.positive_day_pct`` / ``AbsoluteStat.positive_day_pct`` 都不是
+        一回事，别混用：那两个是**日级**的（当天这一篮的均值为正吗），这个是**股级**
+        的（这只票赚了吗）。一篮 10 只里 3 只 +20%、7 只 -5%，日级算「正收益日」，
+        股级只有 30%。「选出的股票都赚钱」问的是后者。
+
+        判正的门槛是**扣掉往返成本之后**：毛涨 0.1% 的票扣完 0.202% 是亏的，算赢会
+        把成本一栏悄悄漏掉。
+        """
+        rets = self.per_stock_returns(codes, buy_ds, sell_ds)
+        if not rets:
+            return None
+        return 100.0 * sum(1 for r in rets if r - ROUND_TRIP_COST_PCT > 0) / len(rets)
 
 
 def resolve_layer(day: dict, universe: set[str], layer: str) -> tuple[list[str], list[str]]:
@@ -365,6 +418,8 @@ class MatchedBaseline:
 
     ret: float
     mom: float
+    # 胜率口径要拿基准篮自己的成分重算一遍股级胜率，均值算不出胜率来，故带上成分。
+    codes: tuple[str, ...] = ()
 
 
 def absolute_row(hits: list[str], panels: Panels, ds: str, buy_ds: str, sell_ds: str) -> dict | None:
@@ -379,6 +434,8 @@ def absolute_row(hits: list[str], panels: Panels, ds: str, buy_ds: str, sell_ds:
         "date": ds,
         "size_abs": len(hits),
         "net_abs": gross - ROUND_TRIP_COST_PCT,
+        # 股级胜率：当天这批票里有多少只自己赚了钱，与 net_abs 的日级均值不同口径。
+        "stock_win_abs": panels.stock_win_rate(hits, buy_ds, sell_ds),
         # 基准不扣成本：它是「不动手」的参照，不产生交易。
         "bench": panels.bench_return(buy_ds, sell_ds),
     }
@@ -426,6 +483,10 @@ def random_control_row(
         "size": len(band),
         "net": ctl - ROUND_TRIP_COST_PCT,
         "control": baseline.ret - ROUND_TRIP_COST_PCT,
+        # 胜率与收益同结构：net 是随机篮自己的股级胜率，control 是共用基准的胜率。
+        # 两者必须同源于 baseline_codes，否则相减时基准不抵消（见本函数上文的坑）。
+        "stock_win": panels.stock_win_rate(band, buy_ds, sell_ds),
+        "stock_win_control": panels.stock_win_rate(baseline.codes, buy_ds, sell_ds),
         # 与本行超额（随机篮 - 基准）对齐的中性化检查项，故是随机篮减基准的动量差。
         "residual_mom": mean(mom[c] for c in band if c in mom) - baseline.mom,
     }
@@ -478,7 +539,7 @@ def evaluate_daily(
         # 配对篮既是配对组的对照，也是随机组的基准：两组减同一条线，相减后基准
         # 抵消，剩下「漏斗挑的 vs 同邻域内随便挑的」。缺了这条共用，gap 就退化成
         # 两个对照篮互比，与候选无关（见 random_control_row）。
-        baseline = MatchedBaseline(ret=ctl, mom=mean(mom[c] for c in paired_ctrl))
+        baseline = MatchedBaseline(ret=ctl, mom=mean(mom[c] for c in paired_ctrl), codes=tuple(paired_ctrl))
         rows["matched"].append(
             {
                 "date": ds,
@@ -486,6 +547,9 @@ def evaluate_daily(
                 # 两边都扣成本，故超额里成本抵消；net/control 本身仍是净值口径
                 "net": hit_ret - ROUND_TRIP_COST_PCT,
                 "control": baseline.ret - ROUND_TRIP_COST_PCT,
+                # 胜率与收益同结构、同基准：配对组与随机组减的都是这一条。
+                "stock_win": panels.stock_win_rate(paired_hits, buy_ds, sell_ds),
+                "stock_win_control": panels.stock_win_rate(paired_ctrl, buy_ds, sell_ds),
                 "residual_mom": mean(mom[h] for h in paired_hits) - baseline.mom,
             }
         )
@@ -506,15 +570,32 @@ def control_gap(matched: GroupStat, controls: list[GroupStat]) -> dict[str, Any]
     小于控制组自身的抽样宽度，就不能说漏斗含选股信息——这是唯一能否掉「漏斗有效」
     的环节，所以它必须对候选表现敏感（回归测试守在 ``TestControlGapDiscriminates``）。
     """
-    usable = [c.excess_pct for c in controls if c.excess_pct is not None]
-    if matched.excess_pct is None or len(usable) < 2:
+    return _gap_of(matched, controls, attr="excess_pct")
+
+
+def win_control_gap(matched: GroupStat, controls: list[GroupStat]) -> dict[str, Any]:
+    """胜率口径的同一道否证。
+
+    胜率必须自己过一遍随机负控制，不能借收益那一栏的结论：风格择时那轮实测两栏
+    分家——收益过了月内置换（T+5 p=0.025 / T+10 p=0.001），胜率没过（p=0.284）。
+    近期强弱能预测**亏多少**、预测不了**赢不赢**。所以「收益有边缘」不蕴含「胜率
+    有边缘」，反之亦然。
+    """
+    return _gap_of(matched, controls, attr="stock_win_excess_pct")
+
+
+def _gap_of(matched: GroupStat, controls: list[GroupStat], *, attr: str) -> dict[str, Any]:
+    """``control_gap`` 与 ``win_control_gap`` 共用的实现，只换读哪一栏超额。"""
+    matched_excess = getattr(matched, attr)
+    usable = [v for v in (getattr(c, attr) for c in controls) if v is not None]
+    if matched_excess is None or len(usable) < 2:
         return {"verdict": "样本不足", "seeds": len(usable)}
     avg = mean(usable)
     spread = max(usable) - min(usable)
-    gap = matched.excess_pct - avg
+    gap = matched_excess - avg
     return {
         "seeds": len(usable),
-        "matched_excess": _round(matched.excess_pct),
+        "matched_excess": _round(matched_excess),
         "control_excess_avg": _round(avg),
         "control_excess_min": _round(min(usable)),
         "control_excess_max": _round(max(usable)),
@@ -522,8 +603,8 @@ def control_gap(matched: GroupStat, controls: list[GroupStat]) -> dict[str, Any]
         "gap": _round(gap),
         # 只标「有没有高过每个种子」这一件事：报告按它把「没跑赢随机」和「跑赢但
         # 幅度薄」分开计数。别把「落在区间内」也塞进这个布尔——一个字段两种语义。
-        "beats_band": matched.excess_pct > max(usable),
-        "verdict": _gap_verdict(matched.excess_pct, usable, gap=gap, spread=spread),
+        "beats_band": matched_excess > max(usable),
+        "verdict": _gap_verdict(matched_excess, usable, gap=gap, spread=spread),
     }
 
 

--- a/docs/evidence/funnel_stock_win_rate.json
+++ b/docs/evidence/funnel_stock_win_rate.json
@@ -1,0 +1,478 @@
+{
+  "question": "漏斗选出的票自己赚不赚钱（股级胜率，已扣往返成本 0.202%）",
+  "buy_convention": "T+1 开盘买入 / T+1+H 收盘卖出",
+  "win_threshold": "单只净收益 r - 0.202 > 0",
+  "cands_nominal_range": [
+    "2026-05-25",
+    "2026-09-03"
+  ],
+  "statuses": {
+    "formal_l4": {
+      "5": {
+        "eval_window": [
+          "2026-07-01",
+          "2026-08-27"
+        ],
+        "days": 39,
+        "absolute": {
+          "days": 39,
+          "avg_size": 19.3,
+          "net_pct": -1.9776,
+          "net_t": -1.74,
+          "positive_day_pct": 48.7,
+          "worst_day_pct": -23.9247,
+          "best_day_pct": 10.0408,
+          "bench_days": 0,
+          "bench_pct": null,
+          "bench_excess_pct": null,
+          "bench_excess_t": null,
+          "stock_win_pct": 41.6,
+          "stock_win_days": 39,
+          "verdict": "绝对收益为负：这批票拿着是亏的"
+        },
+        "matched": {
+          "label": "matched",
+          "days": 39,
+          "avg_size": 19.0,
+          "net_pct": -2.2311,
+          "control_pct": -2.6057,
+          "excess_pct": 0.3747,
+          "excess_t": 0.36,
+          "positive_day_pct": 53.8,
+          "residual_mom_pct": 0.019,
+          "by_quarter": {
+            "20263": 0.375
+          },
+          "stock_win_pct": 41.0,
+          "stock_win_control_pct": 42.7,
+          "stock_win_excess_pct": -1.71,
+          "stock_win_excess_t": -0.4
+        },
+        "win_control_gap": {
+          "seeds": 5,
+          "matched_excess": -1.7096,
+          "control_excess_avg": -1.4808,
+          "control_excess_min": -3.607,
+          "control_excess_max": 1.8219,
+          "seed_spread": 5.4289,
+          "gap": -0.2288,
+          "beats_band": false,
+          "verdict": "配对超额落在随机负控制区间内：边缘仅来自动量选位，不含选股信息"
+        },
+        "win_by_month": {
+          "2026-07": {
+            "days": 20,
+            "cand_win_pct": 41.51,
+            "control_win_pct": 41.1,
+            "win_excess_pct": 0.411,
+            "seed_band": [
+              -4.922,
+              3.574
+            ],
+            "beats_band": false
+          },
+          "2026-08": {
+            "days": 19,
+            "cand_win_pct": 40.53,
+            "control_win_pct": 44.47,
+            "win_excess_pct": -3.941,
+            "seed_band": [
+              -7.134,
+              -0.022
+            ],
+            "beats_band": false
+          }
+        }
+      },
+      "10": {
+        "eval_window": [
+          "2026-07-01",
+          "2026-08-20"
+        ],
+        "days": 34,
+        "absolute": {
+          "days": 34,
+          "avg_size": 16.5,
+          "net_pct": -3.3677,
+          "net_t": -1.97,
+          "positive_day_pct": 44.1,
+          "worst_day_pct": -29.9362,
+          "best_day_pct": 14.0967,
+          "bench_days": 0,
+          "bench_pct": null,
+          "bench_excess_pct": null,
+          "bench_excess_t": null,
+          "stock_win_pct": 40.6,
+          "stock_win_days": 34,
+          "verdict": "绝对收益为负：这批票拿着是亏的"
+        },
+        "matched": {
+          "label": "matched",
+          "days": 34,
+          "avg_size": 16.2,
+          "net_pct": -3.7175,
+          "control_pct": -5.213,
+          "excess_pct": 1.4955,
+          "excess_t": 1.09,
+          "positive_day_pct": 55.9,
+          "residual_mom_pct": 0.024,
+          "by_quarter": {
+            "20263": 1.495
+          },
+          "stock_win_pct": 39.9,
+          "stock_win_control_pct": 37.7,
+          "stock_win_excess_pct": 2.25,
+          "stock_win_excess_t": 0.57
+        },
+        "win_control_gap": {
+          "seeds": 5,
+          "matched_excess": 2.2491,
+          "control_excess_avg": -1.3481,
+          "control_excess_min": -1.76,
+          "control_excess_max": -0.5525,
+          "seed_spread": 1.2076,
+          "gap": 3.5972,
+          "beats_band": true,
+          "verdict": "配对超额跑赢随机负控制：含独立选股信息"
+        },
+        "win_by_month": {
+          "2026-07": {
+            "days": 20,
+            "cand_win_pct": 43.08,
+            "control_win_pct": 37.09,
+            "win_excess_pct": 5.99,
+            "seed_band": [
+              -1.453,
+              4.89
+            ],
+            "beats_band": true
+          },
+          "2026-08": {
+            "days": 14,
+            "cand_win_pct": 35.37,
+            "control_win_pct": 38.47,
+            "win_excess_pct": -3.095,
+            "seed_band": [
+              -11.26,
+              -0.896
+            ],
+            "beats_band": false
+          }
+        }
+      },
+      "20": {
+        "eval_window": [
+          "2026-07-01",
+          "2026-08-06"
+        ],
+        "days": 24,
+        "absolute": {
+          "days": 24,
+          "avg_size": 11.9,
+          "net_pct": -2.5948,
+          "net_t": -1.13,
+          "positive_day_pct": 50.0,
+          "worst_day_pct": -27.1614,
+          "best_day_pct": 17.2395,
+          "bench_days": 0,
+          "bench_pct": null,
+          "bench_excess_pct": null,
+          "bench_excess_t": null,
+          "stock_win_pct": 39.4,
+          "stock_win_days": 24,
+          "verdict": "绝对收益为负：这批票拿着是亏的"
+        },
+        "matched": {
+          "label": "matched",
+          "days": 24,
+          "avg_size": 11.5,
+          "net_pct": -3.3413,
+          "control_pct": -4.6701,
+          "excess_pct": 1.3288,
+          "excess_t": 0.72,
+          "positive_day_pct": 58.3,
+          "residual_mom_pct": 0.023,
+          "by_quarter": {
+            "20263": 1.329
+          },
+          "stock_win_pct": 38.1,
+          "stock_win_control_pct": 37.2,
+          "stock_win_excess_pct": 0.94,
+          "stock_win_excess_t": 0.16
+        },
+        "win_control_gap": {
+          "seeds": 5,
+          "matched_excess": 0.9383,
+          "control_excess_avg": 4.7333,
+          "control_excess_min": 0.4956,
+          "control_excess_max": 7.7354,
+          "seed_spread": 7.2398,
+          "gap": -3.795,
+          "beats_band": false,
+          "verdict": "配对超额落在随机负控制区间内：边缘仅来自动量选位，不含选股信息"
+        },
+        "win_by_month": {
+          "2026-07": {
+            "days": 20,
+            "cand_win_pct": 35.18,
+            "control_win_pct": 35.38,
+            "win_excess_pct": -0.2,
+            "seed_band": [
+              0.243,
+              9.802
+            ],
+            "beats_band": false
+          },
+          "2026-08": {
+            "days": 4,
+            "cand_win_pct": 52.83,
+            "control_win_pct": 46.2,
+            "win_excess_pct": 6.629,
+            "seed_band": [
+              -4.261,
+              1.759
+            ],
+            "beats_band": true
+          }
+        }
+      }
+    },
+    "l4_vs_rest": {
+      "5": {
+        "eval_window": [
+          "2026-07-01",
+          "2026-08-27"
+        ],
+        "days": 38,
+        "absolute": {
+          "days": 39,
+          "avg_size": 19.3,
+          "net_pct": -1.9776,
+          "net_t": -1.74,
+          "positive_day_pct": 48.7,
+          "worst_day_pct": -23.9247,
+          "best_day_pct": 10.0408,
+          "bench_days": 0,
+          "bench_pct": null,
+          "bench_excess_pct": null,
+          "bench_excess_t": null,
+          "stock_win_pct": 41.6,
+          "stock_win_days": 39,
+          "verdict": "绝对收益为负：这批票拿着是亏的"
+        },
+        "matched": {
+          "label": "matched",
+          "days": 38,
+          "avg_size": 17.2,
+          "net_pct": -2.3506,
+          "control_pct": -4.3497,
+          "excess_pct": 1.9991,
+          "excess_t": 1.7,
+          "positive_day_pct": 60.5,
+          "residual_mom_pct": -0.194,
+          "by_quarter": {
+            "20263": 1.999
+          },
+          "stock_win_pct": 40.7,
+          "stock_win_control_pct": 33.9,
+          "stock_win_excess_pct": 6.79,
+          "stock_win_excess_t": 1.75
+        },
+        "win_control_gap": {
+          "seeds": 5,
+          "matched_excess": 6.7851,
+          "control_excess_avg": -0.6455,
+          "control_excess_min": -1.7656,
+          "control_excess_max": 1.0481,
+          "seed_spread": 2.8137,
+          "gap": 7.4306,
+          "beats_band": true,
+          "verdict": "配对超额跑赢随机负控制：含独立选股信息"
+        },
+        "win_by_month": {
+          "2026-07": {
+            "days": 19,
+            "cand_win_pct": 41.1,
+            "control_win_pct": 26.77,
+            "win_excess_pct": 14.329,
+            "seed_band": [
+              -2.983,
+              0.806
+            ],
+            "beats_band": true
+          },
+          "2026-08": {
+            "days": 19,
+            "cand_win_pct": 40.24,
+            "control_win_pct": 41.0,
+            "win_excess_pct": -0.759,
+            "seed_band": [
+              -2.8,
+              2.917
+            ],
+            "beats_band": false
+          }
+        }
+      },
+      "10": {
+        "eval_window": [
+          "2026-07-01",
+          "2026-08-20"
+        ],
+        "days": 33,
+        "absolute": {
+          "days": 34,
+          "avg_size": 16.5,
+          "net_pct": -3.3677,
+          "net_t": -1.97,
+          "positive_day_pct": 44.1,
+          "worst_day_pct": -29.9362,
+          "best_day_pct": 14.0967,
+          "bench_days": 0,
+          "bench_pct": null,
+          "bench_excess_pct": null,
+          "bench_excess_t": null,
+          "stock_win_pct": 40.6,
+          "stock_win_days": 34,
+          "verdict": "绝对收益为负：这批票拿着是亏的"
+        },
+        "matched": {
+          "label": "matched",
+          "days": 33,
+          "avg_size": 14.7,
+          "net_pct": -4.1335,
+          "control_pct": -8.2648,
+          "excess_pct": 4.1314,
+          "excess_t": 3.69,
+          "positive_day_pct": 75.8,
+          "residual_mom_pct": -0.194,
+          "by_quarter": {
+            "20263": 4.131
+          },
+          "stock_win_pct": 37.9,
+          "stock_win_control_pct": 28.0,
+          "stock_win_excess_pct": 9.84,
+          "stock_win_excess_t": 3.1
+        },
+        "win_control_gap": {
+          "seeds": 5,
+          "matched_excess": 9.8422,
+          "control_excess_avg": -0.266,
+          "control_excess_min": -2.3692,
+          "control_excess_max": 1.8138,
+          "seed_spread": 4.183,
+          "gap": 10.1082,
+          "beats_band": true,
+          "verdict": "配对超额跑赢随机负控制：含独立选股信息"
+        },
+        "win_by_month": {
+          "2026-07": {
+            "days": 19,
+            "cand_win_pct": 40.25,
+            "control_win_pct": 22.31,
+            "win_excess_pct": 17.938,
+            "seed_band": [
+              -3.297,
+              4.985
+            ],
+            "beats_band": true
+          },
+          "2026-08": {
+            "days": 14,
+            "cand_win_pct": 34.69,
+            "control_win_pct": 35.83,
+            "win_excess_pct": -1.145,
+            "seed_band": [
+              -3.111,
+              1.932
+            ],
+            "beats_band": false
+          }
+        }
+      },
+      "20": {
+        "eval_window": [
+          "2026-07-01",
+          "2026-08-06"
+        ],
+        "days": 23,
+        "absolute": {
+          "days": 24,
+          "avg_size": 11.9,
+          "net_pct": -2.5948,
+          "net_t": -1.13,
+          "positive_day_pct": 50.0,
+          "worst_day_pct": -27.1614,
+          "best_day_pct": 17.2395,
+          "bench_days": 0,
+          "bench_pct": null,
+          "bench_excess_pct": null,
+          "bench_excess_t": null,
+          "stock_win_pct": 39.4,
+          "stock_win_days": 24,
+          "verdict": "绝对收益为负：这批票拿着是亏的"
+        },
+        "matched": {
+          "label": "matched",
+          "days": 23,
+          "avg_size": 11.6,
+          "net_pct": -3.5843,
+          "control_pct": -10.1547,
+          "excess_pct": 6.5704,
+          "excess_t": 3.55,
+          "positive_day_pct": 73.9,
+          "residual_mom_pct": -0.123,
+          "by_quarter": {
+            "20263": 6.57
+          },
+          "stock_win_pct": 39.0,
+          "stock_win_control_pct": 31.1,
+          "stock_win_excess_pct": 7.89,
+          "stock_win_excess_t": 1.76
+        },
+        "win_control_gap": {
+          "seeds": 5,
+          "matched_excess": 7.8856,
+          "control_excess_avg": -0.9527,
+          "control_excess_min": -2.534,
+          "control_excess_max": 3.1723,
+          "seed_spread": 5.7063,
+          "gap": 8.8383,
+          "beats_band": true,
+          "verdict": "配对超额跑赢随机负控制：含独立选股信息"
+        },
+        "win_by_month": {
+          "2026-07": {
+            "days": 19,
+            "cand_win_pct": 35.56,
+            "control_win_pct": 25.82,
+            "win_excess_pct": 9.736,
+            "seed_band": [
+              -5.023,
+              3.177
+            ],
+            "beats_band": true
+          },
+          "2026-08": {
+            "days": 4,
+            "cand_win_pct": 55.42,
+            "control_win_pct": 56.32,
+            "win_excess_pct": -0.903,
+            "seed_band": [
+              -1.053,
+              10.382
+            ],
+            "beats_band": false
+          }
+        }
+      }
+    }
+  },
+  "notes": [
+    "候选集名义区间自 2026-05-25 起，但 2026-05-25..06-30 共 26 个交易日正式 L4 恒为 0（那段 candidate_lane 只写出 launchpad/trend_lane_pullback/trend_breakout 等 Lane 通道，与 FORMAL_L4_LANES 的六条形式触发不相交），真实评估区间自 2026-07-01 起。",
+    "候选自身胜率在两个月、两种 status 下都稳定在 ~40%；变动的是对照池，不是候选。",
+    "所有跑赢随机负控制的格子都落在 2026-07；2026-08 四格全部带内。两个月样本，一个月扛全部。",
+    "t 值被高估：逐日持有窗口重叠。判显著要取不重叠日并扫遍相位。",
+    "T+20 的 2026-08 只有 4 个交易日（快照止于 09-04，T+20 需要 20 个前瞻日，评估区间被截到 08-06），那两格（formal_l4 +6.63 / l4_vs_rest -0.90）不可读。同理 T+10 的 08 只有 14 天。"
+  ]
+}

--- a/scripts/evaluate_funnel_effect.py
+++ b/scripts/evaluate_funnel_effect.py
@@ -42,6 +42,7 @@ from core.funnel_effect_eval import (
     evaluate_daily,
     summarize_absolute,
     summarize_group,
+    win_control_gap,
 )
 from core.funnel_effect_panels import build_panels, load_market_frame
 from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
@@ -98,21 +99,57 @@ def render_absolute(result: dict) -> list[str]:
         "",
         "算在**全部候选**上（不是配对子集），已扣往返成本。基准为主指数同窗口 T+1 开盘进、T+1+H 收盘出，不扣成本。",
         "",
-        "| H | 天数 | 日均只数 | 绝对净收益 | t | 胜率 | 最差日 | 最好日 | 基准 | 减基准 | t | 判定 |",
-        "|---|---|---|---|---|---|---|---|---|---|---|---|",
+        "股级胜率 = 这批票里**自己赚钱的只数占比**（已扣成本）；正收益日 = 当天这一篮**均值**为正的日子占比。"
+        "两者不是一回事：一篮 3 只 +20% / 7 只 -5%，正收益日算赢、股级胜率只有 30%。",
+        "",
+        "| H | 天数 | 日均只数 | 绝对净收益 | t | 股级胜率 | 正收益日 | 最差日 | 最好日 | 基准 | 减基准 | t | 判定 |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for h, block in result["horizons"].items():
         a = block["absolute"]
         if a["net_pct"] is None:
-            lines.append(f"| T+{h} | {a['days']} | — | — | — | — | — | — | — | — | — | 样本不足(<{MIN_DAYS}) |")
+            lines.append(f"| T+{h} | {a['days']} | — | — | — | — | — | — | — | — | — | — | 样本不足(<{MIN_DAYS}) |")
             continue
         bench = "—" if a["bench_pct"] is None else f"{a['bench_pct']:+.2f}%"
         b_ex = "—" if a["bench_excess_pct"] is None else f"{a['bench_excess_pct']:+.2f}pct"
         b_t = "—" if a["bench_excess_t"] is None else f"{a['bench_excess_t']:+.2f}"
+        s_win = "—" if a.get("stock_win_pct") is None else f"{a['stock_win_pct']:.1f}%"
         lines.append(
             f"| T+{h} | {a['days']} | {a['avg_size']:.1f} | {a['net_pct']:+.2f}% | {a['net_t']:+.2f} "
-            f"| {a['positive_day_pct']:.0f}% | {a['worst_day_pct']:+.2f}% | {a['best_day_pct']:+.2f}% "
+            f"| {s_win} | {a['positive_day_pct']:.0f}% | {a['worst_day_pct']:+.2f}% | {a['best_day_pct']:+.2f}% "
             f"| {bench} | {b_ex} | {b_t} | {a['verdict']} |"
+        )
+    return lines
+
+
+def render_win_rate(result: dict) -> list[str]:
+    """胜率块。与收益块分开，因为两栏实测会分家：能预测亏多少 ≠ 能预测赢不赢。
+
+    胜率过不过随机负控制要单独判，不能借收益那一栏的结论。
+    """
+    lines = [
+        "",
+        "## 股级胜率（同动量中性化后）",
+        "",
+        "问的是「选出的票自己赚不赚钱」，判正门槛已扣往返成本。对照与收益口径同源：同一批配对候选、同一条基准篮。",
+        "",
+        "| H | 天数 | 候选胜率 | 配对对照 | 胜率超额 | t | 随机控制区间 | 判定 |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for h, block in result["horizons"].items():
+        m, gap = block["matched"], block.get("win_control_gap", {})
+        if m.get("stock_win_excess_pct") is None:
+            lines.append(f"| T+{h} | {m['days']} | — | — | — | — | — | 样本不足(<{MIN_DAYS}) |")
+            continue
+        band = (
+            "—"
+            if gap.get("verdict") == "样本不足"
+            else f"{gap['control_excess_min']:+.2f}~{gap['control_excess_max']:+.2f}pct"
+        )
+        lines.append(
+            f"| T+{h} | {m['days']} | {m['stock_win_pct']:.1f}% | {m['stock_win_control_pct']:.1f}% "
+            f"| {m['stock_win_excess_pct']:+.2f}pct | {m['stock_win_excess_t']:+.2f} "
+            f"| {band} | {gap.get('verdict', '—')} |"
         )
     return lines
 
@@ -167,6 +204,7 @@ def render(result: dict, status: str) -> str:
             f"（均值 {gap['control_excess_avg']:+.3f}，宽度 {gap['seed_spread']:.3f}），"
             f"差距 {gap['gap']:+.3f}pct → {gap['verdict']}"
         )
+    lines += render_win_rate(result)
     lines += ["", "## 怎么读", "", *read_absolute_notes(result)]
     if inside:
         lines += [
@@ -211,6 +249,8 @@ def main() -> int:
             "matched": matched.as_dict(),
             "controls": [c.as_dict() for c in controls],
             "control_gap": control_gap(matched, controls),
+            # 胜率自己过一遍同一道否证：收益过了不代表胜率过了（风格择时那轮两栏分家）。
+            "win_control_gap": win_control_gap(matched, controls),
         }
 
     print(render(result, args.status))

--- a/tests/core/test_funnel_effect_eval.py
+++ b/tests/core/test_funnel_effect_eval.py
@@ -22,6 +22,7 @@ from core.funnel_effect_eval import (
     summarize_absolute,
     summarize_group,
     tstat,
+    win_control_gap,
 )
 from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
 
@@ -281,8 +282,12 @@ class TestSummarizeAbsolute:
         assert stat.net_pct == pytest.approx(-2.0)
         assert stat.verdict == "绝对收益为负：这批票拿着是亏的"
 
-    def test_win_rate_counts_net_positive_days(self):
-        """AbsoluteStat.positive_day_pct 是胜率,不是 GroupStat 的「超额为正日」。"""
+    def test_positive_day_pct_counts_net_positive_days(self):
+        """AbsoluteStat.positive_day_pct 是「正收益**日**占比」,不是股级胜率。
+
+        它也不是 GroupStat 的「超额为正日」。三个名字相近的口径互不等价,股级胜率
+        看 ``stock_win_pct``(守在 TestStockWinRate)。
+        """
         stat = summarize_absolute(_abs_daily([1.0] * 15 + [-1.0] * 5))
         assert stat.positive_day_pct == pytest.approx(75.0)
         assert stat.worst_day_pct == pytest.approx(-1.0)
@@ -390,6 +395,76 @@ class TestPanels:
         assert (panels.bench_open, panels.bench_close) == ({}, {})
 
 
+class TestStockWinRate:
+    """股级胜率:这批票里有多少只自己赚了钱。与日级口径不可混用。"""
+
+    def _panels_with(self, rets: dict[str, float]) -> Panels:
+        """按给定的逐只收益(%)造一个两日面板。"""
+        codes = sorted(rets)
+        return Panels(
+            open={"2026-06-01": dict.fromkeys(codes, 100.0)},
+            close={"2026-06-02": {c: 100.0 * (1.0 + rets[c] / 100.0) for c in codes}},
+            liquid={"2026-06-01": set(codes)},
+            mom20={"2026-06-01": dict.fromkeys(codes, 0.0)},
+            dates=["2026-06-01", "2026-06-02"],
+        )
+
+    def test_counts_stocks_not_days(self):
+        """3 只 +20% / 7 只 -5%:日级均值为正,股级只有 30%。这一格是两个口径的分水岭。"""
+        rets = {f"w{i}": 20.0 for i in range(3)} | {f"l{i}": -5.0 for i in range(7)}
+        panels = self._panels_with(rets)
+        codes = sorted(rets)
+        assert panels.stock_win_rate(codes, "2026-06-01", "2026-06-02") == pytest.approx(30.0)
+        # 同一批票的日级均值确实为正,若把它当胜率就会读成「赢」。
+        assert panels.gross_return(codes, "2026-06-01", "2026-06-02") > 0
+
+    def test_cost_threshold_makes_thin_winners_losses(self):
+        """毛涨 0.1% 扣掉往返成本是亏的,不能算赢。"""
+        thin = ROUND_TRIP_COST_PCT / 2.0
+        panels = self._panels_with({"a": thin, "b": thin})
+        assert panels.stock_win_rate(["a", "b"], "2026-06-01", "2026-06-02") == pytest.approx(0.0)
+
+        clear = ROUND_TRIP_COST_PCT * 2.0
+        panels = self._panels_with({"a": clear, "b": clear})
+        assert panels.stock_win_rate(["a", "b"], "2026-06-01", "2026-06-02") == pytest.approx(100.0)
+
+    def test_missing_prices_are_dropped_not_counted_as_losses(self):
+        """缺价的票不进分母,否则停牌会被记成亏。"""
+        panels = self._panels_with({"a": 10.0})
+        assert panels.stock_win_rate(["a", "ghost"], "2026-06-01", "2026-06-02") == pytest.approx(100.0)
+        assert panels.stock_win_rate(["ghost"], "2026-06-01", "2026-06-02") is None
+
+    def test_absolute_win_needs_min_days(self):
+        """样本不足时给 None,不给一个看着像结论的数。"""
+        short = [
+            {"date": f"2026-06-{i + 1:02d}", "size_abs": 10, "net_abs": 1.0, "stock_win_abs": 60.0, "bench": None}
+            for i in range(MIN_DAYS - 1)
+        ]
+        assert summarize_absolute(short).stock_win_pct is None
+        enough = short + [{"date": "2026-07-01", "size_abs": 10, "net_abs": 1.0, "stock_win_abs": 60.0, "bench": None}]
+        assert summarize_absolute(enough).stock_win_pct == pytest.approx(60.0)
+
+    def test_group_win_excess_skips_days_missing_either_side(self):
+        """缺一栏的日子不按 0 补,否则会凭空造出负超额。"""
+        rows = [
+            {
+                "date": f"2026-06-{i + 1:02d}",
+                "size": 10,
+                "net": 1.0,
+                "control": 0.0,
+                "residual_mom": 0.0,
+                "stock_win": 60.0,
+                "stock_win_control": 50.0,
+            }
+            for i in range(MIN_DAYS)
+        ]
+        rows[0]["stock_win_control"] = None
+        stat = summarize_group("m", rows)
+        # 19 个可用日 < MIN_DAYS,故胜率一栏给 None,而收益一栏(20 日)照常有值。
+        assert stat.stock_win_excess_pct is None
+        assert stat.excess_pct == pytest.approx(1.0)
+
+
 def _noisy_panels(n_days: int = 32, n_codes: int = 200) -> Panels:
     """行情带噪声、动量与噪声独立的面板。
 
@@ -416,7 +491,12 @@ def _verdict(cands: dict[str, dict], panels: Panels, horizon: int = 5) -> dict:
     rows = evaluate_daily(cands, panels, horizon, status="formal_l4")
     matched = summarize_group("matched", rows["matched"])
     controls = [summarize_group(f"c{s}", rows[f"control_{s}"]) for s in CONTROL_SEEDS]
-    return {"gap": control_gap(matched, controls), "matched": matched}
+    return {
+        "gap": control_gap(matched, controls),
+        "win_gap": win_control_gap(matched, controls),
+        "matched": matched,
+        "absolute": summarize_absolute(rows["absolute"]),
+    }
 
 
 class TestControlGapDiscriminates:
@@ -473,6 +553,32 @@ class TestControlGapDiscriminates:
         strong = _verdict(self._foresight(panels), panels, self.HORIZON)["gap"]
         weak = _verdict(self._random_picks(panels), panels, self.HORIZON)["gap"]
         assert strong["gap"] > weak["gap"] + 1.0, (strong["gap"], weak["gap"])
+
+    def test_win_gap_discriminates_like_the_return_gap(self):
+        """胜率的否证环节也必须对候选好坏敏感,不能借收益那一栏。
+
+        与收益版同构:共用基准若填错(比如拿候选自己的胜率当对照),完美预知与纯随机
+        会拿到同一句判定。
+        """
+        panels = _noisy_panels()
+        strong = _verdict(self._foresight(panels), panels, self.HORIZON)
+        weak = _verdict(self._random_picks(panels), panels, self.HORIZON)
+        assert strong["matched"].stock_win_excess_pct > 10.0, strong["matched"].stock_win_excess_pct
+        assert abs(weak["matched"].stock_win_excess_pct) < 10.0, weak["matched"].stock_win_excess_pct
+        assert strong["win_gap"]["gap"] > weak["win_gap"]["gap"] + 5.0
+        assert "含独立选股信息" in strong["win_gap"]["verdict"], strong["win_gap"]
+        assert "不含选股信息" in weak["win_gap"]["verdict"], weak["win_gap"]
+
+    def test_win_gap_reads_the_win_column_not_the_return_column(self):
+        """守住 _gap_of 的 attr 分派:两个 gap 不能是同一个数。
+
+        实现时 ``beats_band`` / ``_gap_verdict`` 两处曾仍读 ``matched.excess_pct``,
+        那样胜率块会把收益的数字印出来,而表头写着胜率。
+        """
+        panels = _noisy_panels()
+        out = _verdict(self._foresight(panels), panels, self.HORIZON)
+        assert out["win_gap"]["matched_excess"] == pytest.approx(out["matched"].stock_win_excess_pct, abs=1e-4)
+        assert out["win_gap"]["matched_excess"] != pytest.approx(out["gap"]["matched_excess"], abs=1e-4)
 
 
 class TestEvaluateDaily:

--- a/workflows/review_shadow_control.py
+++ b/workflows/review_shadow_control.py
@@ -12,11 +12,14 @@ full-market-control-confounds-momentum 记的就是这个坑：候选动量 +19%
 统计全部复用 ``core.funnel_effect_eval``（``match_by_momentum`` / ``sample_momentum_band``
 / ``control_gap``），这里只做形状适配，不新写一套统计口径。
 
-三栏必须同时读
+四栏必须同时读
 --------------
-- ``absolute``：拿着这批票赚不赚钱（分母=全部车道票）。
+- ``absolute``：拿着这批票赚不赚钱（分母=全部车道票），含**股级**胜率。
 - ``matched``：同动量同侪里选得好不好（分母=配对成功的子集，与对照组一致）。
-- ``control_gap``：超额是不是只来自动量选位。这是唯一能否掉「该补强」的一环。
+- ``control_gap``：收益超额是不是只来自动量选位。
+- ``win_control_gap``：胜率超额是不是只来自动量选位。胜率必须自己过一遍控制，
+  不能借收益那一栏的结论——风格择时那轮实测两栏分家：收益过了月内置换
+  （T+5 p=0.025），胜率没过（p=0.284）。
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ from core.funnel_effect_eval import (
     evaluate_daily,
     summarize_absolute,
     summarize_group,
+    win_control_gap,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - 仅类型标注，避免运行时强依赖
@@ -78,6 +82,8 @@ def evaluate_lane_control(
             "matched": matched.as_dict(),
             "controls": [c.as_dict() for c in controls],
             "control_gap": control_gap(matched, controls),
+            # 车道比较同样要看胜率:两条车道的收益差与胜率差实测会分家。
+            "win_control_gap": win_control_gap(matched, controls),
         }
     return result
 
@@ -123,13 +129,27 @@ def control_verdict_lines(summary: dict[str, Any]) -> list[str]:
 
 
 def _cell_line(cell: dict[str, Any]) -> str:
-    """绝对与超额同时出：任何一栏单看都会得出相反结论。"""
+    """绝对、股级胜率、超额同时出：任何一栏单看都会得出相反结论。
+
+    ``positive_day_pct`` 是**日级**的（当天这一篮均值为正的日子占比），不是胜率，
+    早先这里就把它写成了「胜率」。一篮 3 只 +20% / 7 只 -5%，日级算赢、股级只有
+    30%，两者能同时成立。真正回答「选出来的票赚不赚钱」的是 ``stock_win_pct``。
+    """
     absolute = cell.get("absolute") or {}
     matched = cell.get("matched") or {}
     gap = cell.get("control_gap") or {}
-    abs_txt = f"绝对 {_num(absolute.get('net_pct'))}%（胜率 {_num(absolute.get('positive_day_pct'))}%，{absolute.get('verdict')}）"
-    exc_txt = f"配对超额 {_num(matched.get('excess_pct'))}pct（t={_num(matched.get('excess_t'))}）"
-    return f"{abs_txt}；{exc_txt}；{gap.get('verdict') or '样本不足'}"
+    win_gap = cell.get("win_control_gap") or {}
+    abs_txt = (
+        f"绝对 {_num(absolute.get('net_pct'))}%"
+        f"（股级胜率 {_num(absolute.get('stock_win_pct'))}%，"
+        f"正收益日 {_num(absolute.get('positive_day_pct'))}%，{absolute.get('verdict')}）"
+    )
+    exc_txt = f"配对超额 {_num(matched.get('excess_pct'))}pct（t={_num(matched.get('excess_t'))}）→ {gap.get('verdict') or '样本不足'}"
+    win_txt = (
+        f"胜率超额 {_num(matched.get('stock_win_excess_pct'))}pct"
+        f"（t={_num(matched.get('stock_win_excess_t'))}）→ {win_gap.get('verdict') or '样本不足'}"
+    )
+    return f"{abs_txt}；{exc_txt}；{win_txt}"
 
 
 def _num(value: Any) -> str:


### PR DESCRIPTION
## 问题

`core/funnel_effect_eval.py` 是仓里对照做得最全的一环：T+1 开盘买入的可成交口径、最近邻动量 1:1 配对、5 个种子的随机负控制、`MIN_DAYS=20` 的样本闸门。但它从头到尾只量幅度（`net` / `control` / `bench_excess_pct`）。第一优先级的问题——「选出来的票赚不赚钱」——这个数它一直没有。

而且报告里那一列 `胜率` 填的是 `positive_day_pct`，那是**日级**统计（当天这一篮均值为正的日子占比）。一篮 3 只 +20% / 7 只 -5%：日级算赢，股级只有 30%，两者同时成立。照这列读会读到反的。`workflows/review_shadow_control.py` 的车道小节犯同一个错。

## 改了什么

| | |
|---|---|
| `Panels.per_stock_returns` / `stock_win_rate` | 逐只算净收益，按 `r - ROUND_TRIP_COST_PCT > 0` 判赢。毛涨 0.1% 扣完双边 0.202 是亏的，阈值在检验里面而不是事后减 |
| `MatchedBaseline.codes` | 胜率要拿基准篮自己的成分重算，均值算不出胜率来 |
| `stock_win` / `stock_win_control` | 挂在配对行与随机对照行上，共享同一个基准篮 |
| `GroupStat` +4 字段、`AbsoluteStat` +2 字段 | 逐日差分只取两侧都有值的天 |
| `control_gap` → `_gap_of` + `win_control_gap` | 胜率自己过一遍随机负控制 |
| 报告 | `胜率` 一列拆成 `股级胜率` / `正收益日`，新增胜率对照小节 |

## 两处踩过的坑，这轮显式挡住

`random_control_row` 的 docstring 记着上一次：对照栏填了候选自己的收益，gap 恒等于 0.0000，完美先知（+5.79pct / t=+35.6）和纯随机（-0.14pct）拿到同一句判定。胜率这栏用共享基准篮，并且有判别性回归——`win_gap` 必须能把完美先知和随机选票分开。

抽 `_gap_of` 时我把两处 `matched.excess_pct` 漏着没改，会在胜率表头下印出收益的数字。`test_win_gap_reads_the_win_column_not_the_return_column` 挡这个。

缺一侧填 0 会把「算不出来」读成「胜率 0%」，凭空造负超额；与 `bench_excess` 那道 guard 同源。

## 为什么胜率不能借收益那栏的结论

风格择时那轮实测两栏分家：收益过了月内置换（T+5 p=0.025 / T+10 p=0.001），胜率没过（p=0.284，见 `docs/evidence/style_timing_win.json`）。趋势强度预测的是亏多少，不是赢不赢。

## 验证

`955 passed`。`ruff format --check` / `ruff check` / `--check-no-sql` 全过。

本轮只补口径，**不动任何生产开关**，也还没跑出实际读数。
