### PR TITLE
fix(ic-shadow): 影子行不产出 regime 列,110 行全吃了 DB 默认值 NEUTRAL

### DIFF
--- a/core/ic_shadow_score.py
+++ b/core/ic_shadow_score.py
@@ -228,11 +228,18 @@ def _last_percentile(panel, eligible) -> dict[str, float]:
     return (row.rank(pct=True) * 100).to_dict()
 
 
-def to_rows(picks: list[ShadowPick], trade_date: str, config: ShadowScoreConfig) -> list[dict]:
+def to_rows(picks: list[ShadowPick], trade_date: str, config: ShadowScoreConfig, *, regime: str) -> list[dict]:
     """转成 signal_observations 行。signal_type 用 ic_shadow 便于与真实买点区分。
 
     放在 core 而非 scripts：workflows/wyckoff_funnel 要调它，而
     tests/test_architecture_boundaries 禁止 runtime 层依赖脚本入口。
+
+    regime 是必填关键字参数，不给默认值：此前这里根本不产出 regime 列，落库时
+    吃 DB 默认值 NEUTRAL，首批 110 行（2026-08-24..09-07，11 个交易日）全被标成
+    NEUTRAL，而这 11 天真实档位是 RISK_OFF 8 天 / BEAR_REBOUND 2 天 / CRASH 1 天，
+    没有一天真的是 NEUTRAL。其中 08-24..08-28 这 5 天表里只有影子行、没有同日
+    其它信号可交叉核对，错标是查不出来的。给默认值等于把这个失效模式原样留着，
+    所以宁可让新调用方编译期就被逼着回答这个问题。
     """
     import json
 
@@ -256,6 +263,9 @@ def to_rows(picks: list[ShadowPick], trade_date: str, config: ShadowScoreConfig)
             # 当时容错生效、漏斗主流程未受影响。
             "track": "Accum",
             "stage": "",
+            # 缺档位写 UNKNOWN 而不是 NEUTRAL：NEUTRAL 是一个真实档位，用它兜底就
+            # 把「没拿到」和「确实中性」压成同一个值，分层归因再也分不开。
+            "regime": str(regime or "").strip().upper() or "UNKNOWN",
             "strategy_version": config.describe(),
             "features_json": json.dumps(pick.as_features(), ensure_ascii=False),
         }

--- a/scripts/run_ic_shadow_pool.py
+++ b/scripts/run_ic_shadow_pool.py
@@ -102,6 +102,27 @@ def compute_percentiles(
     return panels, str(dates[idx].date()), len(eligible)
 
 
+def _regime_for(trade_date: str) -> str:
+    """查信号日当天的基准档位。本脚本从行情缓存跑，手里没有漏斗的 benchmark_context。
+
+    查不到就返回 UNKNOWN，不要退成 NEUTRAL：NEUTRAL 是真实档位，兜底用它会把
+    「这天没查到」混进「这天中性」，而影子池正是靠 regime 分层做归因的。
+    """
+    from core.market_trade_mode import normalize_regime
+
+    try:
+        from integrations.supabase_market_signal import load_market_signal_daily
+
+        row = load_market_signal_daily(trade_date) or {}
+    except Exception as exc:  # noqa: BLE001 - 查不到档位不该挡住影子池计算
+        print(f"[shadow] 未能读到 {trade_date} 的市场档位（记 UNKNOWN）: {str(exc)[:120]}")
+        return "UNKNOWN"
+    regime = normalize_regime(row.get("benchmark_regime"))
+    if regime == "UNKNOWN":
+        print(f"[shadow] {trade_date} 无可用 benchmark_regime，档位记 UNKNOWN")
+    return regime
+
+
 def main() -> int:
     args = parse_args()
     config = build_config(args)
@@ -123,7 +144,7 @@ def main() -> int:
         detail = " ".join(f"{k}={v:.0f}" for k, v in pick.factor_ranks.items())
         print(f"{pick.rank:>3} {pick.code:12}{pick.score:>+9.2f}  {detail}")
 
-    rows = to_rows(picks, trade_date, config)
+    rows = to_rows(picks, trade_date, config, regime=_regime_for(trade_date))
     if args.dry_run:
         print(f"\n[shadow] dry-run：本应写入 {len(rows)} 行")
         return 0

--- a/tests/core/test_ic_shadow_score.py
+++ b/tests/core/test_ic_shadow_score.py
@@ -13,6 +13,8 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
 from core.ic_shadow_score import (
@@ -133,7 +135,7 @@ class TestObservationRows:
         from scripts.run_ic_shadow_pool import to_rows
 
         picks = [ShadowPick(code="600363.SH", score=-1.06, rank=1, factor_ranks={"ret60": 0.0})]
-        row = to_rows(picks, "2026-08-14", ShadowScoreConfig())[0]
+        row = to_rows(picks, "2026-08-14", ShadowScoreConfig(), regime="RISK_OFF")[0]
         assert row["ai_recommended"] is False
         assert row["selected_for_ai"] is False
         assert row["candidate_status"] == "shadow_observe"
@@ -141,7 +143,7 @@ class TestObservationRows:
     def test_source_and_channel_tagged(self):
         from scripts.run_ic_shadow_pool import to_rows
 
-        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
+        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig(), regime="RISK_OFF")[0]
         assert row["source"] == SHADOW_SOURCE
         assert row["channel"] == SHADOW_CHANNEL
         assert row["signal_type"] == SHADOW_SOURCE
@@ -149,7 +151,7 @@ class TestObservationRows:
     def test_code_stripped_of_suffix(self):
         from scripts.run_ic_shadow_pool import to_rows
 
-        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
+        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig(), regime="RISK_OFF")[0]
         assert row["code"] == "600363"
 
     def test_features_json_records_composition(self):
