### PR TITLE
fix(market-signal): anon 读 market_signal_daily 被 RLS 读空，与「没这天」同形

### DIFF
--- a/integrations/supabase_base.py
+++ b/integrations/supabase_base.py
@@ -100,13 +100,24 @@ def create_anon_client() -> Client:
     return create_client(url, key, options=_client_options())
 
 
+def read_client_uses_admin() -> bool:
+    """create_read_client() 这次会不会返回 service-role 客户端。
+
+    调用方判断「要不要再挂一层 admin 兜底重读」时用它，避免各处自己抄
+    一份 ``current_write_context() == SERVER_WRITE_CONTEXT and ...``
+    条件：抄出来的副本一旦与 create_read_client() 走偏，兜底就会在该生效
+    的场景静默不生效。
+    """
+    return current_write_context() == SERVER_WRITE_CONTEXT and is_admin_configured()
+
+
 def create_read_client() -> Client:
     """只读场景客户端。
 
     Server job 可用 service role 读取生产表；CLI 默认走 anon/RLS，
     需要用户级权限的场景应显式传入 create_user_client() 的结果。
     """
-    if current_write_context() == SERVER_WRITE_CONTEXT and is_admin_configured():
+    if read_client_uses_admin():
         return create_admin_client()
     return create_anon_client()
 

--- a/integrations/supabase_market_signal.py
+++ b/integrations/supabase_market_signal.py
@@ -9,6 +9,7 @@ Supabase 最新交易日市场信号读写
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any
 
