### PR TITLE
feat(funnel-eval): 逐对随机互换固化成否证工具

### DIFF
--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -36,8 +36,9 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from statistics import mean
+from statistics import mean, pstdev
 from typing import Any
 
 from core.pattern_forward_eval import ROUND_TRIP_COST_PCT
@@ -50,6 +51,9 @@ MIN_DAYS = 20
 CONTROL_SEEDS = (11, 23, 37, 53, 71)
 # 配对时允许的 20 日动量绝对偏差上限（百分点）。超出即视为无可配对对象。
 MOM_MATCH_TOL_PCT = 3.0
+# 逐对随机互换的置换次数。200 次让单侧 p 的分辨率到 0.005，足够判 0.05 这道门槛；
+# 再加收益递减，而每次置换都要把每天两篮的收益重算一遍。
+N_SWAP_PERMUTATIONS = 200
 
 
 def tstat(values: list[float]) -> float | None:
@@ -626,3 +630,185 @@ def _gap_verdict(matched: float, usable: list[float], *, gap: float, spread: flo
             f"配对超额高过随机负控制上界，但差距 {gap:+.3f}pct 未超过种子宽度 {spread:.3f}pct：证据不足，不能算选股信息"
         )
     return "配对超额跑赢随机负控制：含独立选股信息"