@@ -158,7 +160,7 @@ class TestObservationRows:
         from scripts.run_ic_shadow_pool import to_rows
 
         pick = ShadowPick("600363.SH", -1.06, 1, {"ret60": 0.0, "dry_vol_q250": 3.0})
-        payload = json.loads(to_rows([pick], "2026-08-14", ShadowScoreConfig())[0]["features_json"])
+        payload = json.loads(to_rows([pick], "2026-08-14", ShadowScoreConfig(), regime="RISK_OFF")[0]["features_json"])
         assert payload["ic_shadow_rank"] == 1
         assert payload["factor_percentiles"]["dry_vol_q250"] == pytest.approx(3.0)
 
@@ -166,7 +168,7 @@ class TestObservationRows:
         """便于事后区分不同权重版本写入的行。"""
         from scripts.run_ic_shadow_pool import to_rows
 
-        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig())[0]
+        row = to_rows([ShadowPick("600363.SH", -1.0, 1)], "2026-08-14", ShadowScoreConfig(), regime="RISK_OFF")[0]
         assert "ret60" in row["strategy_version"]
 
 
@@ -223,7 +225,7 @@ class TestRequiredColumns:
         from core.ic_shadow_score import to_rows
 
         picks = [ShadowPick("002121.SZ", -1.65, 1, {"ret60": 2.0, "dry_vol_q250": 1.0})]
-        return to_rows(picks, "2026-08-24", ShadowScoreConfig())[0]
+        return to_rows(picks, "2026-08-24", ShadowScoreConfig(), regime="CRASH")[0]
 
     def test_track_present_and_valid(self):
         """track 仅接受 Trend / Accum。影子池选低位缩量股，语义属吸筹。"""
@@ -239,3 +241,84 @@ class TestRequiredColumns:
         row = self._row()
         for key in ("market", "trade_date", "code", "signal_type"):
             assert row.get(key), key
