### PR TITLE
fix(trigger): 重放帧漏了 pct_chg，触发面板从没生成过

### DIFF
--- a/scripts/evaluate_trigger_weight.py
+++ b/scripts/evaluate_trigger_weight.py
@@ -185,6 +185,40 @@ def merge_panel(feats: pd.DataFrame, panel: pd.DataFrame) -> pd.DataFrame:
     return merged
 
 
+def build_replay_payload(market: pd.DataFrame) -> dict[str, object]:
+    """把全市场行情摊成共享给子进程的列数组。
+
+    单独成函数是为了让测试能不起进程池就走完整条重放路径：
+    build_replay_payload -> _init_worker -> _replay_symbol。之前这段内联在
+    gen_panel 里，测试只能另手搓一个帧,于是漏列这类事测不出来 —— 首轮定时轮
+    就是死在这:帧里没 pct_chg,_detect_evr 与 _detect_sos 在池子里抛 KeyError。
+    """
+    df = market.copy()
+    if "pct_chg" not in df.columns:
+        # 缓存行情可能是早于 FIELDS 的旧文件。不用 close.pct_change() 兜底：
+        # tushare daily 给的是不复权价，除权日 close 跳空，推出来的涨跌幅在那些
+        # 日子上是假的大值，正好落在 _detect_evr / _detect_sos 的判据上。
+        raise SystemExit(f"缓存行情缺 pct_chg 列，删掉 {PANEL_CACHE}/market.csv 重新取数")
+    for col in ("open", "high", "low", "close", "vol"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    df = df.dropna(subset=["open", "high", "low", "close", "vol"])
+    # pct_chg 不进 dropna：每只票首个 bar 无前收,天然是 NaN,检测器逐日自己判
+    # （_detect_evr 在 day_pct 处、_detect_sos 同式）。丢行会把首 bar 连带删掉。
+    df["pct_chg"] = pd.to_numeric(df["pct_chg"], errors="coerce")
+    codes, cidx = np.unique(df["ts_code"].to_numpy(), return_inverse=True)
+    return {
+        "codes": codes,
+        "cidx": cidx,
+        "dates": df["trade_date"].to_numpy(dtype=np.int64),
+        "open": df["open"].to_numpy(dtype=np.float64),
+        "high": df["high"].to_numpy(dtype=np.float64),
+        "low": df["low"].to_numpy(dtype=np.float64),
+        "close": df["close"].to_numpy(dtype=np.float64),
+        "volume": df["vol"].to_numpy(dtype=np.float64),
+        "pct_chg": df["pct_chg"].to_numpy(dtype=np.float64),
+    }
+
+
 _PANEL: dict[str, object] = {}
 
 
@@ -206,6 +240,9 @@ def _replay_symbol(ci: int) -> list[tuple[str, int, float, int, str]]:
     mask = cidx == ci
     if int(mask.sum()) < MIN_BARS:
         return []
+    # 这些列名要和生产 df_map 对齐:六个检测器里 _detect_evr 与 _detect_sos 都读
+    # pct_chg,缺了会在池子里抛 KeyError 而整轮重放退出（面板生成不了,依赖它的
+    # Trigger Points Eval 也跟着挂）。加列前先看 production_detectors() 读了什么。
     frame = pd.DataFrame(
         {
             "date": _PANEL["dates"][mask],  # type: ignore[index]
@@ -214,6 +251,7 @@ def _replay_symbol(ci: int) -> list[tuple[str, int, float, int, str]]:
             "low": _PANEL["low"][mask],  # type: ignore[index]
             "close": _PANEL["close"][mask],  # type: ignore[index]
             "volume": _PANEL["volume"][mask],  # type: ignore[index]
+            "pct_chg": _PANEL["pct_chg"][mask],  # type: ignore[index]
         }
     ).sort_values("date", ignore_index=True)
     out: list[tuple[str, int, float, int, str]] = []
@@ -237,21 +275,8 @@ def gen_panel(market: pd.DataFrame, cache: Path, workers: int) -> None:
     """多进程重放触发面板。全市场约 90 分钟，结果落缓存供后续统计复用。"""
     from multiprocessing import Pool, cpu_count
 
-    df = market.copy()
-    for col in ("open", "high", "low", "close", "vol"):
-        df[col] = pd.to_numeric(df[col], errors="coerce")
-    df = df.dropna(subset=["open", "high", "low", "close", "vol"])
-    codes, cidx = np.unique(df["ts_code"].to_numpy(), return_inverse=True)
-    payload = {
-        "codes": codes,
-        "cidx": cidx,
-        "dates": df["trade_date"].to_numpy(dtype=np.int64),
-        "open": df["open"].to_numpy(dtype=np.float64),
-        "high": df["high"].to_numpy(dtype=np.float64),
-        "low": df["low"].to_numpy(dtype=np.float64),
-        "close": df["close"].to_numpy(dtype=np.float64),
-        "volume": df["vol"].to_numpy(dtype=np.float64),
-    }
+    payload = build_replay_payload(market)
+    codes = payload["codes"]
     n_workers = workers if workers > 0 else max(cpu_count() - 2, 2)
     print(f"[trigw] 重放 {len(codes)} 只 / {n_workers} 进程")
     rows: list[tuple[str, int, float, int, str]] = []

--- a/tests/core/test_trigger_weight_eval.py
+++ b/tests/core/test_trigger_weight_eval.py
@@ -548,3 +548,97 @@ class TestReplayWrappers:
     def test_replay_bars_cover_the_longest_lookback(self):
         """检测器要看 200 日 MA;预热不够会把早段截面静默判成不触发。"""
         assert MIN_REPLAY_BARS >= 210
+
+    def test_every_detector_runs_on_the_replay_frame(self):
+        """六个检测器都得能吃下重放帧。
+
+        首轮定时轮（33953595070）就是死在这:重放帧只摊了 open/high/low/close/
+        volume,而 _detect_evr 与 _detect_sos 都读 pct_chg,于是在进程池里抛
+        KeyError、整轮退出,面板没生成,依赖面板的 Trigger Points Eval 跟着挂。
+        逐个检测器单独断言,漏哪一列能直接看出是哪个检测器要的。
+        """
+        import numpy as np
+        import pandas as pd
+
+        from core.wyckoff_engine import FunnelConfig
+
+        n = MIN_REPLAY_BARS + 20
+        rng = np.random.default_rng(11)
+        close = 10.0 * np.cumprod(1.0 + rng.normal(0.0004, 0.02, n))
+        frame = pd.DataFrame(
+            {
+                "date": [int(d.strftime("%Y%m%d")) for d in pd.bdate_range("2025-01-02", periods=n)],
+                "open": close * (1 + rng.normal(0, 0.004, n)),
+                "high": close * (1 + np.abs(rng.normal(0, 0.012, n))),
+                "low": close * (1 - np.abs(rng.normal(0, 0.012, n))),
+                "close": close,
+                "volume": rng.integers(4_000_000, 40_000_000, n).astype(float),
+                "pct_chg": pd.Series(close).pct_change().mul(100).to_numpy(),
+            }
+        )
+        cfg = FunnelConfig()
+        limit = replay_entry_bias_limit("600000.SH", frame, cfg)
+        for kind, fn in production_detectors():
+            score = fn(frame, cfg, max_bias_200=limit, code="600000.SH")
+            assert score is None or isinstance(score, float), kind
+
+    def test_replay_frame_carries_every_column_detectors_read(self):
+        """走完 build_replay_payload -> _init_worker -> _replay_symbol 这条真实路径。
+
+        不起进程池:池子里的异常会被包成 RemoteTraceback,测试里看不清是谁抛的。
+        直接在本进程调 worker,漏列会以原样 KeyError 冒出来。
+        """
+        import numpy as np
+        import pandas as pd
+
+        from scripts.evaluate_trigger_weight import _init_worker, _replay_symbol, build_replay_payload
+
+        n = MIN_REPLAY_BARS + 15
+        rng = np.random.default_rng(3)
+        rows = []
+        for code in ("600000.SH", "300001.SZ"):
+            close = 10.0 * np.cumprod(1.0 + rng.normal(0.0005, 0.022, n))
+            for i, day in enumerate(pd.bdate_range("2025-01-02", periods=n)):
+                prev = close[i - 1] if i else close[0]
+                rows.append(
+                    {
+                        "ts_code": code,
+                        "trade_date": int(day.strftime("%Y%m%d")),
+                        "open": close[i] * 0.998,
+                        "high": close[i] * 1.012,
+                        "low": close[i] * 0.988,
+                        "close": close[i],
+                        "vol": float(rng.integers(4_000_000, 40_000_000)),
+                        "amount": float(rng.integers(80_000, 900_000)),
+                        "pct_chg": (close[i] / prev - 1.0) * 100.0,
+                    }
+                )
+        payload = build_replay_payload(pd.DataFrame(rows))
+        _init_worker(payload)
+        for ci in range(len(payload["codes"])):
+            for row in _replay_symbol(ci):
+                assert len(row) == 5
+
+    def test_missing_pct_chg_fails_loudly_instead_of_deriving(self):
+        """旧缓存缺列时要报错退出,不许用 close.pct_change() 兜底。
+
+        tushare daily 是不复权价,除权日 close 跳空,推出来的涨跌幅在那几天是假的
+        大值 —— 正好落在 _detect_evr / _detect_sos 的判据上,面板会静默变脏。
+        """
+        import pandas as pd
+
+        from scripts.evaluate_trigger_weight import build_replay_payload
+
+        market = pd.DataFrame(
+            {
+                "ts_code": ["600000.SH"] * 3,
+                "trade_date": [20250102, 20250103, 20250106],
+                "open": [10.0, 10.1, 10.2],
+                "high": [10.3, 10.4, 10.5],
+                "low": [9.9, 10.0, 10.1],
+                "close": [10.1, 10.2, 10.3],
+                "vol": [1e6, 1.1e6, 1.2e6],
+            }
+        )
+        with pytest.raises(SystemExit, match="pct_chg"):
+            build_replay_payload(market)


### PR DESCRIPTION
## 问题

Trigger Weight Eval 的定时轮从来没跑成过。唯一一次运行（run 33953595070，2026-09-05
07:49Z）在进程池里抛 `KeyError: 'pct_chg'` 退出，面板没生成；依赖面板的 Trigger Points
Eval 随即撞在缺文件守卫上失败。两个失败是一个根因。

`_replay_symbol` 摊出的重放帧只有 `date/open/high/low/close/volume` 六列，而
`production_detectors()` 里的 `_detect_evr` 与 `_detect_sos` 都读 `pct_chg`
（`core/wyckoff_engine.py:1275` 与 `:1395`）。缺列不是数据问题，重放路径本身没通。

漏得掉的原因在测试形状：`TestReplayWrappers` 里那个六列帧是测试自己搓的，只喂给
`replay_entry_bias_limit`，没喂给六个检测器；而生产帧的构造逻辑内联在 `gen_panel`
里，测试碰不到，两边于是各自成立。

工作流头部注释里「首轮 2026-08-31、423 个交易日」那批结论不是这个定时任务产出的
（`gh run list` 只有一次 failure 记录），本 PR 不动那些数字。

## 变更

- `gen_panel` 的载荷构造抽成 `build_replay_payload()`，重放帧补上 `pct_chg`
- 旧缓存缺该列时报错退出，不用 `close.pct_change()` 兜底：tushare `daily` 是不复权价，
  除权日 `close` 跳空，推出来的涨跌幅在那几天是假的大值，正好落在 `_detect_evr` /
  `_detect_sos` 的判据上，面板会静默变脏
- `pct_chg` 不进 `dropna`：每只票首个 bar 无前收，天然 NaN，检测器逐日自己判

不改任何权重、阈值与判定口径。

## 验证

新增三个用例，都在 `TestReplayWrappers`：

- 六个检测器逐个吃重放帧，漏哪列能看出是哪个检测器要的
- 走完 `build_replay_payload -> _init_worker -> _replay_symbol` 真实路径（不起进程池，
  否则异常被包成 `RemoteTraceback` 看不清抛点）
- 缺列时 `SystemExit`，锁住「不许推导兜底」

判别性已验证：把 `_replay_symbol` 里那行 `pct_chg` 去掉重跑，
`test_replay_frame_carries_every_column_detectors_read` 以原样 `KeyError: 'pct_chg'`
失败；恢复后 7 项全过。

```
tests/core/test_trigger_weight_eval.py            72 passed
tests/test_architecture_boundaries.py             24 passed
ruff check / ruff format --check                  clean
```

面板重放本身约 90 分钟、需 210 个 bar 预热，没在本地跑全量；下次周六定时轮
（UTC 周六 03:35）能验证端到端。