+
+
+@dataclass
+class SwapDay:
+    """一天的配对结果。``pairs`` 里每个元组是 (待测组成员, 对照组成员)，动量已配平。
+
+    配对本身由 ``match_by_momentum`` 之类的最近邻配对产出，这里只负责拿着不动。
+    """
+
+    date: str
+    buy_ds: str
+    sell_ds: str
+    pairs: list[tuple[str, str]]
+
+
+def swap_arms(pairs: list[tuple[str, str]], *, rng: random.Random) -> tuple[list[str], list[str]]:
+    """逐对随机互换：每一对独立以 1/2 概率交换两个成员的组别归属。
+
+    这是整个否证的全部随机性来源。**必须**返回互换后的分组，别图省事拿原始标签去
+    算差值——那样零假设分布会退化成一堆与观测值相同的数，p 恒等于 1，工具看着在跑
+    实际上什么都没检验。回归测试 ``TestSwapFalsification`` 用「完美标签必须 p→0」
+    守这一条。
+    """
+    arm_a: list[str] = []
+    arm_b: list[str] = []
+    for first, second in pairs:
+        if rng.random() < 0.5:
+            arm_a.append(first)
+            arm_b.append(second)
+        else:
+            arm_a.append(second)
+            arm_b.append(first)
+    return arm_a, arm_b
+
+
+# 两栏各自成一道否证。收益过了不蕴含胜率过了（见 ``win_control_gap``），所以两栏
+# 都算、都报，不允许用一栏的结论替另一栏。
+SWAP_METRICS: dict[str, Callable[[Panels, list[str], str, str], float | None]] = {
+    "stock_win": lambda p, codes, buy, sell: p.stock_win_rate(codes, buy, sell),
+    "gross_return": lambda p, codes, buy, sell: p.gross_return(codes, buy, sell),
+}
+
+
+@dataclass
+class SwapTest:
+    """一栏的逐对随机互换结果。``*_pct`` 都是「待测组 − 对照组」的日均差（百分点）。"""
+
+    column: str
+    days: int
+    avg_pairs: float
+    observed_pct: float
+    null_avg_pct: float
+    null_sd_pct: float
+    p_one_sided: float
+    p_two_sided: float
+    permutations: int
+
+    @property
+    def verdict(self) -> str:
+        """三种不通过要分开说，理由不同（同 ``_gap_verdict`` 的用意）。"""
+        if self.days < MIN_DAYS:
+            return f"可评估日仅 {self.days} 天（门槛 {MIN_DAYS}）：尚未可知，不是没通过"
+        if self.observed_pct <= 0:
+            return f"待测组反而更差（{self.observed_pct:+.3f}pct）：这个标签没有正向信息"
+        if self.p_two_sided > 0.05:
+            return f"观测差 {self.observed_pct:+.3f}pct 落在互换零分布内（双侧 p={self.p_two_sided:.3f}）：配平动量后该标签不含信息"
+        return (
+            f"观测差 {self.observed_pct:+.3f}pct 超出互换零分布（双侧 p={self.p_two_sided:.3f}）："
+            "过了这一道，但还要收紧配对容差、按月拆开才能算筛"
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "column": self.column,
+            "days": self.days,
+            "avg_pairs": _round(self.avg_pairs, 2),
+            "observed_pct": _round(self.observed_pct, 3),
+            "null_avg_pct": _round(self.null_avg_pct, 3),
+            "null_sd_pct": _round(self.null_sd_pct, 3),
+            "p_one_sided": _round(self.p_one_sided, 4),
+            "p_two_sided": _round(self.p_two_sided, 4),
+            "permutations": self.permutations,
+            "verdict": self.verdict,
+        }
+
+
+def swap_falsification(
+    days: list[SwapDay],
+    panels: Panels,
+    *,
+    n_perm: int = N_SWAP_PERMUTATIONS,
+) -> dict[str, SwapTest]:
+    """逐对随机互换否证：配平动量之后，这个标签本身还含信息吗？
+
+    比 ``sample_momentum_band`` 严在哪：那个每天重新抽一篮，抽样噪声里混着「换了一
+    批票」这件事；这个把配对**完全钉住**，只抹掉标签，零假设正好是「配平动量后该
+    标签不含信息」。同一批票、同一个动量位置，只问分组本身有没有意义。
+
+    p 值偏乐观，报告里必须写出来：持有窗口逐日重叠，日间观测不独立，而置换零分布
+    按独立处理。这与 t 值虚高是同一个来源。
+
+    **过了这一道不等于是个筛。** 实测反例：振幅上限 cap=7.0 拿到胜率单侧 p=0.020、
+    收益 p<0.005，随后两道否证把它杀了——配对容差从 3.0 收到 0.5，残差动量 -1.18→
+    -0.11，胜率差 +5.44→+3.18；去掉 2026-07 直接反号成 -4.71。所以拿到小 p 之后固定
+    还要跑：①收紧容差看效应是否存活；②按月拆开看是否单月扛着。
+
+    返回 ``{列名: SwapTest}``，两栏都在（胜率、收益）。一天不足 ``MIN_HITS_PER_DAY``
+    对的直接丢；一对可评估日都没有则返回空 dict。
+    """
+    usable = [d for d in days if len(d.pairs) >= MIN_HITS_PER_DAY]
+    observed: dict[str, list[float]] = {col: [] for col in SWAP_METRICS}
+    for day in usable:
+        arm_a = [a for a, _ in day.pairs]
+        arm_b = [b for _, b in day.pairs]
+        for col, metric in SWAP_METRICS.items():
+            diff = _arm_diff(panels, metric, arm_a, arm_b, day)
+            if diff is not None:
+                observed[col].append(diff)
+
+    # 零分布：同一批置换驱动两栏，种子不含列名。两栏共用抽样，判定才在同一基准上。
+    null: dict[str, list[float]] = {col: [] for col in SWAP_METRICS}
+    for i in range(n_perm):
+        drawn: dict[str, list[float]] = {col: [] for col in SWAP_METRICS}
+        for day in usable:
+            rng = random.Random(f"{i}:{day.date}")
+            arm_a, arm_b = swap_arms(day.pairs, rng=rng)
+            for col, metric in SWAP_METRICS.items():
+                diff = _arm_diff(panels, metric, arm_a, arm_b, day)
+                if diff is not None:
+                    drawn[col].append(diff)
+        for col, vals in drawn.items():
+            if vals:
+                null[col].append(mean(vals))
+
+    out: dict[str, SwapTest] = {}
+    for col, obs_vals in observed.items():
+        if not obs_vals or len(null[col]) < 2:
+            continue
+        obs = mean(obs_vals)
+        draws = null[col]
+        out[col] = SwapTest(
+            column=col,
+            days=len(obs_vals),
+            avg_pairs=mean(len(d.pairs) for d in usable),
+            observed_pct=obs,
+            null_avg_pct=mean(draws),
+            null_sd_pct=pstdev(draws),
+            p_one_sided=_perm_p(obs, draws, two_sided=False),
+            # 双侧是默认判据：提案方向几乎总是扫过来的（振幅那轮扫了 3 档上限 ×
+            # 3 个持有期），单侧会把「扫出来的方向」当成事先定的方向。
+            p_two_sided=_perm_p(obs, draws, two_sided=True),
+            permutations=len(draws),
+        )
+    return out
+
+
+def _arm_diff(
+    panels: Panels,
+    metric: Callable[[Panels, list[str], str, str], float | None],
+    arm_a: list[str],
+    arm_b: list[str],
+    day: SwapDay,
+) -> float | None:
+    """一天里两篮的差值。任一篮算不出（行情缺失）则整天不收录，避免拿半天凑数。"""
+    va = metric(panels, arm_a, day.buy_ds, day.sell_ds)
+    vb = metric(panels, arm_b, day.buy_ds, day.sell_ds)
+    if va is None or vb is None:
+        return None
+    return va - vb
+
+
+def _perm_p(observed: float, draws: list[float], *, two_sided: bool) -> float:
+    """置换 p 值，用 (r+1)/(n+1)。
+
+    不能写成 r/n：200 次抽样最小只能说到 1/201≈0.005，硬报 p=0.000 是把分辨率之外
+    的东西当成结论。加一等于把观测值本身算进零分布，这也是置换检验的标准做法。
+    """
+    if two_sided:
+        hits = sum(1 for v in draws if abs(v) >= abs(observed))
+    else:
+        hits = sum(1 for v in draws if v >= observed)
+    return (hits + 1) / (len(draws) + 1)