@@ -24,6 +25,7 @@ from core.market_trade_mode import (
 from integrations.supabase_base import create_admin_client as _get_supabase_admin_client
 from integrations.supabase_base import create_read_client as _get_supabase_read_client
 from integrations.supabase_base import is_admin_configured as is_supabase_admin_configured
+from integrations.supabase_base import read_client_uses_admin as _read_client_uses_admin
 from integrations.supabase_base import require_server_write_context
 from utils.safe import finite_float as _safe_float
 
@@ -544,16 +546,27 @@ def _load_market_signal_by_trade_date(client: Client, trade_date: str) -> dict[s
     return dict(resp.data[0])
 
 
-def _iter_market_signal_clients(client: Client | None = None) -> list[Client]:
-    clients: list[Client] = []
+def _iter_market_signal_clients(client: Client | None = None) -> Iterator[tuple[str, Client]]:
+    """按 (来源标签, 客户端) 逐个产出读取通道，anon 读空时兜底到 service role。
+
+    market_signal_daily 有 RLS，anon 读它返回的是 0 行而不是报错，跟「表里
+    真没有这天」完全同形。这里之所以是生成器：admin 客户端只在前一个通道
+    没读到时才创建，server job 场景 read client 本身已经是 service role，
+    不必再连一次。
+    """
     if client is not None:
-        clients.append(client)
-        return clients
+        yield "caller", client
+        return
     try:
-        clients.append(_get_supabase_read_client())
+        yield "read", _get_supabase_read_client()
     except Exception:
         logger.debug("failed to create supabase read client", exc_info=True)
-    return clients
+    if _read_client_uses_admin() or not is_supabase_admin_configured():
+        return
+    try:
+        yield "admin", _get_supabase_admin_client()
+    except Exception:
+        logger.debug("failed to create supabase admin client", exc_info=True)
 
 
 _UPSERT_MAX_RETRIES = 3
@@ -628,10 +641,11 @@ def upsert_market_signal_daily(trade_date: date | str, patch: dict[str, Any]) ->
 
 def load_market_signal_daily(trade_date: date | str, client: Client | None = None) -> dict[str, Any] | None:
     trade_date_text = _normalize_trade_date(trade_date)
-    for sb in _iter_market_signal_clients(client):
+    for source, sb in _iter_market_signal_clients(client):
         try:
             row = _load_market_signal_by_trade_date(sb, trade_date_text)
             if row:
+                _log_admin_rescue(source, "load_market_signal_daily", trade_date_text)
                 return row
         except Exception as e:
             logger.debug("[supabase_market_signal] load_market_signal_daily failed for client: %s", e)
@@ -640,14 +654,31 @@ def load_market_signal_daily(trade_date: date | str, client: Client | None = Non
 
 
 def load_latest_market_signal_daily(client: Client | None = None) -> dict[str, Any] | None:
-    for sb in _iter_market_signal_clients(client):
+    for source, sb in _iter_market_signal_clients(client):
         try:
             if sb is None:
                 continue
             merged = _merge_latest_market_signal_rows(_latest_market_signal_rows(sb))
             if merged:
+                _log_admin_rescue(source, "load_latest_market_signal_daily", str(merged.get("trade_date", "")))
                 return merged
         except Exception as e:
             logger.debug("[supabase_market_signal] load_latest_market_signal_daily failed for client: %s", e)
             continue
     return None
+
+
+def _log_admin_rescue(source: str, fn: str, trade_date_text: str) -> None:
+    """兜底通道读到东西时喊一声：说明 anon 通道刚才被 RLS 读空了。
+
+    下游 step4_market 把「读不到行」直接折成 regime=UNKNOWN（禁买态），
+    所以这条是禁买究竟出于市场还是出于权限的唯一区分依据。
+    """
+    if source != "admin":
+        return
+    logger.warning(
+        "[supabase_market_signal] %s: anon 读到 0 行,已用 service key 重读到 trade_date=%s;"
+        "该进程读 market_signal_daily 走的是 RLS,禁买态可能是权限而非市场",
+        fn,
+        trade_date_text or "unknown",
+    )

--- a/tests/integrations/test_supabase_market_signal.py
+++ b/tests/integrations/test_supabase_market_signal.py
@@ -3,6 +3,7 @@ from core.market_trade_mode import PROBE_ONLY_REGIMES, merge_premarket_regime, r
 from integrations.supabase_market_signal import (
     _merge_latest_market_signal_rows,
     compose_market_state,
+    load_market_signal_daily,
     market_signal_readiness,
     upsert_market_signal_daily,
 )
@@ -304,3 +305,81 @@ def test_upsert_market_signal_daily_scrubs_non_finite_numeric_fields(monkeypatch
     assert written["main_index_close"] is None
     assert written["vix_close"] is None
     assert written["a50_close"] == 13200.5
+
+
+class _RlsBlindClient:
+    """anon 视角：表里有行，但 RLS 把它过滤成 0 行,且不报错。"""
+
+    def __init__(self):
+        self.reads = 0
+
+    def table(self, _name):
+        self.reads += 1
+        return _FakeQuery(_FakeMarketSignalTable({}), "select")
+
+
+def test_load_market_signal_daily_falls_back_to_admin_when_anon_reads_empty(monkeypatch):
+    """anon 被 RLS 读空必须兜底到 service key,否则下游把它折成禁买态。
+
+    step4_market 拿不到行且 benchmark_context 也没 regime 时，会把 regime 置成
+    UNKNOWN——一个禁买状态。所以「读空」在这条链路上不是缺数据，是当天不许买；
+    权限问题伪装成市场判断，日志里两者同形。
+    """
+    blind = _RlsBlindClient()
+    served = _FakeMarketSignalTable({"trade_date": "2026-06-20", "benchmark_regime": "NEUTRAL"})
+    monkeypatch.setattr(market_signal_module, "_get_supabase_read_client", lambda: blind)
+    monkeypatch.setattr(market_signal_module, "_read_client_uses_admin", lambda: False)
+    monkeypatch.setattr(market_signal_module, "is_supabase_admin_configured", lambda: True)
+    monkeypatch.setattr(market_signal_module, "_get_supabase_admin_client", lambda: served)
+
+    row = load_market_signal_daily("2026-06-20")
+
+    assert blind.reads == 1, "anon 通道必须先试，不能直接上 service key"
+    assert row is not None, "anon 读空后没兜底：这行会被下游折成 UNKNOWN 禁买"
+    assert row["benchmark_regime"] == "NEUTRAL"
+
+
+def test_load_market_signal_daily_skips_admin_when_read_client_already_admin(monkeypatch):
+    """server job 的 read client 本身就是 service role,不该再连一次库。"""
+    served = _FakeMarketSignalTable({"trade_date": "2026-06-20", "benchmark_regime": "RISK_ON"})
+    admin_calls = []
+
+    def _unexpected_admin():
+        admin_calls.append(1)
+        return served
+
+    monkeypatch.setattr(market_signal_module, "_get_supabase_read_client", lambda: _RlsBlindClient())
+    monkeypatch.setattr(market_signal_module, "_read_client_uses_admin", lambda: True)
+    monkeypatch.setattr(market_signal_module, "is_supabase_admin_configured", lambda: True)
+    monkeypatch.setattr(market_signal_module, "_get_supabase_admin_client", _unexpected_admin)
+
+    assert load_market_signal_daily("2026-06-20") is None
+    assert admin_calls == [], "read client 已是 admin，兜底通道属于重复连接"
+
+
+def test_load_market_signal_daily_logs_when_admin_rescues_the_read(monkeypatch, caplog):
+    """兜底生效时必须留一条 warning,否则没人知道这台机器读的是 RLS 视图。"""
+    served = _FakeMarketSignalTable({"trade_date": "2026-06-20", "benchmark_regime": "NEUTRAL"})
+    monkeypatch.setattr(market_signal_module, "_get_supabase_read_client", lambda: _RlsBlindClient())
+    monkeypatch.setattr(market_signal_module, "_read_client_uses_admin", lambda: False)
+    monkeypatch.setattr(market_signal_module, "is_supabase_admin_configured", lambda: True)
+    monkeypatch.setattr(market_signal_module, "_get_supabase_admin_client", lambda: served)
+
+    with caplog.at_level("WARNING", logger=market_signal_module.logger.name):
+        load_market_signal_daily("2026-06-20")
+
+    assert any("service key 重读" in r.getMessage() for r in caplog.records)
+
+
+def test_load_market_signal_daily_stays_quiet_on_a_normal_first_try_hit(monkeypatch, caplog):
+    """anon 一次读到就别喊兜底,否则 warning 天天出,真出事时没人看。"""
+    served = _FakeMarketSignalTable({"trade_date": "2026-06-20", "benchmark_regime": "NEUTRAL"})
+    monkeypatch.setattr(market_signal_module, "_get_supabase_read_client", lambda: served)
+    monkeypatch.setattr(market_signal_module, "_read_client_uses_admin", lambda: False)
+    monkeypatch.setattr(market_signal_module, "is_supabase_admin_configured", lambda: True)
+
+    with caplog.at_level("WARNING", logger=market_signal_module.logger.name):
+        row = load_market_signal_daily("2026-06-20")
+
+    assert row is not None
+    assert not [r for r in caplog.records if "service key 重读" in r.getMessage()]

--- a/workflows/step4_market.py
+++ b/workflows/step4_market.py
@@ -70,6 +70,13 @@ def missing_market_inputs(
     `normalize_*_regime` 会把缺失值和真实的 UNKNOWN 判定压成同一个 UNKNOWN，
     而 UNKNOWN 属于禁止开仓状态。不单独识别缺失，运维就无法区分「行情不明」和
     「上游任务没跑」——生产 47 天里有 11 天因后者被禁买，比 NEUTRAL 放行的天数还多。
+
+    上面那 11 天已经是关掉的历史区间，两半各有各的成因，别再拿它去查现网：
+    盘前那半是外部 08:20 触发器连续漏掉周一周二，5a8d5a83(2026-07-30) 补了兜底
+    cron；benchmark 那半是当时 DB CHECK 不收 PANIC_REPAIR、而旧兜底只降级
+    PANIC_REPAIR_CONFIRMED，纯 PANIC_REPAIR 落空后写入抛错记成 ok=False，
+    0286f735(2026-07-14) 连同放宽约束一起收掉。两个修复之后各自 0 复发。
+    留这个函数不是为了那 11 天，是为了下一次上游静默时仍能分清缺失与不明。
     """
     missing: list[str] = []
     if not clean_text(raw_premarket):


### PR DESCRIPTION
## 变更摘要

- `integrations/supabase_market_signal.py`：读 `market_signal_daily` 时，anon 通道读到 0 行就用 service role 再读一次，与 `concept_heat_history`(#392) 同一模式。兜底真的救回来时打一条 WARNING。
- `integrations/supabase_base.py`：新增 `read_client_uses_admin()`，把「这次 `create_read_client()` 会不会返回 service-role」这个判断收成一处。
- `tests/integrations/test_supabase_market_signal.py`：4 个用例——anon 读空能兜底、read client 本身已是 admin 时不重复连、兜底救回时有 WARNING、首次就命中时不打这条 WARNING。
- `workflows/step4_market.py`：只改注释，给 `missing_market_inputs` 里那句「47 天里有 11 天」标注这是已关闭的历史区间。

## 为什么

`market_signal_daily` 带 RLS，anon 读它返回 `count=0` 而不报错，跟表里真没有这天完全同形。下游把读不到行折成 `regime=UNKNOWN`，而 `UNKNOWN` 在禁买档位里，所以一次权限读空会静默变成一次禁买。这一类已经咬过两张表（`concept_heat_history` 是 #392）。

**这个改动的范围要说清楚：它不是线上禁买的修复。** 生产里读 `market_signal_daily` 的两条链路都设了 `WYCKOFF_WRITE_CONTEXT=server_job`（`premarket_risk.yml:31`、`step4_from_supabase.yml:23`），`create_read_client()` 在该上下文下返回的已经是 service-role 客户端，不走 RLS。所以这里补的是本地/CLI 侧的防御加一条可观测性，真正的受益者是 `scripts/diagnose_funnel_throughput.py` 这种不在任何 workflow 里、只手工跑的脚本。

顺便把原来那条线索查干净了，结论是**否证**：docstring 里「11 天因上游没跑被禁买」跟 RLS 无关。直连生产量了一遍，`market_signal_daily` 在 2026-05-25..09-07 有 75 行，只缺 1 个工作日（06-19，大概是假期），写入侧基本一直在跑，不存在缺行。9 个真正禁买的日子全落在周一或周二，随机日历下 (2/5)^9 ≈ 0.03%，是排期产物不是数据运气，且两半成因都已修完：

- 盘前那半（06-02、07-20、07-21、07-27、07-28）：外部 08:20 触发器连续漏掉周一周二，`premarket_risk.yml` 自己的注释就记着这事，`5a8d5a83`(2026-07-30, #184) 补了兜底 cron，之后 0 复发。
- benchmark 那半（05-25、06-09、06-15、06-30）：漏斗当天跑成功了，但日志是 `市场信号写库(benchmark): ok=False, regime=PANIC_REPAIR`，三分钟后 Step4 读到 `benchmark=-`。这四行的 `source_jobs` 只有 `premarket_risk_job`，确认漏斗那次写入没落库。成因是当时 DB CHECK 不收 `PANIC_REPAIR`，而旧兜底只降级 `PANIC_REPAIR_CONFIRMED`，纯 `PANIC_REPAIR` 落空后再撞约束抛错记成 `ok=False`。`0286f735`(2026-07-14) 连同放宽约束一起收掉，`PANIC_REPAIR` 行只从 07-14 起才存在，之后 0 复发。

另外两天（08-07、08-17）写的是 `premarket_regime=UNKNOWN`，原因 `A50 数据缺失`，但 benchmark 给出 `BEAR_REBOUND`，`effective=BEAR_REBOUND` 不在禁买集合里，只把 readiness 降成 `partial`，不禁买。

## 验证

- 反证过测试有区分力：把读取侧还原成改动前的样子，恰好是两个兜底用例失败、两个守卫用例仍通过，再还原回来。
- `ruff format --check` / `ruff check` 通过；`quality_gate.py --check-functions --check-no-sql` 0 violations。
- `pytest tests/integrations/ tests/workflows/ -q` → 1094 passed。
