### PR TITLE
fix(trigger): 重放帧不带换手率,量到的 EVR 比生产宽 27%

### DIFF
--- a/core/trigger_weight_eval.py
+++ b/core/trigger_weight_eval.py
@@ -168,7 +168,12 @@ def replay_entry_bias_limit(code: str, frame: pd.DataFrame, cfg: object) -> floa
     """重放用的 ``max_bias_200`` 上限，与生产 ``layer4_triggers`` 同式。
 
     ``channel=""``、``rps_slow=None``：不复现 L2 的通道放宽，取全局/科创板上限，
-    所以重放出的触发率是**下界**。同样为了绕开私有成员边界而收在 core 里。
+    所以**这一项**让重放触发率偏低。同样为了绕开私有成员边界而收在 core 里。
+
+    别把它读成整体下界：曾经另有一个反向偏差与它同时在（重放帧不带 turnover，
+    ``_evr_turnover_ok`` 缺列即放行，量到的 EVR 比生产宽约 27%），两者符号相反、
+    量级都不清楚时触发率哪个方向都不构成界。turnover 已在
+    ``build_replay_payload`` 补齐；再往重放帧里省列前先想清楚符号。
     """
     from core.wyckoff_engine import _effective_entry_max_bias_200, _ret120_pct
 

--- a/scripts/evaluate_trigger_weight.py
+++ b/scripts/evaluate_trigger_weight.py
@@ -216,7 +216,40 @@ def build_replay_payload(market: pd.DataFrame) -> dict[str, object]:
         "close": df["close"].to_numpy(dtype=np.float64),
         "volume": df["vol"].to_numpy(dtype=np.float64),
         "pct_chg": df["pct_chg"].to_numpy(dtype=np.float64),
+        "turnover": _replay_turnover(df),
     }
+
+
+def _replay_turnover(df: pd.DataFrame) -> np.ndarray:
+    """换手率(%)，与生产 workflows/funnel_data.py::_attach_turnover 同式同源。
+
+    生产在装配数据时就补了这一列，重放不补的话 _evr_turnover_ok 走"缺列即通过"
+    分支，量到的是一个比生产更松的 EVR：实测重放 EVR 触发日有 21% 落在
+    evr_min_turnover=1.5 以下，即多算约 27%。而模块头说重放触发率是"下界"
+    （漏了 L2 通道放宽），方向正相反 —— 两个偏差同时在，面板的 EVR 触发率
+    哪个方向都不构成界。
+
+    单位链错 100 倍会凭空造出或抹掉整个效应，逐段核过：生产
+    data_source_tushare 把 vol 乘 100 后存进 volume（股），这里的 vol 是
+    tushare 原始值（手），流通股本缓存已是股，故 vol*100/float_share*100。
+    """
+    from integrations.market_metadata import fetch_float_share_map
+
+    float_share_map = fetch_float_share_map()
+    if not float_share_map:
+        # 不学生产的 warning-then-continue：生产宁可少一道闸也要出票，而一份
+        # 静默量着更松检测器的评估产物比没有产物更糟 —— 拿它的幅度推断生产,
+        # 错的方向还不知道。
+        raise SystemExit("流通股本映射为空，重放会量到比生产更松的 EVR；先修数据源再跑")
+    symbols = df["ts_code"].astype(str).str.split(".").str[0]
+    # 缺流通股本的填 NaN 不填 0：_evr_turnover_ok 对 NaN 也是放行，与生产对齐；
+    # 填 0 会把方向反过来变成整只票全拒。
+    float_share = symbols.map(float_share_map).astype(float)
+    float_share = float_share.where(float_share > 0)
+    turnover = df["vol"].to_numpy(dtype=np.float64) * 100.0 / float_share.to_numpy(dtype=np.float64) * 100.0
+    covered = int(np.isfinite(turnover).sum())
+    print(f"[trigw] 换手率折算覆盖: {covered:,}/{len(turnover):,} ({covered / max(len(turnover), 1):.1%})")
+    return turnover
 
 
 _PANEL: dict[str, object] = {}
@@ -242,7 +275,9 @@ def _replay_symbol(ci: int) -> list[tuple[str, int, float, int, str]]:
         return []
     # 这些列名要和生产 df_map 对齐:六个检测器里 _detect_evr 与 _detect_sos 都读
     # pct_chg,缺了会在池子里抛 KeyError 而整轮重放退出（面板生成不了,依赖它的