--- a/tests/core/test_funnel_effect_eval.py
+++ b/tests/core/test_funnel_effect_eval.py
@@ -14,6 +14,7 @@ from core.funnel_effect_eval import (
     MOM_MATCH_TOL_PCT,
     GroupStat,
     Panels,
+    SwapDay,
     control_gap,
     evaluate_daily,
     match_by_momentum,
@@ -21,6 +22,8 @@ from core.funnel_effect_eval import (
     sample_momentum_band,
     summarize_absolute,
     summarize_group,
+    swap_arms,
+    swap_falsification,
     tstat,
     win_control_gap,
 )
@@ -764,3 +767,136 @@ class TestControlGap:
     def test_ignores_seeds_without_excess(self):
         gap = control_gap(self._stat(0.35), [self._stat(0.10), self._stat(0.30), self._stat(None)])
         assert gap["seeds"] == 2
+
+
+def _swap_days(pairs_by_day: list[list[tuple[str, str]]]) -> list[SwapDay]:
+    return [SwapDay(date=f"d{i}", buy_ds=f"b{i}", sell_ds=f"s{i}", pairs=pairs) for i, pairs in enumerate(pairs_by_day)]
+
+
+def _swap_panels(days: list[SwapDay], ret) -> Panels:
+    """只填 open/close：逐对随机互换用不到 liquid/mom20/dates（配对已在入参里钉死）。"""
+    opens: dict[str, dict[str, float]] = {}
+    closes: dict[str, dict[str, float]] = {}
+    for i, day in enumerate(days):
+        codes = [c for pair in day.pairs for c in pair]
+        opens[day.buy_ds] = dict.fromkeys(codes, 100.0)
+        closes[day.sell_ds] = {c: 100.0 * (1.0 + ret(i, c) / 100.0) for c in codes}
+    return Panels(open=opens, close=closes, liquid={}, mom20={}, dates=[])
+
+
+def _perfect(n_days: int = 24, n_pairs: int = 8) -> tuple[list[SwapDay], Panels]:
+    """完美标签：每对里 A 组那只必赢、B 组那只必亏。这是天花板用例。"""
+    days = _swap_days([[(f"w{i}_{j}", f"l{i}_{j}") for j in range(n_pairs)] for i in range(n_days)])
+    return days, _swap_panels(days, lambda _i, code: 3.0 if code.startswith("w") else -3.0)
+
+
+def _noise(n_days: int = 24, n_pairs: int = 8, seed: int = 7) -> tuple[list[SwapDay], Panels]:
+    """纯噪声标签：收益与分组无关。这是 null 那一侧，p 必须留在带内。"""
+    rng = random.Random(seed)
+    days = _swap_days([[(f"a{i}_{j}", f"b{i}_{j}") for j in range(n_pairs)] for i in range(n_days)])
+    draws = {(i, c): rng.gauss(0.0, 3.0) for i, d in enumerate(days) for pair in d.pairs for c in pair}
+    return days, _swap_panels(days, lambda i, code: draws[(i, code)])
+
+
+class TestSwapFalsification:
+    """逐对随机互换必须有分辨力：完美标签 p→下限，纯噪声标签 p 留在带内。
+
+    这套测试守的是一个会让工具静默失效的写法——零分布若拿**原始标签**算差值，每次
+    抽样都等于观测值，p 恒等于 1、null_sd 恒等于 0，报告上看不出任何异常，只会一路
+    印「不含信息」。所以下面同时钉住 null 的均值和离散度，不只看 p。
+    """
+
+    N_PERM = 60
+
+    def _run(self, days: list[SwapDay], panels: Panels) -> dict:
+        return swap_falsification(days, panels, n_perm=self.N_PERM)
+
+    def test_perfect_label_breaks_the_null(self):
+        """完美标签下两栏都必须打穿零分布，且 p 取到 (0+1)/(n+1) 这个下限。"""
+        out = self._run(*_perfect())
+        assert set(out) == {"stock_win", "gross_return"}
+        assert out["stock_win"].observed_pct == pytest.approx(100.0)
+        assert out["gross_return"].observed_pct == pytest.approx(6.0)
+        for test in out.values():
+            assert test.p_one_sided == pytest.approx(1.0 / (self.N_PERM + 1))
+            assert test.p_two_sided == pytest.approx(1.0 / (self.N_PERM + 1))
+            assert "超出互换零分布" in test.verdict
+
+    def test_null_is_not_the_observed_value(self):
+        """bug 版本（用原始标签算零分布）下 null_avg 会等于观测值、null_sd 恒为 0。"""
+        out = self._run(*_perfect())
+        for test in out.values():
+            assert test.null_sd_pct > 0.0
+            assert abs(test.null_avg_pct) < abs(test.observed_pct) / 2.0
+
+    def test_pure_noise_label_stays_inside_the_band(self):
+        """收益与分组无关时，观测差必须读作零分布里的一次普通抽样。"""
+        out = self._run(*_noise())
+        for test in out.values():
+            assert test.p_two_sided > 0.05
+            assert abs(test.observed_pct - test.null_avg_pct) < 2.0 * test.null_sd_pct
+            assert "不含信息" in test.verdict or "反而更差" in test.verdict
+
+    def test_reversed_label_is_called_worse_not_significant(self):
+        """标签反着接时观测差为负：单侧 p 必须变大，判定说「反而更差」而不是「过了」。"""
+        days, panels = _perfect()
+        flipped = [SwapDay(d.date, d.buy_ds, d.sell_ds, [(b, a) for a, b in d.pairs]) for d in days]
+        out = self._run(flipped, panels)
+        assert out["stock_win"].observed_pct == pytest.approx(-100.0)
+        assert out["stock_win"].p_one_sided == pytest.approx(1.0)
+        # 双侧照样打穿——效应是真的，只是方向相反。判定必须先看方向。
+        assert out["stock_win"].p_two_sided == pytest.approx(1.0 / (self.N_PERM + 1))
+        assert "反而更差" in out["stock_win"].verdict
+
+    def test_p_never_reports_zero(self):
+        """(r+1)/(n+1)：200 次抽样说不出小于 1/201 的话，硬报 0.000 是越过分辨率。"""
+        out = swap_falsification(*_perfect(), n_perm=10)
+        assert out["stock_win"].p_one_sided == pytest.approx(1.0 / 11)
+        assert out["stock_win"].permutations == 10
+
+    def test_short_window_is_unknown_not_failed(self):
+        """可评估日不够只能说「尚未可知」，不能当成「没通过」。"""
+        out = self._run(*_perfect(n_days=MIN_DAYS - 1))
+        assert out["stock_win"].days == MIN_DAYS - 1
+        assert "尚未可知" in out["stock_win"].verdict
+        assert "不含信息" not in out["stock_win"].verdict
+
+    def test_thin_days_are_dropped(self):
+        """不足 MIN_HITS_PER_DAY 对的日子不进汇总，avg_pairs 也只按入选的日子算。"""
+        days, panels = _perfect(n_days=MIN_DAYS)
+        days[0].pairs = days[0].pairs[: MIN_HITS_PER_DAY - 1]
+        out = self._run(days, panels)
+        assert out["stock_win"].days == MIN_DAYS - 1
+        assert out["stock_win"].avg_pairs == pytest.approx(8.0)
+
+    def test_no_usable_day_returns_empty(self):
+        days, panels = _perfect(n_days=3, n_pairs=MIN_HITS_PER_DAY - 1)
+        assert swap_falsification(days, panels, n_perm=self.N_PERM) == {}
+
+    def test_is_reproducible(self):
+        """种子按 (置换序号, 日期) 定，两次调用必须逐位一致，否则报告数字会漂。"""
+        assert self._run(*_perfect())["stock_win"].as_dict() == self._run(*_perfect())["stock_win"].as_dict()
+
+    def test_both_columns_share_the_same_draws(self):
+        """两栏共用同一批置换，判定才在同一基准上；置换数不同就说明种子掺了列名。"""
+        out = self._run(*_noise())
+        assert out["stock_win"].permutations == out["gross_return"].permutations
+
+
+class TestSwapArms:
+    PAIRS = [("a1", "b1"), ("a2", "b2"), ("a3", "b3")]
+
+    def test_each_pair_contributes_one_member_per_arm(self):
+        for seed in range(20):
+            arm_a, arm_b = swap_arms(self.PAIRS, rng=random.Random(seed))
+            assert len(arm_a) == len(arm_b) == len(self.PAIRS)
+            for (first, second), a, b in zip(self.PAIRS, arm_a, arm_b, strict=True):
+                assert {a, b} == {first, second}
+
+    def test_both_orderings_occur(self):
+        """互换必须真的会换。恒等返回时下游零分布退化，p 恒为 1。"""
+        seen = {swap_arms(self.PAIRS, rng=random.Random(s))[0][0] for s in range(20)}
+        assert seen == {"a1", "b1"}
+
+    def test_same_rng_state_gives_same_arms(self):
+        assert swap_arms(self.PAIRS, rng=random.Random(5)) == swap_arms(self.PAIRS, rng=random.Random(5))


### PR DESCRIPTION
## 变更摘要

把「逐对随机互换」这个否证工具固化进 `core/funnel_effect_eval.py`,配上能挡住它静默
失效的回归测试。纯新增,不动既有函数,生产参数不变。

## 背景

上一轮振幅上限的测试里,判掉提案的关键工具就是逐对随机互换,但它只活在 `/tmp` 的
一次性脚本里。下次再有候选筛的提案,应该能直接用。

## 它严在哪

现有的 `sample_momentum_band` 每天从候选动量区间内重新抽一篮,抽样噪声里混着「换了
一批票」这件事。逐对随机互换把配对**完全钉住**,只抹掉标签——同一批票、同一个动量
位置,只问分组本身有没有意义。零假设正好是「配平动量后这个标签不含信息」。

两栏各自成一道否证,不允许用一栏的结论替另一栏。风格择时那轮实测两栏分家:收益过了
月内置换(T+5 p=0.025 / T+10 p=0.001),胜率没过(p=0.284)。种子只按 `(置换序号, 日期)`
定、不掺列名,两栏共用同一批抽样,判定才在同一基准上。

## 会让它静默失效的写法

零分布若拿**原始标签**算差值,每次抽样都等于观测值,`p` 恒为 1、`null_sd` 恒为 0。
报告上看不出任何异常,只会一路印「不含信息」——工具看着在跑,实际什么都没检验。

`TestSwapFalsification` 钉住三件事:完美标签必须把单侧和双侧 p 都压到 `1/(n+1)` 这个
下限;`null_sd > 0`;零分布均值必须远离观测值。把实现改回原始标签会挂掉 5 个用例
(已实测)。`TestSwapArms` 另外守住互换本身真的会换、每对只贡献一个成员给每篮。

## 判定口径

- `p` 用 `(r+1)/(n+1)`。200 次抽样最小只能说到 1/201≈0.005,硬报 `p=0.000` 是把分辨率
  之外的东西当结论。
- 默认判据取**双侧**。提案方向几乎总是扫出来的(振幅那轮扫了 3 档上限 × 3 个持有期),
  单侧会把扫出来的方向当成事先定的方向。
- 三种不通过分开说,理由不同:日数不够是「尚未可知」、方向为负是「反而更差」、落在
  零分布内才是「不含信息」。
- 判定里写明**过了这一道不等于是个筛**,后面固定还要跑收紧配对容差、按月拆开两道。

## 实测复核

用库版本复跑振幅上限 cap=7.0 那一格,观测值与原脚本逐位一致:

| horizon | 天数 | 胜率差 | 双侧 p | 去 07 月 |
|---|---|---|---|---|
| 5 | 53 | +5.44pct | 0.010 | -0.71pct(30d, p=0.896) |
| 10 | 48 | +4.61pct | 0.025 | +1.52pct(25d, p=0.617) |
| 20 | 38 | +5.88pct | 0.025 | 只剩 15 天,不足判定 |

`p=0.010` 而去掉一个月就塌到 `p=0.896`——这正是判定里那句提醒要挡的情况。p 值本身也
偏乐观,docstring 写明了原因:持有窗口逐日重叠、日间观测不独立,而置换零分布按独立
处理,与 t 值虚高同源。

## 影响面

纯新增,没有改动既有函数。生产参数不变。

## 验证

- `tests/core/test_funnel_effect_eval.py` 88 passed
- funnel / trigger / wyckoff / effect 全扫 593 passed
- `ruff format --check`、`ruff check`、`quality_gate.py --check-no-sql` 全过
- 变异测试:零分布改回原始标签 → 5 个用例失败
