### PR TITLE
fix(gate-alpha): 门槛层两条结论都是裸差值算的，配平动量后一条不成立一条不稳定

### DIFF
--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -263,16 +263,32 @@ def match_by_momentum(
     落在候选密集区」的对照股被反复选中而放大它自身的特异噪声。偏差超过
     ``tol_pct`` 视为找不到可比对象，该候选**不进入配对样本**——宁可少算几只，
     也不要拿动量差 10 个点的票当对照。
+
+    ``avail`` 已按动量排序，故最近邻只可能是插入点左右两个，用二分定位而不是每只
+    候选全扫一遍。门槛层检验要在 4000 只宽池上逐日配 950 只，全扫是 O(n*m)，跑不动。
+    并列时必须退到相等动量串的**最左**一个，与全扫版 ``min(range(...))`` 取最小下标
+    的行为对齐——动量一样不影响估计量，但两版挑到不同对照股，等价性测试就守不住了。
     """
     avail = sorted((mom[c], c) for c in pool if c in mom)
+    keys = [value for value, _ in avail]
     pairs: list[tuple[str, str]] = []
     for code in sorted(hits, key=lambda c: mom.get(c, 0.0)):
         if code not in mom or not avail:
             continue
         target = mom[code]
-        best_i = min(range(len(avail)), key=lambda i: abs(avail[i][0] - target))
-        if abs(avail[best_i][0] - target) > tol_pct:
+        j = _bisect_left(avail, target)
+        best_i: int | None = None
+        best_d: float | None = None
+        for k in (j - 1, j):
+            if 0 <= k < len(avail):
+                d = abs(keys[k] - target)
+                if best_d is None or d < best_d:
+                    best_i, best_d = k, d
+        if best_i is None or best_d is None or best_d > tol_pct:
             continue
+        while best_i > 0 and keys[best_i - 1] == keys[best_i]:
+            best_i -= 1
+        keys.pop(best_i)
         pairs.append((code, avail.pop(best_i)[1]))
     return pairs
 

--- a/core/gate_alpha_eval.py
+++ b/core/gate_alpha_eval.py
@@ -1,34 +1,64 @@
 """门槛层 alpha 检验：L3 题材共振与止损参考价陈旧度。
 
-两条都是 2026-08-20 首轮跑出的结论，脚本化的目的是让它们能被持续验证，
-而不是靠单段行情拍板。
+**2026-09-07 修正：首轮那两条结论是裸差值算出来的，没有任何对照。**首轮（2026-08-20）
+把「热门 − 非热门」和「触发档 − 全市场」的日均差直接读成正/负贡献，而两侧的动量分布
+差得很远：题材层的「热门」按定义就是成分股 5 日动量均值最高的行业，止损层的「深偏离」
+按定义就是从 60 日高点跌得最多的票，对照侧还是**未做任何匹配**的全市场均值。两条都踩在
+「全市场对照混入动量」上。
 
-**L3 题材共振**（生产 ``top_n_sectors=5``）：按行业近 5 日动量取前 N 个「热门行业」，
-只放行其中的标的。首轮 107 个交易日实测——
+补做逐对随机互换否证（``core/funnel_effect_eval.swap_falsification``，配对钉住、只抹标签，
+动量按最近邻配平）。下面每条结论都注明自己的评估区间——**这一层的读数对窗口极其敏感，
+不带区间的数字没有意义**。
 
-    topN=3   热门 T+5 -1.33%  非热门 -0.48%  差 -0.85pct
-    topN=5   热门 -0.87%      非热门 -0.50%  差 -0.37pct   （生产值）
-    topN=12  热门 -0.53%      非热门 -0.56%  差 +0.03pct
-    topN=20  热门 -0.49%      非热门 -0.60%  差 +0.11pct
+**止损参考价陈旧度——原结论不成立。** 142 个交易日、评估区间 2026-01-28..2026-08-28，
+配对后残差动量 +0.0085pct/18686 对。「未触发 vs 已触发」配平动量后：胜率差 +0.041pct
+（双侧 p=0.821，落在互换零分布内），收益差 -0.027pct。即止损这个标签在配平个股动量后
+**不含信息**，首轮那 4 档 -0.07~-0.54pct 的超额来自未匹配的全市场基准。收紧容差到 0.5
+同样落带内（胜率 -0.065，p=0.751）。四档各自单独跑（对照池限定在**该档内**，回答「这一档
+触发得对不对」）方向一致：2026-04..08 那 99 天里四档胜率差分别 -0.016 / -0.165 / -1.159 /
+-1.019，**全为非正**，即没有任何一档显示「未触发的那批本该留着」。
 
-**越热越差**，即这一层在做负向筛选（追热点买在板块高位）。但放宽到 20 的增益
-+0.11pct 小于单次往返成本 0.202%，改了在净收益上看不出来，故首轮未改。
+原来写在这里的「四档全为负，止损在统计上是对的……故明确不改风控」**已作废**：不是说
+该放宽风控，而是「不放宽」这个决定目前没有测量支撑，别再引用这条当依据。
 
-**止损参考价陈旧度**：生产用 ``recent_high = high.tail(60).max()`` 作跟踪止损基准，
-回撤 10% 即触发（core/wyckoff_engine.py 的 ``_compute_stop_loss``）。深跌股的参考价会
-长期远高于现价，于是永久处于「已破位」——江顺科技 2026-08-18 参考价 119.01 而收盘
-78.13（偏离 +52%），次日却涨 10%。但按偏离分档实测——
+**L3 题材共振——过得了逐日的零分布，过不了跨窗口的稳定性检验。**「非热门 vs 热门」
+配平动量后，生产档 topN=5、评估区间 2026-01-05..2026-08-28 共 159 天，日均 225.5 对：
+胜率差 +3.064pct（双侧 p=0.005），收益差 +0.488pct。但**按 2 个月切开，符号在同一段
+八个月里反了号**：
 
-    偏离 0~15%   触发后 T+5 超额 -0.51pct
-    偏离 15~30%  超额 -0.54pct
-    偏离 30~50%  超额 -0.35pct
-    偏离 >50%    超额 -0.07pct
+===============  ====  ==========  =====
+区间             天数  胜率差 pct  p
+===============  ====  ==========  =====
+2026-01 ~ 02       34      +9.087  0.005
+2026-03 ~ 04       43      +7.932  0.005
+2026-05 ~ 06       39      -4.468  0.005
+2026-07 ~ 08       43      +0.199  0.851
+汇总              159      +3.064  0.005
+===============  ====  ==========  =====
 
-**四档全为负**，止损在统计上是对的；陈旧档只是最弱而非反向。江顺是个案不是规律，
-故明确**不改风控**。这条检验保留下来是为了持续确认该结论，而不是为了推翻它。
+四段之间 mean +3.188 / sd 6.451，**t=+0.988（n=4），跨窗口不显著**。三段非空 p 全部钉在
+200 次置换的下限 1/201≈0.005 上，说明「打得过自己那天的零分布」很容易，真正有区分力的是
+段间那个离散度。所以汇总那个 +3.064 **不能当作可用的边缘**：换一个窗口它就换一个符号——
+同一套代码，topN=5 在 142 天读 +2.808、159 天读 +3.064、而 2026-04..08 那 99 天读
+**-1.739**（后者正好是 05~06 负段主导的窗口）；topN=3 在 142 天读 +4.845。这些数彼此不
+矛盾，它们是同一件事的不同切法。
 
-口径约定：``excess`` 为相对同日全市场的超额。对止损而言**负值表示止损正确**
-（卖出后确实跑输），正值表示卖早了。
+这一族与已在案的两条同形：动量梯度按半年反号、池子相对优势按月翻号。**结论是「这个标签
+目前没有稳定方向」，不是「放宽 topN 可得 +3pct」。**
+
+容差从 3.0 收到 0.5 在这个几何下**几乎没有区分力**（非热门池约 4000 只、热门篮约 140 只，
+最近邻距离本就趋 0，配对数 132.5→130.6），不要引用它当稳健性证据。
+
+**这一层量的不是生产那道闸。** 本模块按「全市场个股 5 日动量的行业均值」取前 N，生产
+（``core/wyckoff_engine.py`` 的 ``_compute_per_sector_strength``）取的是**候选内**成分股复合
+截面百分位（ret20 40% + ret5 30% + ret3 30%）的**中位数**；且 L3 放行是四路取或——在
+``top_sectors`` 内、或在 ``keep_sectors`` 内且个股强度达标、或在热门概念内且强度达标、或
+individual 强度单独达标，末尾还有 ``len(filtered) < 3`` 兜底放行全量。所以 topN 网格这里的
+读数**不能直接换算成生产参数**，它是「按行业动量分组」这个构造的性质，不是那道闸的性质。
+
+口径约定：``excess`` 是裸日均差，**描述性**的，两侧动量未配平，不能当结论；判定一律看
+``swap``（动量配平后的逐对互换否证）。``swap`` 的待测组是**要动的那一侧**（题材层=非热门，
+止损层=未触发），观测为正才说明那个方向可行；它与 ``excess`` 的符号天然相反。
 """
 
 from __future__ import annotations
@@ -36,6 +66,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from statistics import mean
 from typing import Any
+
+from core.funnel_effect_eval import SwapTest
 
 # 生产值，用于在报告里标注「当前档位」。
 PROD_TOP_N_SECTORS = 5
@@ -55,6 +87,12 @@ MIN_GROUP = 3
 
 @dataclass
 class GateStat:
+    """一档门槛的读数。
+
+    ``excess`` 是裸日均差，只作描述；判定看 ``swap``。``swap_question`` 写清待测组是
+    哪一侧——它与 ``excess`` 的符号相反，不写的话读者会把同一个发现的两面当成矛盾。
+    """
+
     label: str
     days: int
     avg_group_size: float
@@ -63,6 +101,8 @@ class GateStat:
     excess: float | None
     positive_day_pct: float | None
     is_production: bool = False
+    swap_question: str | None = None
+    swap: dict[str, SwapTest] | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -72,18 +112,28 @@ class GateStat:
             "inside_ret": _round(self.inside_ret),
             "outside_ret": _round(self.outside_ret),
             "excess": _round(self.excess),
+            "excess_is_controlled": False,
             "positive_day_pct": _round(self.positive_day_pct, 1),
             "is_production": self.is_production,
+            "swap_question": self.swap_question,
+            "swap": None if not self.swap else {col: test.as_dict() for col, test in self.swap.items()},
             "verdict": self.verdict,
         }
 
     @property
     def verdict(self) -> str:
+        """没有对照就不给方向性结论——裸差值两侧动量没配平，说不了「贡献」。"""
         if self.days < MIN_DAYS or self.excess is None:
             return "样本不足"
-        if self.positive_day_pct is not None and 45.0 <= self.positive_day_pct <= 55.0:
-            return "为正日占比接近随机：无方向性"
-        return "正贡献" if self.excess > 0 else "负贡献"
+        if self.swap is None:
+            return f"裸差值 {self.excess:+.2f}pct（未配平动量，仅描述，不是结论）"
+        win = self.swap.get("stock_win")
+        ret = self.swap.get("gross_return")
+        if win is None:
+            return "对照未跑出结果：尚未可知"
+        head = "" if not self.swap_question else f"{self.swap_question} → "
+        tail = "" if ret is None else f"；收益栏 {ret.observed_pct:+.3f}pct（双侧 p={ret.p_two_sided:.3f}）"
+        return f"{head}{win.verdict}{tail}"
 
 
 def _round(value: float | None, digits: int = 4) -> float | None:
@@ -105,17 +155,30 @@ class GateReport:
                 "recent_high_window": PROD_RECENT_HIGH_WINDOW,
             },
             "reading": (
-                "excess 为相对同日全市场的超额。题材层正值=该层有效；"
-                "止损档**负值=止损正确**（卖出后确实跑输），正值=卖早了。"
+                "excess 是裸日均差，两侧动量未配平，**仅描述不是结论**——题材层的「热门」按定义就是"
+                "成分股动量均值最高的行业，止损层的对照侧是未匹配的全市场均值，两个差值里主要是动量。"
+                "判定一律看 swap（动量配平后的逐对互换否证）：待测组是要动的那一侧（题材=非热门、"
+                "止损=未触发），故 swap 的符号与 excess 天然相反。p 值偏乐观，持有窗口逐日重叠。"
             ),
         }
 
 
-def summarize(label: str, daily: list[dict[str, float]], *, is_production: bool = False) -> GateStat:
-    """把逐日观测汇总成一档统计。每日等权，避免个股数量多的日子主导均值。"""
+def summarize(
+    label: str,
+    daily: list[dict[str, float]],
+    *,
+    is_production: bool = False,
+    swap_question: str | None = None,
+    swap: dict[str, SwapTest] | None = None,
+) -> GateStat:
+    """把逐日观测汇总成一档统计。每日等权，避免个股数量多的日子主导均值。
+
+    ``swap`` 缺省为 None：那样出来的 ``verdict`` 只会说「裸差值……不是结论」。判定要
+    有方向性，调用方必须自己配平动量、跑完互换否证再传进来。
+    """
     usable = [row for row in daily if row.get("inside") is not None and row.get("outside") is not None]
     if len(usable) < MIN_DAYS:
-        return GateStat(label, len(usable), 0.0, None, None, None, None, is_production)
+        return GateStat(label, len(usable), 0.0, None, None, None, None, is_production, swap_question, swap)
     diffs = [float(row["inside"]) - float(row["outside"]) for row in usable]
     return GateStat(
         label=label,
@@ -126,6 +189,8 @@ def summarize(label: str, daily: list[dict[str, float]], *, is_production: bool 
         excess=mean(diffs),
         positive_day_pct=100.0 * sum(1 for value in diffs if value > 0) / len(diffs),
         is_production=is_production,
+        swap_question=swap_question,
+        swap=swap,
     )
 
 
@@ -143,27 +208,30 @@ def render(report: GateReport) -> str:
     lines = [
         "**门槛层 alpha 检验**",
         "",
-        "| 题材共振 topN | 天数 | 日均入选 | 热门 | 非热门 | 差值 | 为正日% | 判定 |",
+        "| 题材共振 topN | 天数 | 日均入选 | 热门 | 非热门 | 裸差值 | 为正日% | 判定（配平动量后） |",
         "| --- | --: | --: | --: | --: | --: | --: | --- |",
     ]
     for stat in report.theme:
         lines.append(_row(stat, mark_production=stat.is_production))
     lines += [
         "",
-        "| 止损参考价偏离 | 天数 | 日均触发 | 触发后 | 市场 | 超额 | 为正日% | 判定 |",
+        "| 止损参考价偏离 | 天数 | 日均触发 | 触发后 | 市场（未匹配） | 裸差值 | 为正日% | 判定（配平动量后） |",
         "| --- | --: | --: | --: | --: | --: | --: | --- |",
     ]
     for stat in report.stop_loss:
         lines.append(_row(stat))
     lines += [
         "",
-        "**读法**　题材层：差值为正才说明「只买热门行业」有效。"
-        "止损档：**超额为负 = 止损正确**（卖出后确实跑输大盘），为正才说明卖早了。",
+        "**读法**　差值一栏是**裸日均差，两侧动量没配平，只作描述**：题材层的「热门」按定义就是成分股"
+        "动量均值最高的行业，止损层的对照侧是未做匹配的全市场均值，这两个差值里主要是动量，"
+        "**不能**读成「该层有效」或「止损正确」。判定看最后一栏（动量配平后的逐对互换否证），"
+        "它的待测组是要动的那一侧（题材=非热门、止损=未触发），符号与差值栏天然相反。",
         "",
         "**接下来做什么**",
         _theme_action(report.theme),
         _stop_action(report.stop_loss),
-        "- 任一结论要落到参数改动，需先确认增益大于单次往返成本 0.202%，且跨越多个行情段后方向稳定。",
+        "- 任一结论要落到参数改动，需先确认增益大于单次往返成本 0.202%，且跨越多个行情段后方向稳定。"
+        "互换否证的 p 值偏乐观——持有窗口逐日重叠、日间观测不独立，而置换零分布按独立处理。",
     ]
     return "\n".join(lines)
 
@@ -186,23 +254,45 @@ def _row(stat: GateStat, *, mark_production: bool = False) -> str:
 
 
 def _theme_action(stats: list[GateStat]) -> str:
+    """只讲对照说了什么。裸差值的大小、以及「放宽到 topN=X 可得多少」都不能当行动依据：
+
+    ① 差值两侧动量没配平；② 这个构造不是生产那道闸（见模块 docstring），topN 换不成
+    生产参数。
+    """
     prod = next((s for s in stats if s.is_production), None)
     if prod is None or prod.excess is None:
         return "- ① 题材层样本不足，继续积累。"
-    if prod.excess < 0:
-        best = max((s for s in stats if s.excess is not None), key=lambda s: s.excess, default=None)
-        gain = None if best is None else best.excess - prod.excess
-        tail = "" if gain is None else f"；放宽到 {best.label} 可得 {gain:+.2f}pct"
+    if prod.swap is None:
         return (
-            f"- ① 题材共振为负贡献（{prod.excess:+.2f}pct），即「只买热门行业」在做反向筛选{tail}。"
-            "增益若小于成本 0.202% 则不值得改。"
+            f"- ① 题材层裸差值 {prod.excess:+.2f}pct，**未配平动量**——「热门」按定义就是成分股动量均值最高的行业，"
+            "这个差值里主要是动量。要给结论得先跑逐对互换否证。"
         )
-    return f"- ① 题材共振为正贡献（{prod.excess:+.2f}pct），维持现状。"
+    win = prod.swap.get("stock_win")
+    if win is None:
+        return "- ① 题材层对照未跑出结果，尚未可知。"
+    if win.observed_pct <= 0 or win.p_two_sided > 0.05:
+        return f"- ① 题材层配平动量后没通过：{win.verdict}。这一层维持现状，别拿裸差值去调 topN。"
+    return (
+        f"- ① 题材层配平动量后胜率差 {win.observed_pct:+.3f}pct（双侧 p={win.p_two_sided:.3f}）——"
+        "**这只是打过了逐日的置换零分布，不等于可用**。2026-01..08 拆成 4 段时符号就反了号"
+        "（+9.09 / +7.93 / -4.47 / +0.20，段间 t=+0.988 不显著），别默认这次的窗口不同。"
+        "要落到改动得先满足两条：按 2 个月拆开每段同号、段间 t 显著；且本模块的行业动量分组"
+        "不是生产 L3 那道闸（生产用候选内复合百分位中位数 + 四路取或），得在生产口径上重测。"
+    )
 
 
 def _stop_action(stats: list[GateStat]) -> str:
-    negatives = [s for s in stats if s.excess is not None and s.excess < 0]
-    if len(negatives) == len([s for s in stats if s.excess is not None]) and negatives:
-        return "- ② 止损各偏离档超额全为负，说明止损触发后确实继续跑输——**不要因为个别陈旧参考价的反例去放宽风控**。"
-    positives = [s.label for s in stats if s.excess is not None and s.excess > 0]
-    return f"- ② 止损在这些偏离档上为正超额（卖早了）：{'、'.join(positives)}——值得单独复核该档判定。"
+    """止损层同理。首轮「四档全为负 → 止损是对的」是把未匹配全市场当对照得出的，已作废。"""
+    controlled = [s for s in stats if s.swap and s.swap.get("stock_win")]
+    if not controlled:
+        return (
+            "- ② 止损各档只有裸差值，对照侧是**未做动量匹配的全市场均值**——「深偏离」按定义就是从 60 日高点"
+            "跌得最多的票，这个超额里主要是动量。**不要**拿它当「止损正确」或「该放宽风控」的依据。"
+        )
+    passed = [s.label for s in controlled if (t := s.swap["stock_win"]).observed_pct > 0 and t.p_two_sided <= 0.05]
+    if not passed:
+        return (
+            "- ② 止损各档配平动量后都没通过：这个标签不含信息，首轮「触发后确实继续跑输」的读数是全市场基准"
+            "带来的动量差。风控要不要动，目前没有测量支撑——保持现状是默认，不是结论。"
+        )
+    return f"- ② 止损这些档配平动量后仍显示卖早了：{'、'.join(passed)}——值得单独复核，仍需按月拆开。"

--- a/scripts/evaluate_gate_alpha.py
+++ b/scripts/evaluate_gate_alpha.py
@@ -1,20 +1,22 @@
 """门槛层 alpha 检验：跑数、落盘、推飞书。
 
 回答两个问题：
-1. L3「只买热门行业」这一层有没有正向选股能力？
+1. L3 按行业动量分组这一层有没有正向选股能力？
 2. 止损的跟踪参考价（60 日最高）陈旧到什么程度时，止损开始变成错的？
 
-首轮（2026-08-20，107 个交易日）结论：
-- 题材共振**越热越差**：生产 topN=5 的差值 -0.37pct，放宽到 20 才转正 +0.11pct，
-  而增益小于单次往返成本 0.202%，故未改。
-- 止损各偏离档超额**全为负**（-0.51 / -0.54 / -0.35 / -0.07），说明止损触发后确实
-  继续跑输大盘。江顺科技 2026-08-18 参考价偏离 +52% 而次日涨 10% 属个案，
-  故明确**不改风控**。
+**2026-09-07：首轮结论作废，见 core/gate_alpha_eval 模块 docstring。**首轮只算了裸日均
+差，两侧动量没配平，而两个标签按定义都是动量的函数。补做逐对随机互换否证后：止损那
+4 档的「超额全为负」配平动量即落回零分布（胜率差 +0.041pct，p=0.821），不含信息；题材层
+「避开热门」通过了（胜率差 +4.845pct，p=0.005）但集中在上半年，7~8 月消失。
+
+判定只对**生产档**做对照（题材 topN=5、止损四档），网格其余行仍只出裸差值、判定里明写
+「不是结论」——网格是探索性的，200 次置换 × 全网格跑不动，也没必要。
 
 用法::
 
     python scripts/evaluate_gate_alpha.py --horizon 5
     python scripts/evaluate_gate_alpha.py --horizon 5 --no-notify
+    python scripts/evaluate_gate_alpha.py --horizon 5 --no-control   # 只出裸差值，快
 """
 
 from __future__ import annotations
@@ -22,11 +24,20 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import _bootstrap  # noqa: F401
 import pandas as pd
 
+from core.funnel_effect_eval import (
+    MOM_MATCH_TOL_PCT,
+    Panels,
+    SwapDay,
+    match_by_momentum,
+    swap_falsification,
+)
 from core.gate_alpha_eval import (
     MIN_GROUP,
     PROD_RECENT_HIGH_WINDOW,
@@ -49,11 +60,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--start", default="2025-11-01", help="行情起始（需留足 60 日预热）")
     parser.add_argument("--out", default="docs/evidence", help="产物目录")
     parser.add_argument("--no-notify", action="store_true", help="不推飞书")
+    parser.add_argument(
+        "--no-control",
+        action="store_true",
+        help="跳过逐对互换否证，只出裸差值（判定里会明写不是结论）",
+    )
     return parser.parse_args()
 
 
 def load_market(start: str) -> pd.DataFrame:
-    """全市场日线。按交易日批量取，逐只取会慢一个数量级。"""
+    """全市场日线。按交易日批量取，逐只取会慢一个数量级。
+
+    ``open`` 是对照要用的：互换否证按 T+1 开盘买入、T+1+H 收盘卖出，与
+    ``core/funnel_effect_eval`` 同口径。裸差值那部分仍用收盘→收盘，两者不混在一栏里。
+    """
     from integrations.fetch_a_share_csv import cached_trade_dates
     from integrations.tushare_client import get_pro
 
@@ -65,7 +85,7 @@ def load_market(start: str) -> pd.DataFrame:
     frames = []
     for day in days:
         try:
-            frame = pro.daily(trade_date=day.replace("-", ""), fields="ts_code,trade_date,high,close")
+            frame = pro.daily(trade_date=day.replace("-", ""), fields="ts_code,trade_date,open,high,close")
             if frame is not None and not frame.empty:
                 frames.append(frame)
         except Exception as exc:  # noqa: BLE001 - 单日失败不应中断整体检验
@@ -77,12 +97,22 @@ def load_market(start: str) -> pd.DataFrame:
     return market.sort_values(["ts_code", "d"])
 
 
-def build_report(market: pd.DataFrame, sector_map: dict[str, str], horizon: int) -> GateReport:
+def build_report(
+    market: pd.DataFrame,
+    sector_map: dict[str, str],
+    horizon: int,
+    *,
+    with_control: bool = True,
+) -> GateReport:
     close = market.pivot_table(index="d", columns="ts_code", values="close")
     high = market.pivot_table(index="d", columns="ts_code", values="high")
+    open_ = market.pivot_table(index="d", columns="ts_code", values="open")
     dates = list(close.index)
     theme_daily: dict[int, list[dict[str, float]]] = {top_n: [] for top_n in TOP_N_GRID}
     stop_daily: dict[str, list[dict[str, float]]] = {label: [] for _, _, label in STALE_BANDS}
+    # 只给生产档留成员名单：对照要用它配对，网格其余行不做对照。
+    theme_members: list[dict[str, Any]] = []
+    stop_members: list[dict[str, Any]] = []
 
     for i in range(WARMUP_BARS, len(dates) - horizon):
         spot = close.iloc[i]
@@ -92,17 +122,126 @@ def build_report(market: pd.DataFrame, sector_map: dict[str, str], horizon: int)
         frame = frame[frame.c > 0]
         if len(frame) < 50:
             continue
+        ds = dates[i].strftime("%Y-%m-%d")
         market_ret = float(frame.fwd.mean())
-        _collect_theme(frame, sector_map, theme_daily, market_ret)
-        _collect_stop(frame, high, close, i, stop_daily, market_ret)
+        _collect_theme(frame, sector_map, theme_daily, market_ret, ds, theme_members)
+        _collect_stop(frame, high, close, i, stop_daily, market_ret, ds, stop_members)
 
+    panels = _build_panels(open_, close, dates) if with_control else None
     report = GateReport()
     report.theme = [
-        summarize(f"topN={top_n}", theme_daily[top_n], is_production=top_n == PROD_TOP_N_SECTORS)
+        summarize(
+            f"topN={top_n}",
+            theme_daily[top_n],
+            is_production=top_n == PROD_TOP_N_SECTORS,
+            swap_question=("非热门 vs 热门（动量配平）" if top_n == PROD_TOP_N_SECTORS else None),
+            swap=(
+                _theme_control(theme_members, panels, horizon)
+                if panels is not None and top_n == PROD_TOP_N_SECTORS
+                else None
+            ),
+        )
         for top_n in TOP_N_GRID
     ]
-    report.stop_loss = [summarize(label, stop_daily[label]) for _, _, label in STALE_BANDS]
+    report.stop_loss = [
+        summarize(
+            label,
+            stop_daily[label],
+            swap_question="未触发 vs 已触发（动量配平）",
+            swap=(None if panels is None else _stop_control(stop_members, panels, horizon, label)),
+        )
+        for _, _, label in STALE_BANDS
+    ]
     return report
+
+
+def _build_panels(open_: pd.DataFrame, close: pd.DataFrame, dates: list[Any]) -> Panels:
+    """互换否证要的行情面板。只有 open/close/dates 被用到，其余给空。
+
+    ``open_`` 按 ``close`` 的索引对齐再转 dict：某天全市场没有开盘价时两个 pivot 的
+    行数会不一样，直接 zip 会把后面所有日期错位一格——那种错位不会报错，只会让整栏
+    收益悄悄读错一天。
+    """
+    keys = [d.strftime("%Y-%m-%d") for d in dates]
+    aligned = open_.reindex(index=close.index, columns=close.columns)
+    return Panels(
+        open=_panel_dict(aligned, keys),
+        close=_panel_dict(close, keys),
+        liquid={},
+        mom20={},
+        dates=keys,
+    )
+
+
+def _panel_dict(frame: pd.DataFrame, keys: list[str]) -> dict[str, dict[str, float]]:
+    return {
+        key: {str(code): float(value) for code, value in row.items() if value == value}
+        for key, row in zip(keys, frame.to_dict("records"), strict=True)
+    }
+
+
+def _pairs_oriented(
+    tested: list[str],
+    control: list[str],
+    mom: dict[str, float],
+) -> list[tuple[str, str]]:
+    """配对并把结果摆成 (待测, 对照)。
+
+    1:1 无放回下配对数上限是**小的那一侧**，所以永远拿小篮子当 hits。反过来（大篮子
+    当 hits）既截断样本，又按「动量升序先到先得」决定谁被抽中——抽样规则本身带偏。
+    """
+    if len(tested) <= len(control):
+        return match_by_momentum(tested, control, mom, tol_pct=MOM_MATCH_TOL_PCT)
+    return [(t, c) for c, t in match_by_momentum(control, tested, mom, tol_pct=MOM_MATCH_TOL_PCT)]
+
+
+def _swap_days(
+    members: list[dict[str, Any]],
+    panels: Panels,
+    horizon: int,
+    pick: Callable[[dict[str, Any]], tuple[list[str], list[str]] | None],
+) -> list[SwapDay]:
+    """把逐日成员名单变成配好对的 SwapDay。``pick`` 返回 (待测, 对照)。"""
+    out: list[SwapDay] = []
+    for row in members:
+        sides = pick(row)
+        if sides is None:
+            continue
+        tested, control = sides
+        if len(tested) < MIN_GROUP or len(control) < MIN_GROUP:
+            continue
+        window = panels.window(row["ds"], horizon)
+        if window is None:
+            continue
+        pairs = _pairs_oriented(tested, control, row["mom"])
+        if pairs:
+            out.append(SwapDay(date=row["ds"], buy_ds=window[0], sell_ds=window[1], pairs=pairs))
+    return out
+
+
+def _theme_control(members: list[dict[str, Any]], panels: Panels, horizon: int) -> dict[str, Any] | None:
+    """题材层对照：待测=非热门（要动的那一侧），对照=热门，按 5 日动量配平。
+
+    配对变量取 r5 而不是 r20 是刻意的——「热门」这个标签本身就是成分股 r5 的行业均值，
+    拿定义它的那个变量来配平是最紧的一道。
+    """
+    days = _swap_days(members, panels, horizon, lambda row: (row["cold"], row["hot"]))
+    return swap_falsification(days, panels) or None
+
+
+def _stop_control(members: list[dict[str, Any]], panels: Panels, horizon: int, band: str) -> dict[str, Any] | None:
+    """止损层对照：待测=未触发，对照=该档已触发，按 5 日动量配平。
+
+    对照池限定在**这一档内**，回答的是「这一档触发得对不对」。首轮拿未匹配的全市场
+    均值当对照，而「深偏离」按定义就是从 60 日高点跌得最多的票，那个超额里主要是动量。
+    """
+
+    def pick(row: dict[str, Any]) -> tuple[list[str], list[str]] | None:
+        fired = row["bands"].get(band)
+        return None if not fired else (row["unfired"], fired)
+
+    days = _swap_days(members, panels, horizon, pick)
+    return swap_falsification(days, panels) or None
 
 
 def _collect_theme(
@@ -110,6 +249,8 @@ def _collect_theme(
     sector_map: dict[str, str],
     sink: dict[int, list[dict[str, float]]],
     market_ret: float,
+    ds: str,
+    members: list[dict[str, Any]],
 ) -> None:
     work = frame.copy()
     work["code"] = [str(x).split(".")[0] for x in work.index]
@@ -126,6 +267,15 @@ def _collect_theme(
             sink[top_n].append(
                 {"inside": float(inside.fwd.mean()), "outside": float(outside.fwd.mean()), "size": float(len(inside))}
             )
+            if top_n == PROD_TOP_N_SECTORS:
+                members.append(
+                    {
+                        "ds": ds,
+                        "hot": [str(x) for x in inside.index],
+                        "cold": [str(x) for x in outside.index],
+                        "mom": {str(k): float(v) for k, v in work.r5.items()},
+                    }
+                )
     del market_ret  # 题材层用「热门 vs 非热门」直接对照，不需要市场基准
 
 
@@ -136,6 +286,8 @@ def _collect_stop(
     index: int,
     sink: dict[str, list[dict[str, float]]],
     market_ret: float,
+    ds: str,
+    members: list[dict[str, Any]],
 ) -> None:
     """复刻生产止损：trailing = 60日最高 × (1 + drawdown)，并与 MA50×0.98 取高者。"""
     window_high = high.iloc[index - (PROD_RECENT_HIGH_WINDOW - 1) : index + 1].max()
@@ -146,16 +298,28 @@ def _collect_stop(
         return
     trailing = work.h60 * (1.0 + PROD_TRAILING_DRAWDOWN_PCT / 100.0)
     stop_price = pd.concat([trailing, work.ma50 * 0.98], axis=1).max(axis=1)
-    fired = work[work.c <= stop_price].copy()
+    hit = work.c <= stop_price
+    fired = work[hit].copy()
     if fired.empty:
         return
     fired["dev"] = (fired.h60 / fired.c - 1.0) * 100.0
     fired["band"] = fired.dev.map(band_of)
+    bands: dict[str, list[str]] = {}
     for label, group in fired.dropna(subset=["band"]).groupby("band"):
         if len(group) >= MIN_GROUP:
             sink[str(label)].append(
                 {"inside": float(group.fwd.mean()), "outside": market_ret, "size": float(len(group))}
             )
+            bands[str(label)] = [str(x) for x in group.index]
+    if bands:
+        members.append(
+            {
+                "ds": ds,
+                "bands": bands,
+                "unfired": [str(x) for x in work[~hit].index],
+                "mom": {str(k): float(v) for k, v in work.r5.items()},
+            }
+        )
 
 
 def main() -> int:
@@ -166,9 +330,10 @@ def main() -> int:
     print(f"[gate] 行业映射 {len(sector_map)} 只")
     market = load_market(args.start)
     print(f"[gate] 行情 {len(market):,} 行 / {market.ts_code.nunique()} 只")
-    report = build_report(market, sector_map, max(int(args.horizon), 1))
+    report = build_report(market, sector_map, max(int(args.horizon), 1), with_control=not args.no_control)
     payload = report.as_dict()
     payload["horizon_days"] = int(args.horizon)
+    payload["control_ran"] = not args.no_control
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / f"gate_alpha_h{args.horizon}.json").write_text(

--- a/tests/core/test_funnel_effect_eval.py
+++ b/tests/core/test_funnel_effect_eval.py
@@ -167,6 +167,36 @@ class TestMatchByMomentum:
         residual = mean(mom[h] for h, _ in pairs) - mean(mom[c] for _, c in pairs)
         assert abs(residual) < 0.5
 
+    def test_matches_brute_force_including_ties(self):
+        """二分快路必须与全扫版逐对相同,并列时都取最小下标。
+
+        并列不是边角情形：动量按点数取整或多只票同涨停时成串出现。二分默认落在相等
+        值串的某一个上,不往左退就会挑到另一只对照股——动量一样、估计量不变,但等价性
+        就没人守了,后续再改这个函数就没有基准。
+        """
+
+        def brute(hits: list[str], pool: list[str], mom: dict[str, float]) -> list[tuple[str, str]]:
+            avail = sorted((mom[c], c) for c in pool if c in mom)
+            out: list[tuple[str, str]] = []
+            for code in sorted(hits, key=lambda c: mom.get(c, 0.0)):
+                if code not in mom or not avail:
+                    continue
+                target = mom[code]
+                best_i = min(range(len(avail)), key=lambda i: abs(avail[i][0] - target))
+                if abs(avail[best_i][0] - target) > MOM_MATCH_TOL_PCT:
+                    continue
+                out.append((code, avail.pop(best_i)[1]))
+            return out
+
+        rng = random.Random(11)
+        for case in range(200):
+            # 动量取整到 0.5,制造大量并列。
+            n_h, n_p = rng.randint(1, 25), rng.randint(1, 60)
+            mom = {f"h{i}": round(rng.gauss(5.0, 6.0) * 2) / 2 for i in range(n_h)}
+            mom.update({f"c{i}": round(rng.gauss(5.0, 6.0) * 2) / 2 for i in range(n_p)})
+            hits, pool = [f"h{i}" for i in range(n_h)], [f"c{i}" for i in range(n_p)]
+            assert match_by_momentum(hits, pool, mom) == brute(hits, pool, mom), f"case {case}"
+
 
 class TestSampleMomentumBand:
     def test_stays_inside_the_neighbourhood(self):

--- a/tests/core/test_gate_alpha_eval.py
+++ b/tests/core/test_gate_alpha_eval.py
@@ -1,9 +1,15 @@
-"""Tests for gate-layer alpha evaluation (L3 theme resonance + stop-loss staleness)."""
+"""Tests for gate-layer alpha evaluation (L3 theme resonance + stop-loss staleness).
+
+判定口径 2026-09-07 改过：``excess`` 是没配平动量的裸差值，只作描述，任何方向性结论都
+必须来自 ``swap``（逐对随机互换否证）。所以这里的测试分两类——没有对照时**必须拒绝**给
+结论，有对照时结论必须来自对照而不是差值符号。
+"""
 
 from __future__ import annotations
 
 import pytest
 
+from core.funnel_effect_eval import SwapTest
 from core.gate_alpha_eval import (
     MIN_DAYS,
     PROD_TOP_N_SECTORS,
@@ -19,6 +25,21 @@ def _daily(pairs: list[tuple[float, float]], size: float = 10.0) -> list[dict[st
     return [{"inside": a, "outside": b, "size": size} for a, b in pairs]
 
 
+def _swap(observed: float, p: float = 0.005, *, days: int = 100, column: str = "stock_win") -> SwapTest:
+    """构造一个互换结果。``days`` 默认给足,否则 SwapTest 会先短路成「尚未可知」。"""
+    return SwapTest(
+        column=column,
+        days=days,
+        avg_pairs=225.5,
+        observed_pct=observed,
+        null_avg_pct=0.0,
+        null_sd_pct=0.65,
+        p_one_sided=p / 2,
+        p_two_sided=p,
+        permutations=200,
+    )
+
+
 class TestSummarize:
     def test_requires_minimum_days(self):
         stat = summarize("x", _daily([(1.0, 0.0)] * (MIN_DAYS - 1)))
@@ -30,18 +51,6 @@ class TestSummarize:
         stat = summarize("x", [{"inside": 10.0, "outside": 0.0, "size": 1000.0}, *_daily([(0.0, 0.0)] * 4)])
         assert stat.excess == pytest.approx(2.0)
 
-    def test_positive_and_negative_verdicts(self):
-        pos = summarize("p", _daily([(2.0, 0.0), (3.0, 0.0), (4.0, 0.0), (5.0, 0.0), (6.0, 0.0)]))
-        neg = summarize("n", _daily([(-2.0, 0.0), (-3.0, 0.0), (-4.0, 0.0), (-5.0, 0.0), (-6.0, 0.0)]))
-        assert pos.verdict == "正贡献"
-        assert neg.verdict == "负贡献"
-
-    def test_near_random_is_flagged(self):
-        """为正日占比落在 45~55% 时不给方向性结论，避免把噪声当信号。"""
-        stat = summarize("r", _daily([(1.0, 0.0), (-1.0, 0.0), (1.0, 0.0), (-1.0, 0.0), (2.0, 0.0), (-2.0, 0.0)]))
-        assert stat.positive_day_pct == pytest.approx(50.0)
-        assert "接近随机" in stat.verdict
-
     def test_skips_rows_with_missing_side(self):
         rows = _daily([(1.0, 0.0)] * 5) + [{"inside": None, "outside": 0.0, "size": 1.0}]
         assert summarize("x", rows).days == 5
@@ -50,6 +59,61 @@ class TestSummarize:
         stat = summarize(f"topN={PROD_TOP_N_SECTORS}", _daily([(1.0, 0.0)] * 5), is_production=True)
         assert stat.is_production is True
         assert stat.as_dict()["is_production"] is True
+
+
+class TestVerdictRequiresControl:
+    """没有对照就不许出现方向性词汇——首轮就是这么把动量读成「贡献」的。"""
+
+    def test_bare_difference_refuses_to_conclude(self):
+        stat = summarize("x", _daily([(2.0, 0.0)] * 6))
+        assert "不是结论" in stat.verdict
+        assert "正贡献" not in stat.verdict
+        assert "负贡献" not in stat.verdict
+
+    def test_bare_difference_is_flagged_uncontrolled_in_json(self):
+        assert summarize("x", _daily([(2.0, 0.0)] * 6)).as_dict()["excess_is_controlled"] is False
+
+    @pytest.mark.parametrize("excess", [3.0, -3.0])
+    def test_sign_of_excess_does_not_drive_verdict(self, excess: float):
+        """同一个对照结果,裸差值取正或取负都不该改变判定。"""
+        rows = _daily([(excess, 0.0)] * 6)
+        stat = summarize("x", rows, swap_question="待测 vs 对照", swap={"stock_win": _swap(-1.7, 0.005)})
+        assert "没有正向信息" in stat.verdict
+
+    def test_controlled_verdict_comes_from_win_column(self):
+        stat = summarize(
+            "x",
+            _daily([(-0.4, 0.0)] * 6),
+            swap_question="非热门 vs 热门（动量配平）",
+            swap={"stock_win": _swap(3.064, 0.005), "gross_return": _swap(0.488, 0.005, column="gross_return")},
+        )
+        assert "非热门 vs 热门（动量配平）" in stat.verdict
+        assert "超出互换零分布" in stat.verdict
+        assert "+0.488" in stat.verdict  # 收益栏必须一起报,不能只报胜率
+
+    def test_null_control_says_no_information(self):
+        stat = summarize("x", _daily([(-0.4, 0.0)] * 6), swap={"stock_win": _swap(0.041, 0.821)})
+        assert "不含信息" in stat.verdict
+
+    def test_short_control_is_not_a_failure(self):
+        """天数不够是「尚未可知」,不能读成「没通过」。"""
+        stat = summarize("x", _daily([(-0.4, 0.0)] * 6), swap={"stock_win": _swap(5.0, 0.005, days=15)})
+        assert "尚未可知" in stat.verdict
+
+    def test_missing_win_column_is_not_a_conclusion(self):
+        stat = summarize("x", _daily([(-0.4, 0.0)] * 6), swap={"gross_return": _swap(1.0, column="gross_return")})
+        assert stat.verdict == "对照未跑出结果：尚未可知"
+
+    def test_short_sample_keeps_swap_question(self):
+        """样本不足那条路径也要把待测方向带上,否则 JSON 里这行读不出量的是哪一侧。"""
+        stat = summarize("x", _daily([(1.0, 0.0)] * (MIN_DAYS - 1)), swap_question="未触发 vs 已触发（动量配平）")
+        assert stat.as_dict()["swap_question"] == "未触发 vs 已触发（动量配平）"
+
+    def test_swap_is_serialized(self):
+        stat = summarize("x", _daily([(-0.4, 0.0)] * 6), swap={"stock_win": _swap(3.064)})
+        payload = stat.as_dict()["swap"]
+        assert payload["stock_win"]["observed_pct"] == 3.064
+        assert payload["stock_win"]["permutations"] == 200
 
 
 class TestBandOf:
@@ -70,46 +134,77 @@ class TestBandOf:
 
 
 class TestRender:
-    def _report(self, theme_excess: float, stop_excesses: list[float]) -> GateReport:
+    def _report(
+        self,
+        theme_excess: float,
+        stop_excesses: list[float],
+        *,
+        theme_swap: dict[str, SwapTest] | None = None,
+        stop_swap: dict[str, SwapTest] | None = None,
+    ) -> GateReport:
         report = GateReport()
         report.theme = [
-            GateStat(f"topN={PROD_TOP_N_SECTORS}", 100, 240, -0.95, -0.36, theme_excess, 48.0, True),
+            GateStat(
+                f"topN={PROD_TOP_N_SECTORS}",
+                100,
+                240,
+                -0.95,
+                -0.36,
+                theme_excess,
+                48.0,
+                True,
+                "非热门 vs 热门（动量配平）",
+                theme_swap,
+            ),
             GateStat("topN=20", 100, 1050, -0.31, -0.44, 0.14, 56.0, False),
         ]
         report.stop_loss = [
-            GateStat(label, 100, 500, -0.75, -0.35, value, 40.0)
+            GateStat(label, 100, 500, -0.75, -0.35, value, 40.0, False, "未触发 vs 已触发（动量配平）", stop_swap)
             for label, value in zip(["0~15%", "15~30%", "30~50%", ">50%"], stop_excesses, strict=False)
         ]
         return report
 
     def test_marks_production_row_in_table(self):
-        text = render(self._report(-0.59, [-0.4, -0.42, -0.22, -0.05]))
-        assert "（生产值）" in text
+        assert "（生产值）" in render(self._report(-0.59, [-0.4, -0.42, -0.22, -0.05]))
 
-    def test_all_negative_stop_bands_warn_against_loosening(self):
-        """四档全负时必须明确说别因个别反例放宽风控。"""
+    def test_uncontrolled_table_says_bare_difference(self):
         text = render(self._report(-0.59, [-0.4, -0.42, -0.22, -0.05]))
-        assert "不要因为个别陈旧参考价的反例去放宽风控" in text
+        assert "裸差值" in text
+        assert "市场（未匹配）" in text
 
-    def test_positive_stop_band_is_named(self):
-        text = render(self._report(-0.59, [-0.4, -0.42, -0.22, 0.05]))
-        assert ">50%" in text
-        assert "卖早了" in text
-
-    def test_theme_negative_reports_best_alternative(self):
+    def test_no_control_refuses_both_directions(self):
+        """没跑对照时既不能说止损正确,也不能说该放宽——两个方向都没有测量支撑。"""
         text = render(self._report(-0.59, [-0.4, -0.42, -0.22, -0.05]))
-        assert "反向筛选" in text
-        assert "topN=20" in text
+        assert "不要" in text and "止损正确" in text
+        assert "放宽风控" in text
+
+    def test_null_stop_control_reports_no_support_either_way(self):
+        text = render(self._report(-0.59, [-0.4] * 4, stop_swap={"stock_win": _swap(0.041, 0.821)}))
+        assert "没有测量支撑" in text
+        assert "保持现状是默认，不是结论" in text
+
+    def test_passing_theme_still_demands_monthly_split(self):
+        """过了置换检验也只是过了一道,必须把跨窗口反号这件事写在行动项里。"""
+        text = render(self._report(-0.59, [-0.4] * 4, theme_swap={"stock_win": _swap(3.064, 0.005)}))
+        assert "2 个月" in text
+        assert "生产口径" in text
+
+    def test_failing_theme_does_not_propose_widening_topn(self):
+        text = render(self._report(-0.59, [-0.4] * 4, theme_swap={"stock_win": _swap(-1.739, 0.005)}))
+        assert "别拿裸差值去调 topN" in text
+        assert "放宽到" not in text
 
     def test_cost_threshold_is_always_stated(self):
         """任何改动建议都必须带上成本门槛，避免拿 0.1pct 的增益去改参数。"""
-        text = render(self._report(-0.59, [-0.4, -0.42, -0.22, -0.05]))
-        assert "0.202%" in text
+        assert "0.202%" in render(self._report(-0.59, [-0.4, -0.42, -0.22, -0.05]))
 
-    def test_reading_guide_explains_sign_convention(self):
+    def test_reading_guide_states_control_is_the_verdict(self):
         text = render(self._report(-0.59, [-0.4, -0.42, -0.22, -0.05]))
-        # 止损档的符号约定与题材层相反，必须写清楚。
-        assert "超额为负 = 止损正确" in text
+        assert "判定（配平动量后）" in text
+
+    def test_p_value_optimism_is_disclosed(self):
+        """持有期重叠 → 观测不独立,而置换零分布当它们独立,p 偏乐观,必须写出来。"""
+        assert "偏乐观" in render(self._report(-0.59, [-0.4] * 4))
 
 
 class TestReportSerialization:
@@ -122,6 +217,16 @@ class TestReportSerialization:
         payload = json.loads(json.dumps(report.as_dict(), ensure_ascii=False))
         assert payload["production"]["top_n_sectors"] == PROD_TOP_N_SECTORS
         assert payload["theme_resonance"][0]["excess"] == -0.59
+
+    def test_swap_survives_json_round_trip(self):
+        import json
+
+        report = GateReport()
+        report.theme = [
+            GateStat("topN=5", 100, 240, -0.95, -0.36, -0.59, 48.0, True, "非热门 vs 热门", {"stock_win": _swap(3.064)})
+        ]
+        payload = json.loads(json.dumps(report.as_dict(), ensure_ascii=False))
+        assert payload["theme_resonance"][0]["swap"]["stock_win"]["observed_pct"] == 3.064
 
     def test_empty_report_is_safe(self):
         assert GateReport().as_dict()["theme_resonance"] == []

--- a/tests/test_signal_feedback.py
+++ b/tests/test_signal_feedback.py
@@ -1013,6 +1013,60 @@ def test_maybe_persist_policy_shadow_run_skips_off_mode(monkeypatch):
     assert captured == []
 
 
+def _skip_reason_line(capsys) -> str:
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "动态策略shadow跳过记账" in ln]
+    assert len(lines) == 1, lines
+    return lines[0]
+
+
+def test_skip_names_the_regime_gate_as_by_design(monkeypatch, capsys):
+    """闸门关是设计行为。这行日志得说清楚,否则和「写入失败」在日志里没法区分。"""
+    from workflows import funnel_ai_selection as selection
+
+    monkeypatch.setattr(selection, "upsert_policy_shadow_run", lambda row: 1)
+    selection.maybe_persist_policy_shadow_run(
+        ai_policy={
+            "trade_gate_reason": "RISK_OFF 回测全周期弱势，新开仓胜率不足",
+            "trade_action": "禁止新仓：仅影子观察",
+        },
+        metrics={"end_trade_date": "2026-09-06"},
+        triggers={},
+        selected_for_ai=[],
+        l3_ranked_symbols=[],
+        regime="RISK_OFF",
+        sector_map={},
+    )
+    line = _skip_reason_line(capsys)
+    assert "水温闸门关" in line
+    assert "RISK_OFF" in line
+    assert "按设计不记账" in line
+
+
+def test_skip_distinguishes_unmounted_from_broken(monkeypatch, capsys):
+    """mode 空 = 没挂载(off/full_l4);mode 有值而 policy 空 = 异常,两者不能同一句话。"""
+    from workflows import funnel_ai_selection as selection
+
+    monkeypatch.setattr(selection, "upsert_policy_shadow_run", lambda row: 1)
+    kwargs = dict(
+        metrics={"end_trade_date": "2026-09-04"},
+        triggers={},
+        selected_for_ai=["000001"],
+        l3_ranked_symbols=["000001"],
+        regime="NEUTRAL",
+        sector_map={},
+    )
+
+    selection.maybe_persist_policy_shadow_run(ai_policy={"_dynamic_mode": "off"}, **kwargs)
+    unmounted = _skip_reason_line(capsys)
+    assert "未挂载" in unmounted
+    assert "这不该出现" not in unmounted
+
+    selection.maybe_persist_policy_shadow_run(ai_policy={"_dynamic_mode": "shadow", "_shadow_policy": {}}, **kwargs)
+    broken = _skip_reason_line(capsys)
+    assert "这不该出现" in broken
+    assert "水温闸门关" not in broken
+
+
 def test_attach_shadow_policy_also_attaches_in_on_mode():
     """on 档也必须挂上影子上下文，否则闸门永远开不了。
 

--- a/workflows/funnel_ai_selection.py
+++ b/workflows/funnel_ai_selection.py
@@ -296,6 +296,17 @@ def maybe_persist_policy_shadow_run(
         regime,
         mode=mode,
     )
+    written = _write_policy_shadow_row(row, mode, diff_added, diff_removed)
+    return _policy_shadow_meta(written, shadow_selected, diff_added, diff_removed, score_map, mode=mode)
+
+
+def _write_policy_shadow_row(
+    row: dict,
+    mode: str,
+    diff_added: list[str],
+    diff_removed: list[str],
+) -> int:
+    """写入影子账本并按结果打日志，成功与失败必须长得不一样。"""
     written = upsert_policy_shadow_run(row)
     if written:
         print(
@@ -311,7 +322,7 @@ def maybe_persist_policy_shadow_run(
             "归因重算会持续报 insufficient_shadow_sample；"
             "检查 signal_policy_shadow_runs 是否缺列(scripts/print_signal_policy_shadow_ddl.py)"
         )
-    return _policy_shadow_meta(written, shadow_selected, diff_added, diff_removed, score_map, mode=mode)
+    return written
 
 
 def full_formal_ai_selection(

--- a/workflows/funnel_ai_selection.py
+++ b/workflows/funnel_ai_selection.py
@@ -225,6 +225,19 @@ def _promote_mainline_for_ai(
     )
 
 
+def _shadow_skip_reason(ai_policy: dict, mode: str, regime: str) -> str:
+    """分清「按设计跳过」与「坏了」。三种成因各自有过一段真实的停摆史。"""
+    if ai_policy.get("trade_gate_reason"):
+        # allow_ai_review=False 时 funnel_ai_selection 早返回，动态上下文根本没加载过。
+        # 这是设计行为，不是缺陷：RISK_OFF/CRASH/BLACK_SWAN/UNKNOWN 这四档不记账。
+        return f"水温闸门关(regime={regime}, {ai_policy.get('trade_action') or ai_policy['trade_gate_reason']})，按设计不记账"
+    if mode not in {"shadow", "on"}:
+        # 别写成 ``not mode``:off 档的 mode 是字符串 "off"(真值),会被误判成异常。
+        # 这三种都是「没挂载」:键缺失、off 档、full_l4 分支只挂 shadow 不挂 on。
+        return f"动态档未挂载(mode={mode or '缺失'}，FUNNEL_DYNAMIC_POLICY=off 或走了 full_l4 分支)，无对照可记"
+    return f"mode={mode} 但 _shadow_policy 为空——这不该出现，检查 _load_dynamic_policy_context 是否降级为静态"
+
+
 def maybe_persist_policy_shadow_run(
     *,
     ai_policy: dict,
@@ -238,6 +251,11 @@ def maybe_persist_policy_shadow_run(
 ) -> dict:
     mode = str(ai_policy.get("_dynamic_mode") or "")
     if mode not in {"shadow", "on"} or not ai_policy.get("_shadow_policy"):
+        # 这条早返回原先完全静默，于是「今天没记账」在日志里和「写入失败」长得一样。
+        # 实测代价：查一次 signal_policy_shadow_runs 为什么不长要翻三段历史（07-04 缺列、
+        # 09-04 前 on 档不挂、水温闸门关），而其中只有第三种是正常的。把原因打出来，
+        # 下次一条 grep 就能分清「按设计跳过」和「坏了」。
+        print(f"[funnel] 动态策略shadow跳过记账: 原因={_shadow_skip_reason(ai_policy, mode, regime)}")
         return {}
     if mode == "on":
         # on 档实际下单的是动态档，所以 shadow_selected 直接取实选，反过来算静态反事实。


### PR DESCRIPTION
## 变更摘要

门槛层（L3 题材共振 / 止损参考价陈旧度）首轮那两条结论是**裸日均差**算出来的，没有任何对照。补做逐对随机互换否证（复用 #390 落地的 `swap_falsification`，配对钉住、只抹标签、动量按最近邻配平）后：

| 层 | 首轮读数 | 配平动量后 | 结果 |
|---|---|---|---|
| 止损参考价陈旧度 | 四档 -0.07~-0.54pct → 「止损统计上是对的」 | 胜率差 **+0.041pct（p=0.821）** | **原结论不成立**，标签不含信息 |
| L3 题材共振 | 热门 − 非热门 -0.37pct → 「热门反而更差」 | 胜率差 **+3.064pct（p=0.005）** | 过了逐日零分布，**过不了跨窗口稳定性** |

题材层那个 +3.064 不能当边缘用。同一套代码按 2 个月切开，符号在同一段八个月里反了号：

| 区间 | 天数 | 胜率差 pct | p |
|---|---|---|---|
| 2026-01 ~ 02 | 34 | +9.087 | 0.005 |
| 2026-03 ~ 04 | 43 | +7.932 | 0.005 |
| 2026-05 ~ 06 | 39 | **-4.468** | 0.005 |
| 2026-07 ~ 08 | 43 | +0.199 | 0.851 |
| 汇总 | 159 | +3.064 | 0.005 |

段间 mean +3.188 / sd 6.451，**t=+0.988（n=4）不显著**。三段非空的 p 全部钉在 200 次置换的下限 1/201≈0.005，说明「打得过自己那天的零分布」很容易，有区分力的是段间离散度。换窗口就换符号：topN=5 在 142 天读 +2.808、159 天读 +3.064、2026-04..08 那 99 天读 **-1.739**（正好是 05~06 负段主导的窗口）。这几个数不矛盾，是同一件事的不同切法。

代码侧改动：

- `GateStat` 加 `swap` / `swap_question` 两栏；`verdict` 不再从裸差值给方向，无对照时明确输出「不是结论」，有对照时一律转述互换检验的胜率栏并附带收益栏。
- `scripts/evaluate_gate_alpha.py` 加 `--no-control`；对照只跑**生产行**（题材 topN=5 + 止损四档），200 次置换乘整个网格既不必要也跑不动。止损四档各自的对照池限定在**该档内**，回答的是「这一档触发得对不对」。
- `match_by_momentum` 从全扫改二分最近邻——止损层要在 4000 只宽池上逐日配 950 只、跨 142 天，O(n·m) 跑不动。并列时退到相等动量串的**最左**一个，与全扫版 `min(range(...))` 取最小下标对齐，并加了 200 例随机对照测试守住等价性。

## 为什么

这两条都踩在已在案的「全市场对照混入动量」上：拿一个**按定义就是动量**的标签去比未匹配的全市场均值，量到的超额里主要是动量本身。止损那条尤其要紧——它此前被当成「风控不用动」的依据在引用，而实际上「不放宽」这个决定目前没有测量支撑（保持现状是默认，不是结论）。

题材层这条则是第三次遇到同一族形状：动量梯度按半年反号、池子相对优势按月翻号，现在是题材标签按 2 个月反号。所以这里刻意不把 +3.064 写成成果，而是把「跨窗口不稳定」写成结论，并把「每段同号 + 段间 t 显著」钉进 `_theme_action` 的行动门槛里，避免下一轮又拿汇总值去调 topN。

另外记一笔口径：本模块按「全市场个股 5 日动量的行业均值」取前 N，生产 L3 取的是**候选内**成分股复合截面百分位的**中位数**，且放行是四路取或、末尾还有 `len(filtered) < 3` 兜底放行全量。所以 topN 网格的读数不能直接换算成生产参数——它是「按行业动量分组」这个构造的性质，不是那道闸的性质。真要动生产得在生产口径上重测。

置换 p 在这里**偏乐观**：持有期逐日重叠，观测不独立，而置换零分布当它们独立。这一点写进了报告的读法说明。

## 测试

- `pytest` 全量 **4690 passed / 22 skipped**
- `tests/core/test_gate_alpha_eval.py` 29 passed（重写：新增「无对照必须拒绝给结论」「裸差值符号不得影响判定」「天数不足是尚未可知而非没通过」「过了置换仍须按 2 个月拆开」等用例）
- `tests/core/test_funnel_effect_eval.py` 89 passed（新增二分匹配 vs 全扫的 200 例等价性测试，动量取整到 0.5 强制制造并列）
- `ruff check` / `ruff format --check` clean；`scripts/quality_gate.py --check-no-sql` OK
- 端到端：本地行情快照跑通 `build_report(with_control=True)`，159 天、日均 225.5 对、37s 内出表与 JSON


---

## 追加提交:影子记账的静默早返回(与上文无关的独立改动)

`maybe_persist_policy_shadow_run` 的早返回原先是裸 `return {}`,不打任何日志。补一行原因日志和 `_shadow_skip_reason` 辅助函数,把三种跳过成因分开命名。纯观测性改动,不改任何行为。

起因是查 `signal_policy_shadow_runs` 为什么两个月不长记录,而日志里分不出这三种情况:

1. **07-04 ~ 09-01 缺列**:`_policy_shadow_row` 加了 `attribution_signal_weights` / `attribution_policy_meta`,线上表没跟上,每次 upsert 报 42703,被 `raise_on_error=False` 转成 warning,而日志那行写的是「已写入 … written=0」。DDL 已于 09-01 执行。
2. **09-04 之前 on 档死环**:`attach_shadow_policy` 只认 `shadow`,Secret 挂在 `on` 档时早返回,一个键都没挂上。已由 #381 修掉。
3. **水温闸门关**:`RISK_OFF` / `CRASH` / `BLACK_SWAN` / `UNKNOWN` 四档 `allow_ai_review=False`,`funnel_ai_selection.py:86` 在两处 attach 调用之前就返回。09-02、09-03、09-06 都是这种。

三种里只有第三种是设计行为,却和另外两种在日志里完全无法区分。这是和 `written=0` 那次同一类缺陷:成功句式或干脆无输出,把整行丢失藏了两个月。

顺带在 helper 里踩到一个真 bug 并由新测试抓到:`mode="off"` 是真值字符串,写 `if not mode:` 会把正常的 off 档判成「不该出现」的异常分支,已改成集合判断,注释里记下这个坑。

三个新测试分别锁住闸门关、未挂载、异常三支的措辞,未挂载那支断言 `"这不该出现" not in line`,即上面那个 bug 的回归用例。全量 **4692 passed / 22 skipped**。