+
+
+class TestRegimeColumn:
+    """影子行必须带上当天真实档位。
+
+    首批 110 行（2026-08-24..09-07，11 个交易日）全被标成 NEUTRAL：to_rows 当时
+    根本不产出 regime 列，落库吃了 DB 默认值。这 11 天真实档位是 RISK_OFF 8 天 /
+    BEAR_REBOUND 2 天 / CRASH 1 天，没有一天真的是 NEUTRAL，整片影子样本的分层
+    归因都建立在错标签上。其中 08-24..08-28 这 5 天表里只有影子行，没有同日其它
+    信号可交叉核对——这类错标只有靠断言才能发现。
+    """
+
+    def _row(self, regime: str) -> dict:
+        from core.ic_shadow_score import to_rows
+
+        picks = [ShadowPick("002121.SZ", -1.65, 1, {"ret60": 2.0})]
+        return to_rows(picks, "2026-08-24", ShadowScoreConfig(), regime=regime)[0]
+
+    def test_regime_column_present(self):
+        assert self._row("RISK_OFF")["regime"] == "RISK_OFF"
+
+    def test_regime_normalized_to_upper(self):
+        assert self._row("risk_off")["regime"] == "RISK_OFF"
+
+    def test_missing_regime_becomes_unknown_not_neutral(self):
+        """缺档位记 UNKNOWN。NEUTRAL 是真实档位，拿它兜底就把两种情形混成一列。"""
+        for blank in ("", "   ", None):
+            assert self._row(blank)["regime"] == "UNKNOWN"
+
+    def test_regime_is_required_keyword(self):
+        """不给默认值，否则新调用方会以静默默认值的形式重演这个缺陷。"""
+        import inspect
+
+        from core.ic_shadow_score import to_rows
+
+        param = inspect.signature(to_rows).parameters["regime"]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+        assert param.default is inspect.Parameter.empty
+
+
+class TestFunnelThreadsRegime:
+    """漏斗必须把 benchmark_context 的档位透传进影子行，而不是让它落到默认值。"""
+
+    def _run(self, benchmark_context) -> list[dict]:
+        from types import SimpleNamespace
+
+        import core.ic_shadow_score as shadow
+        import workflows.wyckoff_funnel as funnel
+
+        picks = [ShadowPick("002121.SZ", -1.65, 1, {"ret60": 2.0})]
+        orig_panels, orig_combine = shadow.percentiles_from_df_map, shadow.combine_scores
+        shadow.percentiles_from_df_map = lambda df_map, config: {"ret60": {"002121.SZ": 2.0}}
+        shadow.combine_scores = lambda panels, config: picks
+        try:
+            data = SimpleNamespace(
+                all_df_map={},
+                window=SimpleNamespace(end_trade_date=date(2026, 8, 24)),
+                benchmark_context=benchmark_context,
+            )
+            return funnel._build_ic_shadow_pool(data)
+        finally:
+            shadow.percentiles_from_df_map, shadow.combine_scores = orig_panels, orig_combine
+
+    def test_context_regime_reaches_the_row(self):
+        rows = self._run({"available": True, "regime": "RISK_OFF"})
+        assert rows and rows[0]["regime"] == "RISK_OFF"
+
+    def test_row_is_not_silently_neutral(self):
+        """这是原缺陷的形状：RISK_OFF 的日子写出 NEUTRAL。"""
+        rows = self._run({"available": True, "regime": "CRASH"})
+        assert rows and rows[0]["regime"] != "NEUTRAL"
+
+    def test_absent_context_records_unknown(self):
+        for ctx in (None, {}, {"available": False, "regime": "UNKNOWN"}):
+            rows = self._run(ctx)
+            assert rows and rows[0]["regime"] == "UNKNOWN", ctx
+
+    def test_unrecognized_regime_falls_to_unknown(self):
+        """normalize_regime 只认白名单，脏值不该原样落库。"""
+        rows = self._run({"available": True, "regime": "TOTALLY_MADE_UP"})
+        assert rows and rows[0]["regime"] == "UNKNOWN"

--- a/workflows/wyckoff_funnel.py
+++ b/workflows/wyckoff_funnel.py
@@ -943,6 +943,7 @@ def _build_ic_shadow_pool(data) -> list[dict]:
             percentiles_from_df_map,
             to_rows,
         )
+        from core.market_trade_mode import normalize_regime
 
         config = ShadowScoreConfig()
         panels = percentiles_from_df_map(data.all_df_map, config)
@@ -951,7 +952,10 @@ def _build_ic_shadow_pool(data) -> list[dict]:
             return []
         picks = combine_scores(panels, config)
         trade_date = data.window.end_trade_date.isoformat()