-    # Trigger Points Eval 也跟着挂）。加列前先看 production_detectors() 读了什么。
+    # Trigger Points Eval 也跟着挂）。turnover 缺的表现相反 —— 不报错,
+    # _evr_turnover_ok 静默放行,量到一个比生产松 27% 的 EVR。加列前先看
+    # production_detectors() 读了什么,也看生产 df_map 装配时补了什么。
     frame = pd.DataFrame(
         {
             "date": _PANEL["dates"][mask],  # type: ignore[index]
@@ -252,6 +287,7 @@ def _replay_symbol(ci: int) -> list[tuple[str, int, float, int, str]]:
             "close": _PANEL["close"][mask],  # type: ignore[index]
             "volume": _PANEL["volume"][mask],  # type: ignore[index]
             "pct_chg": _PANEL["pct_chg"][mask],  # type: ignore[index]
+            "turnover": _PANEL["turnover"][mask],  # type: ignore[index]
         }
     ).sort_values("date", ignore_index=True)
     out: list[tuple[str, int, float, int, str]] = []

--- a/tests/core/test_trigger_weight_eval.py
+++ b/tests/core/test_trigger_weight_eval.py
@@ -582,7 +582,7 @@ class TestReplayWrappers:
             score = fn(frame, cfg, max_bias_200=limit, code="600000.SH")
             assert score is None or isinstance(score, float), kind
 
