### PR TITLE
fix(replay): 概念热度被 RLS 挡住返回 count=0,回放一直跑在 0 个概念上

### DIFF
--- a/integrations/supabase_concept_heat.py
+++ b/integrations/supabase_concept_heat.py
@@ -66,23 +66,49 @@ def upsert_concept_heat_history(trade_date: str, heat: list[dict[str, Any]], top
             _close(client)
 
 
+def _fetch_concept_heat_rows(client: Any, row_limit: int, as_of_date: str | None) -> list[dict[str, Any]]:
+    query = client.table(TABLE_CONCEPT_HEAT_HISTORY).select("trade_date,concept_name,pct,net_inflow,rank")
+    if as_of_date:
+        query = query.lte("trade_date", as_of_date)
+    resp = query.order("trade_date", desc=True).order("rank").limit(row_limit).execute()
+    return list(resp.data or [])
+
+
 def load_concept_heat_history_from_supabase(limit_days: int = 20, as_of_date: str | None = None) -> dict[str, dict]:
-    """读取最近 N 个交易日的概念热度历史。"""
+    """读取最近 N 个交易日的概念热度历史。
+
+    anon 角色在 concept_heat_history 上被 RLS 挡住,返回的是 count=0 而不是报错——
+    与「表为空」完全同形。回放靠这张表还原当日板块热度,读空不会抛异常,只会静默
+    退化成 concept_heat=[](2026-09-07 实测:回放拿到 0 个概念,库里同日有 31 个),
+    L3 板块过滤和主线打分因此偏离生产。故读空且 service key 可用时升级重读一次。
+    """
     row_limit = max(int(limit_days), 1) * 50
+    rows: list[dict[str, Any]] = []
     client = None
     try:
         client = _read()
-        query = client.table(TABLE_CONCEPT_HEAT_HISTORY).select("trade_date,concept_name,pct,net_inflow,rank")
-        if as_of_date:
-            query = query.lte("trade_date", as_of_date)
-        resp = query.order("trade_date", desc=True).order("rank").limit(row_limit).execute()
+        rows = _fetch_concept_heat_rows(client, row_limit, as_of_date)
     except Exception as exc:
         logger.warning("concept heat read failed: %s", exc)
-        return {}
+        rows = []
     finally:
         if client is not None:
             _close(client)
-    return _rows_to_history(resp.data or [], limit_days)
+
+    if not rows and _configured():
+        admin = None
+        try:
+            admin = _admin()
+            rows = _fetch_concept_heat_rows(admin, row_limit, as_of_date)
+            if rows:
+                logger.warning("concept heat: anon 读到 0 行,已用 service key 重读到 %d 行", len(rows))
+        except Exception as exc:
+            logger.warning("concept heat admin re-read failed: %s", exc)
+        finally:
+            if admin is not None:
+                _close(admin)
+
+    return _rows_to_history(rows, limit_days)
 
 
 def _rows_to_history(rows: list[dict[str, Any]], limit_days: int) -> dict[str, dict]:

--- a/tests/integrations/test_supabase_concept_heat.py
+++ b/tests/integrations/test_supabase_concept_heat.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 
 class _Response:
     def __init__(self, data: list[dict] | None = None):
@@ -13,6 +15,7 @@ class _FakeTable:
         self.conflict = ""
         self.limit_value: int | None = None
         self.deleted_filters: list[tuple[str, str]] = []
+        self.lte_filters: list[tuple[str, str]] = []
         self.kind = ""
 
     def upsert(self, payload: list[dict], *, on_conflict: str):
@@ -32,6 +35,10 @@ class _FakeTable:
 
     def select(self, _columns: str):
         self.kind = "select"
+        return self
+
+    def lte(self, column: str, value: str):
+        self.lte_filters.append((column, value))
         return self
 
     def order(self, _column: str, *, desc: bool = False):
@@ -108,3 +115,53 @@ def test_load_concept_heat_history_groups_recent_days(monkeypatch):
 
     assert list(history) == ["2026-05-25", "2026-05-24"]
     assert history["2026-05-25"]["A"] == {"pct": 1.0, "inflow": 10.0}
+
+
+def test_load_concept_heat_falls_back_to_admin_when_anon_blocked(monkeypatch):
+    """anon 被 RLS 挡住时返回 0 行而非报错,必须升级到 service key 重读。
+
+    回放读空不抛异常,只会静默把当日概念热度降级成空,L3 板块过滤随之偏离生产。
+    """
+    from integrations import supabase_concept_heat as mod
+
+    blocked = _FakeClient([])  # RLS: 有数据但 anon 看不到,表现为空结果集
+    rows = [
+        {"trade_date": "2026-09-04", "concept_name": "猪肉概念", "pct": 3.0, "net_inflow": 30, "rank": 1},
+        {"trade_date": "2026-09-03", "concept_name": "鸡肉概念", "pct": 2.0, "net_inflow": 20, "rank": 1},
+    ]
+    admin = _FakeClient(rows)
+    monkeypatch.setattr(mod, "_read", lambda: blocked)
+    monkeypatch.setattr(mod, "_admin", lambda: admin)
+    monkeypatch.setattr(mod, "_configured", lambda: True)
+
+    history = mod.load_concept_heat_history_from_supabase(limit_days=5, as_of_date="2026-09-04")
+
+    assert list(history) == ["2026-09-04", "2026-09-03"]
+    assert history["2026-09-04"]["猪肉概念"] == {"pct": 3.0, "inflow": 30.0}
+    # as_of 过滤不能在降级路径上丢掉,否则回放会读到未来数据
+    assert admin.table_obj.lte_filters == [("trade_date", "2026-09-04")]
+
+
+def test_load_concept_heat_skips_admin_when_anon_returns_rows(monkeypatch):
+    """anon 读到数据就不升权——降级只为绕 RLS,不是默认路径。"""
+    from integrations import supabase_concept_heat as mod
+
+    client = _FakeClient([{"trade_date": "2026-09-04", "concept_name": "A", "pct": 1, "net_inflow": 10, "rank": 1}])
+    monkeypatch.setattr(mod, "_read", lambda: client)
+    monkeypatch.setattr(mod, "_configured", lambda: True)
+    monkeypatch.setattr(mod, "_admin", lambda: pytest.fail("anon 已有数据,不应升级到 service key"))
+
+    history = mod.load_concept_heat_history_from_supabase(limit_days=5)
+
+    assert list(history) == ["2026-09-04"]
+
+
+def test_load_concept_heat_returns_empty_without_service_key(monkeypatch):
+    """没配 service key 时保持原行为:返回空,不抛异常。"""
+    from integrations import supabase_concept_heat as mod
+
+    monkeypatch.setattr(mod, "_read", lambda: _FakeClient([]))
+    monkeypatch.setattr(mod, "_configured", lambda: False)
+    monkeypatch.setattr(mod, "_admin", lambda: pytest.fail("未配置 service key,不应调用 _admin"))
+
+    assert mod.load_concept_heat_history_from_supabase(limit_days=5) == {}


### PR DESCRIPTION
## 变更摘要

`load_concept_heat_history_from_supabase` 改用 anon 读、读空时升级到 service key 重读一次。
补三条回归测试。

## 为什么

这个函数用 anon 客户端读 `concept_heat_history`,而该表的 RLS 不放行 anon。被挡住时
Supabase 返回的是 `count=0` 而不是报错——与「表为空」完全同形,调用侧无从分辨。

回放模式(`workflows/funnel_data.py` 的 `_load_historical_metadata`)靠这张表还原当日
板块热度。读空不抛异常,只会静默降级到本地 stale JSON 缓存,而那个缓存最后一次写入是
2026-08-24、只含 2 天数据,回放 08-31 / 09-04 都命中不到,于是 `concept_heat=[]`、
`热门概念=[]`。

实测(service key 直连同一条 query):

| 回放日 | 回放实际拿到 | 库里同日实有 |
|---|---|---|
| 2026-08-31 | 0 个概念 | 30 个 |
| 2026-09-04 | 0 个概念 | 31 个 |

表里有 2300 行数据,一直读不到。L3 板块过滤和主线打分因此跑在与生产不同的输入上,
这是回放与生产 membership 对不齐的一个成因。

## 取舍

- 只在读空且 service key 已配置时升权,anon 有数据就走原路;没配 service key 时保持
  原行为返回空,不抛异常。
- 降级路径同样带 `as_of` 过滤——漏掉会让回放读到未来数据,比读空更糟。
- 升权时打一条 warning,便于日后发现 RLS 策略变动,而不是又被静默吸收。

## 验证

`tests/integrations/test_supabase_concept_heat.py` 5 passed。

三条新测试:anon 被挡时必须降级且保留 `as_of`;anon 有数据时不得升权;未配 service
key 时不得调 `_admin`。

第一条做了判别性检查:临时移除降级块后该测试确实失败(`Right contains 2 more items`),
恢复后通过——不是恒真断言。

## 影响面

只改读路径。写路径(`upsert_concept_heat_history`)未动。生产实盘从网络实时抓概念热度,
不走这个函数,因此本次改动只影响回放/历史模式。
