### PR TITLE
fix(review): 风控信号空值有两种含义,复盘把「没查过」读成了「风控干净」

### DIFF
--- a/tests/workflows/test_review_list_replay.py
+++ b/tests/workflows/test_review_list_replay.py
@@ -292,7 +292,7 @@ def test_build_focus_lines_highlights_actionable_buckets():
     assert "日期间隔" in text
     assert "候选池已捕获" in text
     assert "结构强度不足" in text
-    assert "风控拦截优先复盘" in text
+    assert "带风控信号" in text
     assert "000003国农科技" in text
     assert "买点未确认" in text
     assert "题材共振不足" in text
@@ -445,6 +445,62 @@ def test_trigger_miss_focus_stops_proposing_lane_changes() -> None:
     assert "影子回放" in text
 
 
+def test_theme_miss_focus_discloses_co_occurring_exit_signals() -> None:
+    """题材档里同时带离场信号的票要摊出来,不能只报总数。
+
+    级联在 L3 之前不查离场信号,所以这个标签会把带 stop_loss 的票一起收进来。
+    2026-09-04 全市场这一档 1678 只里 1147 只(68.4%)带 stop_loss,对这三分之二
+    来说改题材映射动不了它们。只报总数会把改动引到不是约束点的那一层。
+    """
+    rows = [
+        {**_row("000005", "世纪星源", REVIEW_STAGE_THEME_MISS), "risk_signal": "stop_loss"},
+        {**_row("000006", "深振业A", REVIEW_STAGE_THEME_MISS), "risk_signal": ""},
+    ]
+    text = "\n".join(build_focus_lines(rows, today=date(2026, 9, 4), previous_trade_date=date(2026, 9, 3)))
+
+    assert "题材共振不足" in text
+    assert "1/2" in text
+    assert "000005世纪星源" in text
+    # 带风控信号的那部分不能被说成「改题材映射就能捞回来」
+    assert "题材层不是唯一约束" in text
+
+
+def test_theme_miss_focus_only_points_at_theme_layer_when_cohort_is_clean() -> None:
+    """全档都干净时才可以把改动指向题材层。"""
+    rows = [{**_row("000006", "深振业A", REVIEW_STAGE_THEME_MISS), "risk_signal": ""}]
+    text = "\n".join(build_focus_lines(rows, today=date(2026, 9, 4), previous_trade_date=date(2026, 9, 3)))
+
+    assert "题材映射" in text
+    assert "题材层不是唯一约束" not in text
+
+
+def test_risk_focus_does_not_claim_a_block_that_never_happened() -> None:
+    """没有买点可拦时,不能说「被硬拦截」。
+
+    2026-09-04 落到风控档的 147 只票 trigger_labels 全为空,这个标签只是级联顺序
+    的产物。而且生产里离场信号不是闸门:四路候选生产者只有正式威科夫那一路读它,
+    还是 -35 分的软扣分,车道/alpha/主线三路完全不读。
+    """
+    rows = [{**_row("000003", "国农科技", REVIEW_STAGE_RISK_BLOCK), "trigger_labels": []}]
+    text = "\n".join(build_focus_lines(rows, today=date(2026, 9, 4), previous_trade_date=date(2026, 9, 3)))
+
+    assert "硬拦截" not in text
+    assert "风控没拦下任何东西" in text
+
+
+def test_risk_focus_separates_rows_whose_trigger_actually_fired() -> None:
+    """买点已触发又带离场信号的那几只才真被扣了分,要和其余分开。"""
+    rows = [
+        {**_row("000003", "国农科技", REVIEW_STAGE_RISK_BLOCK), "trigger_labels": []},
+        {**_row("000008", "神州高铁", REVIEW_STAGE_RISK_BLOCK), "trigger_labels": ["SOS（量价点火）"]},
+    ]
+    text = "\n".join(build_focus_lines(rows, today=date(2026, 9, 4), previous_trade_date=date(2026, 9, 3)))
+
+    assert "其中 1 只买点已触发" in text
+    # 是否伤了胜率仍未检验,不能在这里下结论
+    assert "同动量对照" in text
+
+
 def test_focus_lines_open_with_the_result_selected_caveat() -> None:
     """报告一进「重点归因」就要说样本是按结果选的,否则每档只数会被当淘汰率读。"""
     lines = build_focus_lines(
@@ -573,6 +629,101 @@ def test_review_trace_records_as_run_stages_without_ohlcv(tmp_path):
     assert loaded["config_digest"] == payload["config_digest"]
     with pytest.raises(ValueError, match="date mismatch"):
         load_review_trace_artifact(path, date(2026, 5, 11))
+
+
+def test_review_trace_separates_unevaluated_risk_from_clean_risk() -> None:
+    """空的 risk_signal 有两种来源,trace 必须分得开。
+
+    离场信号只对 L2 通过池 + Markup + 战略旁路算过。2026-09-04 全部 1246 只
+    「只是结构强度不足」的票 stop_loss 都是 0,而隔壁查过的池子 68% 带 stop_loss。
+    这个反差是取值范围造成的,不是市场造成的:不记「查过谁」,复盘就会把「没查」
+    读成「风控干净」(memory one-field-two-meanings-corrupts-column)。
+    """
+    frame = pd.DataFrame(
+        {
+            "date": pd.bdate_range("2025-08-01", periods=220),
+            "close": [10.0] * 220,
+            "amount": [100_000_000.0] * 220,
+        }
+    )
+    inputs = SimpleNamespace(
+        cfg=FunnelConfig(),
+        window=SimpleNamespace(end_trade_date=date(2026, 9, 4)),
+        pool=SimpleNamespace(symbols=["000001", "000002"]),
+        ref_data=SimpleNamespace(
+            name_map={"000001": "已评估", "000002": "未评估"},
+            sector_map={"000001": "银行", "000002": "地产"},
+            market_cap_map={"000001": 100.0, "000002": 100.0},
+            financial_map={},
+        ),
+        all_df_map={"000001": frame, "000002": frame},
+        layers=SimpleNamespace(
+            l1_passed=["000001", "000002"],
+            l2_passed=["000001"],
+            l3_passed=[],
+            l2_channel_map={"000001": "点火破局"},
+            l2_rejections={"000002": "最接近趋势延续(缺口5.0%)"},
+        ),
+        candidates=SimpleNamespace(
+            candidate_entries=[],
+            exit_signals={},
+            exit_evaluated=["000001"],
+        ),
+    )
+    rows = build_review_trace(inputs, {}, {})["symbols"]
+
+    # 两只票 risk_signal 都是空,但只有一只是「查过、干净」
+    assert rows["000001"]["risk_signal"] == ""
+    assert rows["000002"]["risk_signal"] == ""
+    assert rows["000001"]["risk_evaluated"] is True
+    assert rows["000002"]["risk_evaluated"] is False
+
+
+def test_review_trace_leaves_risk_evaluated_unknown_without_the_field() -> None:
+    """回放路径自己拼 candidates 对象,缺 exit_evaluated 时要给 None 而不是 False。
+
+    给 False 等于断言「没查过」,会把老 trace 的缺失读成事实。
+    """
+    frame = pd.DataFrame(
+        {
+            "date": pd.bdate_range("2025-08-01", periods=220),
+            "close": [10.0] * 220,
+            "amount": [100_000_000.0] * 220,
+        }
+    )
+    inputs = SimpleNamespace(
+        cfg=FunnelConfig(),
+        window=SimpleNamespace(end_trade_date=date(2026, 9, 4)),
+        pool=SimpleNamespace(symbols=["000001"]),
+        ref_data=SimpleNamespace(
+            name_map={"000001": "平安银行"},
+            sector_map={"000001": "银行"},
+            market_cap_map={"000001": 100.0},
+            financial_map={},
+        ),
+        all_df_map={"000001": frame},
+        layers=SimpleNamespace(
+            l1_passed=["000001"],
+            l2_passed=["000001"],
+            l3_passed=["000001"],
+            l2_channel_map={},
+            l2_rejections={},
+        ),
+        candidates=SimpleNamespace(candidate_entries=[], exit_signals={}),
+    )
+    rows = build_review_trace(inputs, {}, {})["symbols"]
+
+    assert rows["000001"]["risk_evaluated"] is None
+
+
+def test_state_suffix_marks_unevaluated_risk_but_not_unknown() -> None:
+    """渲染侧只在显式 False 时标「未评估」,None 不标。"""
+    from workflows.review_report_render import _state_suffix
+
+    assert "风控=未评估" in _state_suffix({"risk_signal": "", "risk_evaluated": False})
+    assert "风控" not in _state_suffix({"risk_signal": "", "risk_evaluated": True})
+    assert "风控" not in _state_suffix({"risk_signal": "", "risk_evaluated": None})
+    assert "风控=stop_loss" in _state_suffix({"risk_signal": "stop_loss", "risk_evaluated": True})
 
 
 def test_review_trace_records_signal_day_momentum() -> None:

--- a/workflows/funnel_candidates.py
+++ b/workflows/funnel_candidates.py
@@ -49,6 +49,10 @@ class FunnelCandidateOutputs:
     markup_symbols: list[str]
     accum_stage_map: dict[str, str]
     exit_signals: dict[str, dict]
+    # 被送去算离场信号的票。exit_signals 只收有信号的那些,空 dict 项分不出
+    # 「查过、干净」和「根本没查」——L2 未过的票从来没进过这一层,复盘里
+    # 却和查过的干净票长得一样(memory one-field-two-meanings-corrupts-column)。
+    exit_evaluated: list[str]
     candidate_entries: list[dict]
     mainline_candidate_entries: list[dict]
     lane_candidate_entries: list[dict]
@@ -129,8 +133,9 @@ def build_candidate_outputs(
     markup_symbols = sorted(set(detect_markup_stage(layers.l3_passed, all_df_map, cfg)) | set(strategic.markup_symbols))
     accum_stage_map = detect_accum_stage(layers.l2_passed, all_df_map, cfg)
     accum_stage_map.update(strategic.stage_map)
+    exit_evaluated = sorted(set(layers.l2_passed + markup_symbols + strategic.pool))
     exit_signals = layer5_exit_signals(
-        sorted(set(layers.l2_passed + markup_symbols + strategic.pool)),
+        exit_evaluated,
         all_df_map,
         accum_stage_map,
         cfg,
@@ -172,6 +177,7 @@ def build_candidate_outputs(
         markup_symbols=markup_symbols,
         accum_stage_map=accum_stage_map,
         exit_signals=exit_signals,
+        exit_evaluated=exit_evaluated,
         candidate_entries=candidate_entries,
         mainline_candidate_entries=mainline_entries,
         lane_candidate_entries=lane_entries,

--- a/workflows/review_list_replay.py
+++ b/workflows/review_list_replay.py
@@ -314,6 +314,9 @@ def _build_replay_row(
         "l3_eligible": code in ctx.l3_set,
         "trigger_labels": list(decision.get("trigger_labels") or []),
         "risk_signal": str(decision.get("risk_signal") or ""),
+        # 老 trace 没有这个键,取不到就传 None,渲染侧只在显式 False 时标「未评估」,
+        # 不把历史 trace 的缺失读成「没查过」。
+        "risk_evaluated": decision.get("risk_evaluated"),
         "shadow_lane": str(decision.get("shadow_lane") or ""),
         "shadow_score": decision.get("shadow_score"),
         "shadow_reason": str(decision.get("shadow_reason") or ""),

--- a/workflows/review_report_render.py
+++ b/workflows/review_report_render.py
@@ -181,10 +181,26 @@ def _strength_miss_focus(rows: list[dict[str, Any]], total: int) -> list[str]:
 
 
 def _risk_focus(rows: list[dict[str, Any]]) -> list[str]:
+    """不再说「被硬拦截」。
+
+    生产里离场信号根本不是闸门:四路候选生产者只有正式威科夫那一路读 exit_signals
+    (core/wyckoff_engine.py:2349),而且是 -35 分的软扣分;车道/alpha/主线三路
+    完全不读。2026-09-04 落到这一档的 147 只票 trigger_labels 全为空——没有买点
+    可拦,这个标签只是级联顺序的产物(memory funnel-cascade-label-is-not-cause)。
+    同一天有 19 只带 stop_loss 的票照样进了候选池,其中 16 只走的是不读离场信号的车道。
+    """
     if not rows:
         return []
+    blocking = [row for row in rows if row.get("trigger_labels")]
+    if not blocking:
+        return [
+            f"- **带风控信号**：{short_code_list(rows)}。这一档买点本来就没触发，"
+            "所以风控没拦下任何东西，标签只反映级联顺序。"
+            "离场信号在生产里是正式威科夫那一路的软扣分，车道/alpha/主线三路不读它。"
+        ]
     return [
-        f"- **风控拦截优先复盘**：{short_code_list(rows)}。这些票被结构止损/派发信号硬拦截，适合单独检查止损是否对强修复过敏。"
+        f"- **带风控信号**：{short_code_list(rows)}。其中 {len(blocking)} 只买点已触发而带离场信号，"
+        "这几只才真被扣了分；要判断这个扣分是否伤了胜率，需按同动量对照比前向收益。"
     ]
 
 
@@ -205,9 +221,26 @@ def _trigger_miss_focus(rows: list[dict[str, Any]]) -> list[str]:
 
 
 def _theme_miss_focus(rows: list[dict[str, Any]]) -> list[str]:
+    """题材层不一定是这一档的约束点,得先把并发的离场信号摊出来。
+
+    级联在 L3 之前不查离场信号,所以「题材共振不足」这个标签会把同时带 stop_loss
+    的票一起收进来。2026-09-04 全市场这一档 1678 只,其中 1147 只(68.4%)带
+    stop_loss——对这三分之二来说,就算题材层放它过去,下一道也会扣分,改题材映射
+    动不了它们。只报总数会把改动引到不是约束点的那一层。
+    """
     if not rows:
         return []
-    return [f"- **题材共振不足**：{short_code_list(rows)}。优先检查题材映射、主线热度和板块强势车道覆盖。"]
+    risky = [row for row in rows if row.get("risk_signal")]
+    line = f"- **题材共振不足**：{short_code_list(rows)}。"
+    if risky:
+        line += (
+            f"注意其中 {len(risky)}/{len(rows)} 只同时带离场信号（{short_code_list(risky)}），"
+            "对这部分票题材层不是唯一约束，只改题材映射动不了它们；"
+            "先看剩下那些干净的票再决定要不要碰题材层。"
+        )
+    else:
+        line += "这一档都没带离场信号，可以检查题材映射、主线热度和板块强势车道覆盖。"
+    return [line]
 
 
 def _base_reject_focus(rows: list[dict[str, Any]]) -> list[str]:
@@ -240,6 +273,10 @@ def _state_suffix(row: dict[str, Any]) -> str:
         states.append(f"买点={'、'.join(str(x) for x in row['trigger_labels'])}")
     if row.get("risk_signal"):
         states.append(f"风控={row['risk_signal']}")
+    elif row.get("risk_evaluated") is False:
+        # 空的 risk_signal 有两种来源:查过没事,和从来没查。离场信号只对 L2 通过池
+        # 算,L2 未过的票落到这里恒为空,不标出来就会被读成「风控干净」。
+        states.append("风控=未评估")
     if row.get("tracked_previous_day"):
         status = "、".join(str(x) for x in row.get("candidate_statuses") or []) or "已跟踪"
         states.append(f"跟踪状态={status}")

--- a/workflows/review_trace.py
+++ b/workflows/review_trace.py
@@ -111,13 +111,21 @@ def _decision_rows(inputs: Any, triggers: dict) -> dict[str, dict[str, Any]]:
     entry_map = best_candidate_entry_map(candidates.candidate_entries)
     hit_map = _trigger_labels(triggers)
     blocked = _blocked_exit_map(candidates.exit_signals)
+    # 离场信号只对 L2 通过池 + Markup + 战略旁路算过,别的票 risk_signal 恒为空。
+    # 不把「查过谁」记下来,复盘就会把「没查」读成「干净」:2026-09-04 全部 1246
+    # 只结构强度不足的票 stop_loss 都是 0,而隔壁查过的池子 68% 带 stop_loss——
+    # 这个反差是取值范围造成的,不是市场造成的。
+    # 用 None 区分「字段缺失」和「查过 0 只」:`or []` 会把缺失也变成空集合,
+    # 于是每一行都被断言成「没查过」——把缺失读成事实,正是这个字段要治的病。
+    raw_evaluated = getattr(candidates, "exit_evaluated", None)
+    evaluated = None if raw_evaluated is None else {str(code) for code in raw_evaluated}
     # watch_score 落进 trace:pre_breakout 车道的排序键。缺了它影子车道只能给
     # 常数分,31 只同分就无法做「取前 N 只看超额」的效果检验。
     # 用 getattr:回放路径自己拼候选对象,不一定带这个字段,缺了就退回不可排序标签。
     score_map = {str(k): v for k, v in (getattr(candidates, "l3_score_map", None) or {}).items()}
     return {
         code: attach_shadow_signal(
-            _decision_row(code, inputs, l1_set, l2_set, l3_set, entry_map, hit_map, blocked, score_map),
+            _decision_row(code, inputs, l1_set, l2_set, l3_set, entry_map, hit_map, blocked, score_map, evaluated),
             near_l2_max_gap_pct=_SHADOW_NEAR_L2_MAX_GAP_PCT,
         )
         for code in inputs.pool.symbols
@@ -134,6 +142,7 @@ def _decision_row(
     hit_map: dict[str, list[str]],
     blocked: dict[str, dict],
     score_map: dict[str, Any] | None = None,
+    evaluated: set[str] | None = None,
 ) -> dict[str, Any]:
     name = str(inputs.ref_data.name_map.get(code, code)).strip() or code
     sector = str(inputs.ref_data.sector_map.get(code, "")).strip()
@@ -147,6 +156,7 @@ def _decision_row(
         "layer3_quality_score": _score_or_none((score_map or {}).get(code)),
         "trigger_labels": list(hit_map.get(code, [])),
         "risk_signal": str((blocked.get(code) or {}).get("signal") or ""),
+        "risk_evaluated": code in evaluated if evaluated is not None else None,
         **_market_state(code, inputs),
     }
     if code not in inputs.all_df_map:


### PR DESCRIPTION
## 问题

2026-09-07 的强势股复盘报告把改动指向了不是约束点的那一层。两处成因都在代码,不在市场。

### 一、离场信号只对 L2 通过池算过,空值分不出两种含义

`layer5_exit_signals` 的入参是 `l2_passed + markup + 战略旁路`([funnel_candidates.py:132](workflows/funnel_candidates.py#L132)),L2 未过的票从来没进过这一层,`risk_signal` 恒为空。2026-09-04 全市场逐格实测:

| 档位 | n | stop_loss |
|---|---|---|
| 未入候选池[结构强度不足] | 1246 | **0** |
| 未入候选池[题材共振不足] | 1678 | **1147 (68.4%)** |
| 候选池已捕获 | 130 | 19 |
| 风控拦截 | 147 | 147 |

隔壁查过的池子 68% 带 stop_loss,而这 1246 只一个都没有——这个反差是取值范围造成的,不是市场造成的。

空值当干净读还有下游后果:[review_shadow_lanes.py:46](core/review_shadow_lanes.py#L46) 一见 `risk_signal` 非空就不给影子车道。对 `near_l2`(L2 未过)这道过滤恒真,对 `rotation_setup`(L2 已过)是真过滤——两条车道筛选标准不同,却被当同侪比较。

### 二、两处归因措辞与生产行为不符

**「题材共振不足」** 原措辞:`优先检查题材映射、主线热度和板块强势车道覆盖`。级联在 L3 之前不查离场信号,所以这一档会把带 stop_loss 的票一起收进来。对那 1147 只(68.4%),就算题材层放它过去,下一道也会扣分,改题材映射动不了它们。

**「风控拦截」** 原措辞:`这些票被结构止损/派发信号硬拦截`。两处都错:

1. 落到这一档的 147 只票 `trigger_labels` **全为空**。没有买点可拦,这个标签只是级联顺序的产物(级联在 `blocked` 之前先判 `hit_map` 之外的各档)。
2. **离场信号在生产里不是闸门。** 四路候选生产者只有正式威科夫那一路读 `exit_signals`([wyckoff_engine.py:2349](core/wyckoff_engine.py#L2349)),而且是 −35 分的**软扣分**;车道 / alpha / 主线三路完全不读。同日 19 只带 stop_loss 的票照样进了候选池,按路径拆开:

| 入池路径 | 读 exit_signals | 带 stop_loss |
|---|---|---|
| trend_lane_pullback / main_force_entry / trend_breakout | 否(车道) | 13 |
| launchpad / volatile_pullback | 否(alpha) | 3 |
| lps / sos | 是(−35 软扣分) | 3 |

带 stop_loss 的候选 score 中位 96.46,干净的 95.93 —— 略高。−35 的扣分产生不了这个结果,因为 16/19 走的是不读它的路。

## 改动

- `FunnelCandidateOutputs` 加 `exit_evaluated`,记下被送去算离场信号的票
- trace 行加 `risk_evaluated` 三态;**字段缺失给 `None` 不给 `False`** —— 给 `False` 等于从缺失数据里断言「没查过」,正是这个字段要治的病(新增的判别性用例先抓到了我自己这一版的这个 bug)
- 渲染侧:`风控=未评估` 只在显式 `False` 时标;两处归因措辞改成摊出并发信号数,不再声称硬拦截

## 不改什么

这一版只动可观测性和措辞,**不动选股行为**。这道 −35 扣分是否伤了胜率还没过同动量对照,四路只有一路读它这个不对称也还没检验过该往哪边配平。先让报告不再指错层,再去做检验 —— 反过来会是在结果选样的证据上直接改选股。

## 验证

4715 passed / 22 skipped,ruff + format + `--check-no-sql` 全绿。新增 7 个行为用例。已在真实 09-04 trace 上跑过渲染,输出如上表所述。

🤖 Generated with [Claude Code](https://claude.com/claude-code)