-    def test_replay_frame_carries_every_column_detectors_read(self):
+    def test_replay_frame_carries_every_column_detectors_read(self, monkeypatch):
         """走完 build_replay_payload -> _init_worker -> _replay_symbol 这条真实路径。
 
         不起进程池:池子里的异常会被包成 RemoteTraceback,测试里看不清是谁抛的。
@@ -591,8 +591,10 @@ class TestReplayWrappers:
         import numpy as np
         import pandas as pd
 
+        import integrations.market_metadata as meta
         from scripts.evaluate_trigger_weight import _init_worker, _replay_symbol, build_replay_payload
 
+        monkeypatch.setattr(meta, "fetch_float_share_map", lambda: {"600000": 1e9, "300001": 5e8})
         n = MIN_REPLAY_BARS + 15
         rng = np.random.default_rng(3)
         rows = []
@@ -614,6 +616,11 @@ class TestReplayWrappers:
                     }
                 )
         payload = build_replay_payload(pd.DataFrame(rows))
+        # 生产 df_map 在装配阶段补了 turnover(workflows/funnel_data.py::_attach_turnover)。
+        # 单靠上面那趟 _replay_symbol 兜不住这一列:漏了它 _evr_turnover_ok 走
+        # "缺列即通过"分支,不抛错、面板照样生成,只是量到的 EVR 比生产宽约 27%。
+        # 所以这里显式点名,别删。
+        assert "turnover" in payload
         _init_worker(payload)
         for ci in range(len(payload["codes"])):
             for row in _replay_symbol(ci):
@@ -641,4 +648,70 @@ class TestReplayWrappers:
             }
         )
         with pytest.raises(SystemExit, match="pct_chg"):
+            build_replay_payload(market)
+
+    def test_replay_turnover_matches_production_units(self, monkeypatch):
+        """换手率的**数值**要对,不只是列在。
+
+        断言具体数字是因为这里的静默腐化模式是差 100 倍:生产
+        data_source_tushare 把 vol 乘 100 存进 volume(股),而这里的 vol 是 tushare
+        原始值(手),流通股本缓存已是股。少乘一次 100 就让全市场换手率变成百分之
+        一,evr_min_turnover=1.5 从此恒不通过 —— 只断言列在的话测不出来。
+
+        50,000 手 = 500 万股,流通股本 10 亿股,换手率 0.5%。
+        """
+        import numpy as np
+        import pandas as pd
+
+        import integrations.market_metadata as meta
+        from scripts.evaluate_trigger_weight import build_replay_payload
+
+        monkeypatch.setattr(meta, "fetch_float_share_map", lambda: {"600000": 1e9})
+        market = pd.DataFrame(
+            {
+                "ts_code": ["600000.SH", "600000.SH", "000002.SZ"],
+                "trade_date": [20250102, 20250103, 20250102],
+                "open": [10.0, 10.1, 20.0],
+                "high": [10.3, 10.4, 20.5],
+                "low": [9.9, 10.0, 19.5],
+                "close": [10.1, 10.2, 20.2],
+                "vol": [50_000.0, 100_000.0, 50_000.0],
+                "pct_chg": [1.0, 0.99, 1.0],
+            }
+        )
+        turnover = np.asarray(build_replay_payload(market)["turnover"], dtype=float)
+        # 行序跟着 build_replay_payload 里的 dropna,按 ts_code 定位而非猜下标
+        by_code = dict(zip(market["ts_code"] + market["trade_date"].astype(str), turnover))
+        assert by_code["600000.SH20250102"] == pytest.approx(0.5)
+        assert by_code["600000.SH20250103"] == pytest.approx(1.0)
+        # 映射里没有的票填 NaN 不填 0:_evr_turnover_ok 对 NaN 放行(与生产一致),
+        # 填 0 会反向变成整只票全拒。
+        assert np.isnan(by_code["000002.SZ20250102"])
+
+    def test_empty_float_share_map_fails_loudly(self, monkeypatch):
+        """流通股本映射空了要退出,不许照生产那样 warning 后继续。
+
+        生产宁可少一道闸也要出票,评估脚本不行:静默少了 turnover 就是在量一个比
+        生产宽约 27% 的 EVR(重放 EVR 触发日有 21% 落在 evr_min_turnover 以下),
+        而模块头说触发率是"下界"、方向正相反。一份不知偏向哪边的产物比没有更糟。
+        """
+        import pandas as pd
+
+        import integrations.market_metadata as meta
+        from scripts.evaluate_trigger_weight import build_replay_payload
+
+        monkeypatch.setattr(meta, "fetch_float_share_map", lambda: {})
+        market = pd.DataFrame(
+            {
+                "ts_code": ["600000.SH"],
+                "trade_date": [20250102],
+                "open": [10.0],
+                "high": [10.3],
+                "low": [9.9],
+                "close": [10.1],
+                "vol": [1e6],
+                "pct_chg": [1.0],
+            }
+        )
+        with pytest.raises(SystemExit, match="流通股本"):
             build_replay_payload(market)


### PR DESCRIPTION
## 问题

生产在装配数据那一步就补了 `turnover` 列（[`workflows/funnel_data.py::_attach_turnover`](workflows/funnel_data.py)，用流通股本把成交量折算成换手率），检测器之后才跑。重放路径没有这一步，而 `_evr_turnover_ok` 对缺列的处理是**当通过**：

```python
if "turnover" not in frame.columns or float(cfg.evr_min_turnover) <= 0:
    return True
```

于是重放量到的不是生产那个检测器，是一个更松的变体。这类缺列不像上一轮的 `pct_chg`（抛 KeyError、整轮退出、面板生成不了），它不报错 —— 面板照样出，只是数偏了。

## 量级

用本地行情缓存 + 流通股本映射把这列补上重算：**30,316 个重放 EVR 触发日里 6,365 天（21.0%）的换手率低于 `evr_min_turnover = 1.5`**，生产会拒而重放全留，相对生产**多算约 27%**。

生产那道闸是活的，不是两边都死 —— 这一层是关键，不然结论就反了。EVR 那些行的流通股本覆盖 **99.6%**（30,443 行只有 127 缺或非正），两侧都用 `_ts_code_to_symbol` 归一到裸 6 位，join 是对的。

单位链逐段核过，这里错 100 倍会凭空造出或抹掉整个效应：生产 `data_source_tushare` 把 vol 乘 100 后存进 `volume`（股），缓存里的 `vol` 是 tushare 原始值（手），流通股本缓存已是股，故 `vol*100/float_share*100`。折算出来 EVR 日换手率中位数 3.24%，是个正常的 A 股数。

## 方向与文档说法相反

`replay_entry_bias_limit` 的文档说重放触发率是**下界**（理由是不复现 L2 通道放宽）。EVR 这一项偏差往另一边去。两个偏差符号相反、量级都不清楚时，面板的 EVR 触发率**哪个方向都不构成界**。顺手把那句话改成只讲自己那一项，并留了下次往重放帧省列前先想符号的提示。

## 两个刻意与生产不同的地方

- **流通股本缺失填 NaN 不填 0。** NaN 在 `_evr_turnover_ok` 里放行，与生产一致；填 0 会把方向反过来变成整只票全拒。
- **映射整个空了直接 `SystemExit`**，不学生产的 warning-then-continue。生产宁可少一道闸也要出票，评估脚本不行：一份静默量着更松检测器的产物比没有产物更糟，拿它的幅度推断生产，连错的方向都不知道。

## 测试

断言换手率的**具体数值**（50,000 手 / 10 亿股 = 0.5%），不只断言列在 —— 这里的静默腐化模式是差 100 倍，少乘一次 100 会让全市场换手率变成百分之一、`evr_min_turnover` 从此恒不通过。另有空映射的硬失败测试，以及在真实路径测试里显式点名 `turnover` 在 payload 里（那趟 `_replay_symbol` 兜不住它，因为漏了不抛错）。

判别性验过：摘掉补列的两行 → 2 个测试红；少乘一次 100 → 单位测试红。

## 本轮不动 `evr_min_turnover`

生产拒掉的低换手那批 T+10 胜率确实更高（50.2% vs 45.9%，+4.30pct，置换 p<0.001，随机带 ±1.41），看着像"闸门在拒好票"。但低换手在这个窗口是**全市场溢价**，不是 EVR 的性质：按半年逐段跟同期全市场基准配对后，残差只剩 **+0.55pct，t=+0.33，5 个半年 2 个为正，区间 [-4.25, +5.19]**。

汇总口径之所以骗人：全市场那条序列在半年间反号（-3.99 … +7.69）、整窗自己抵消掉了，而 EVR 窗口起点更晚（没有 24H1）。两个有效窗口不同的汇总数放在一起比，差值被放大。

胜率口径按既有约定做：T+1 开盘进场（不用买不到的信号日收盘）、前瞻窗口不足就丢不做截断、胜率扣 0.4% 双边成本、每个差值配置换带。