-        rows = to_rows(picks, trade_date, config)
+        # benchmark_context 自己在拿不到基准时就填 UNKNOWN，直接透传即可保留
+        # 「没拿到」与「确实中性」的区分，不要在这里折成 NEUTRAL。
+        regime = normalize_regime((data.benchmark_context or {}).get("regime"))
+        rows = to_rows(picks, trade_date, config, regime=regime)
         print(f"[shadow] {trade_date} 选出 {len(rows)} 只（{config.describe()}）")
         for pick in picks[:5]:
             detail = " ".join(f"{k}={v:.0f}" for k, v in pick.factor_ranks.items())


### PR DESCRIPTION
## 变更摘要

- `core/ic_shadow_score.py`：`to_rows` 产出 `regime` 列；`regime` 做成**必填**关键字参数，无默认值。缺档位写 `UNKNOWN`。
- `workflows/wyckoff_funnel.py`：`_build_ic_shadow_pool` 透传 `data.benchmark_context` 的档位（经 `normalize_regime`）。
- `scripts/run_ic_shadow_pool.py`：独立脚本手里没有 `benchmark_context`，改为按信号日查 `market_signal_daily.benchmark_regime`，查不到记 `UNKNOWN`。
- `tests/core/test_ic_shadow_score.py`：新增 8 个用例，其中 4 个直接跑 `_build_ic_shadow_pool` 断言落到行上的值。

## 为什么

`to_rows` 从来没产出 `regime` 列，落库时吃 DB 默认值。直连生产核对首批 110 行（2026-08-24..09-07，11 个交易日），**全部**标成 `NEUTRAL`，而这 11 天真实档位是：

| 真实档位 | 天数 | 日期 |
|---|---|---|
| RISK_OFF | 8 | 08-25、08-26、08-27、08-28、09-02、09-03、09-04、09-07 |
| BEAR_REBOUND | 2 | 08-31、09-01 |
| CRASH | 1 | 08-24 |

没有一天真的是 `NEUTRAL`。影子池的用途就是按档位分层看反向因子在什么市况下成立，标签整片错掉，这批样本的分层结论一条都不能用。

08-24..08-28 这 5 天表里只有影子行、没有同日其它信号可交叉核对，错标在库里是看不出来的。08-31 起同日就有 `BEAR_REBOUND`/`RISK_OFF` 的行躺在隔壁（188/195/139/139/136/143 行），说明这列本身完全能写这些值，只是没人给。

两个设计选择值得说明：

- **`regime` 必填、不给默认值。** 给默认值等于把这个失效模式原样留着——下一个调用方照样可以什么都不传，然后静默写出错标签。必填让新调用方在调用点就得回答这个问题。
- **缺档位写 `UNKNOWN` 而不是 `NEUTRAL`。** 代码库里 `signal_feedback` 的惯例是 `str(regime or "NEUTRAL")`，但 `NEUTRAL` 是一个真实档位，拿它兜底正是这次「错了两周没人发现」的原因：错值和真值同形。`benchmark_context` 自己在拿不到基准时就填 `UNKNOWN`，透传即可保留这个区分。

落库前用哨兵行验过 `signal_observations.regime` 收 `UNKNOWN`（写入即删，确认 0 残留）——`_build_ic_shadow_pool` 吞异常，被约束拒掉的写入会静默失败，不验就等于拿一个错值换一个空列。

## 验证

- 反证过测试有区分力：还原成改动前的形状（`regime` 变可选 + 不产出该列），恰好 8 个 regime 用例失败、其余 27 个仍通过。
- 回归测试直接跑 `_build_ic_shadow_pool` 断言落到行上的值，不是 grep 源码——原缺陷是少一个 key，这个文件里既有的 grep 型用例抓不到它。
- `ruff format --check` / `ruff check` 通过；`quality_gate.py --check-functions --check-no-sql` 0 violations。
- `pytest tests/ -q` → 4708 passed, 22 skipped。

## 存量数据

库里那 110 行仍是错的。真实档位已逐日核实（上表），回填语句我另外发你，不放脚本。
