### PR TITLE
fix(shadow-lane): 三条影子车道按不同标准筛风控,却在一张表里当同辈比

### DIFF
--- a/core/review_capture_schema.py
+++ b/core/review_capture_schema.py
@@ -51,7 +51,16 @@ COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("l3_eligible", "boolean not null default false", "前一日是否过题材共振"),
     ("is_candidate", "boolean not null default false", "前一日是否进入候选池"),
     ("trigger_labels", "text[]", "买点触发标签。只对候选池内的票有值——触发检测只跑最终候选集"),
-    ("risk_signal", "text", "风控信号名,如 stop_loss"),
+    ("risk_signal", "text", "风控信号名,如 stop_loss。空值有两种含义,必须配合下一列读"),
+    # 三态,可空,无 default。空的 risk_signal 是「查过、干净」还是「根本没查」,
+    # 只看那一列分不出来:离场信号只对 L2 通过池 + Markup + 战略旁路算过。
+    # 2026-09-04 全部 1246 只结构强度不足的票 risk_signal 都是空,而隔壁查过的
+    # 池子 68.4% 带 stop_loss——差别来自取值范围,不是市场。
+    (
+        "risk_evaluated",
+        "boolean",
+        "当日离场信号是否对这只票算过。null=trace 无此字段,不可当 false 用",
+    ),
     ("tracked_previous_day", "boolean not null default false", "前一日是否已在推荐跟踪表里"),
     ("ai_recommended_previous_day", "boolean not null default false", "前一日是否被 AI 推荐"),
     # 影子车道:与 review_shadow_lane_daily 同源判定,便于两张表对照。

--- a/core/review_shadow_lane_schema.py
+++ b/core/review_shadow_lane_schema.py
@@ -13,7 +13,7 @@
 REST 不支持 DDL、环境也无 psycopg2/asyncpg 与连接串,故 schema 以 Python 常量形式
 版本化,由 scripts/print_review_shadow_lane_ddl.py 打印后人工在 SQL Editor 执行一次。
 
-字段设计的两条约束:
+字段设计的三条约束:
 1. **动量必须同期落下来。** 效果检验要的是「同动量随机对照」(见 memory
    full-market-control-confounds-momentum / uniform-band-control-is-biased):
    不记录当日 RPS,事后就只能拿全市场当对照,把择时读成选股。rps_fast/rps_slow
@@ -21,6 +21,15 @@ REST 不支持 DDL、环境也无 psycopg2/asyncpg 与连接串,故 schema 以 P
 2. **score 可空 + ranked 显式。** rotation_setup 所在的题材共振层是集合成员
    判断,没有连续键;老 trace 也可能缺 watch_score。宁可存 null 并标
    ranked=false,也不要用常数占位——那正是 v1 让 31 只票同分、排不了序的原因。
+3. **risk_evaluated 必须落下来,否则三条车道不可比。**
+   `shadow_signal_from_decision` 见到非空 risk_signal 就不给车道,而离场信号只对
+   L2 通过池算过(workflows/funnel_candidates.py)。于是这道过滤:
+     - 对 near_l2(L2 未过)是**空转**——它的 risk_signal 恒为空,带 stop_loss 的
+       票照样进车道,只是没人知道;
+     - 对 rotation_setup / pre_breakout(L2 已过)是**真过滤**——带信号的被剔掉。
+   三条车道按不同标准筛完却当同辈比。表里不记这一位,这个混淆就只存在于某个人的
+   记忆里;记下来,跨车道比较至少能显式限定在可比的子集上
+   (rotation_setup vs pre_breakout 两条都是筛过的,可比)。
 """
 
 from __future__ import annotations
@@ -44,6 +53,13 @@ COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("l1_eligible", "boolean not null default false", "当日是否过基础准入"),
     ("l2_eligible", "boolean not null default false", "当日是否过结构强度"),
     ("l3_eligible", "boolean not null default false", "当日是否过题材共振"),
+    # 三态,可空。true=查过且干净,false=从没查过,null=老 trace 不带这个字段。
+    # 不给 default:填 false 会把「不知道」写成「没查过」,填 true 更糟。
+    (
+        "risk_evaluated",
+        "boolean",
+        "当日离场信号是否对这只票算过。null=老 trace 无此字段,不可当 false 用",
+    ),
     # 动量:同动量对照的必要条件。缺了它只能拿全市场比,那会把择时当选股。
     ("rps_fast", "numeric(10, 2)", "当日快线 RPS(默认 20 日),L1 闸门同源"),
     ("rps_slow", "numeric(10, 2)", "当日慢线 RPS(默认 120 日),L1 闸门同源"),

--- a/integrations/supabase_review_capture.py
+++ b/integrations/supabase_review_capture.py
@@ -66,6 +66,8 @@ def build_capture_rows(
                 "is_candidate": bool(raw.get("stage") == REVIEW_STAGE_CANDIDATE_HIT),
                 "trigger_labels": [str(x) for x in (raw.get("trigger_labels") or [])],
                 "risk_signal": _text(raw.get("risk_signal")) or None,
+                # 不要 bool():缺失会塌成 False,把「不知道」写成「确定没查过」。
+                "risk_evaluated": (None if raw.get("risk_evaluated") is None else bool(raw.get("risk_evaluated"))),
                 "tracked_previous_day": bool(raw.get("tracked_previous_day")),
                 "ai_recommended_previous_day": bool(raw.get("ai_recommended_previous_day")),
                 "shadow_lane": _text(raw.get("shadow_lane")) or None,

--- a/integrations/supabase_review_shadow_lane.py
+++ b/integrations/supabase_review_shadow_lane.py
@@ -65,6 +65,9 @@ def _lane_row(trade_date: str, code: str, row: dict[str, Any], signal: Any) -> d
         "l1_eligible": bool(row.get("l1_eligible")),
         "l2_eligible": bool(row.get("l2_eligible")),
         "l3_eligible": bool(row.get("l3_eligible")),
+        # 不要 bool():缺失会塌成 False,把「不知道有没有查过」写成「确定没查过」。
+        # 这一位决定三条车道是否可比,详见 core/review_shadow_lane_schema.py 约束 3。
+        "risk_evaluated": _tribool(row.get("risk_evaluated")),
         "rps_fast": _float(row.get("rps_fast")),
         "rps_slow": _float(row.get("rps_slow")),
         "close": _float(row.get("close")),
@@ -104,6 +107,15 @@ def save_review_shadow_lane_rows(rows: list[dict[str, Any]]) -> int:
     else:
         logger.info("[shadow-lane] %s written=%d", TABLE_REVIEW_SHADOW_LANE_DAILY, written)
     return written
+
+
+def _tribool(value: Any) -> bool | None:
+    """None 透传,其余转 bool。
+
+    存在三种状态:查过且干净 / 从没查过 / 老 trace 不带这个字段。第三种必须留 None——
+    用 bool() 会把它变成 False,于是历史行全被断言成「没查过」,把缺失读成事实。
+    """
+    return None if value is None else bool(value)
 
 
 def _float(value: Any) -> float | None:

--- a/tests/integrations/test_supabase_review_shadow_lane.py
+++ b/tests/integrations/test_supabase_review_shadow_lane.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from core.funnel_taxonomy import (
     REVIEW_STAGE_CANDIDATE_HIT,
+    REVIEW_STAGE_STRENGTH_MISS,
     REVIEW_STAGE_THEME_MISS,
     REVIEW_STAGE_TRIGGER_MISS,
 )
@@ -88,6 +89,54 @@ def test_unranked_lane_stores_null_score_not_a_constant() -> None:
 def test_missing_trade_date_yields_no_rows() -> None:
     symbols = {"000001": {"stage": REVIEW_STAGE_TRIGGER_MISS, "l3_eligible": True}}
     assert build_lane_rows({"symbols": symbols}) == []
+
+
+def test_row_records_whether_exit_signals_were_evaluated() -> None:
+    """三条车道按不同标准筛,表里必须留下这一位,否则跨车道比较是混淆的。
+
+    near_l2 来自 L2 未过的票,离场信号从没对它们算过,风控过滤对这条车道空转;
+    rotation_setup / pre_breakout 来自 L2 已过的票,过滤是真的。不记 risk_evaluated,
+    这个差别就只存在于某个人的记忆里。
+    """
+    payload = _trace(
+        {
+            "000001": {
+                "stage": REVIEW_STAGE_STRENGTH_MISS,
+                "reason": "缺口 4.0%",
+                "risk_evaluated": False,
+            },
+            "000002": {
+                "stage": REVIEW_STAGE_TRIGGER_MISS,
+                "l3_eligible": True,
+                "layer3_quality_score": 0.5,
+                "risk_evaluated": True,
+            },
+        }
+    )
+
+    rows = {row["ts_code"]: row for row in build_lane_rows(payload)}
+
+    assert rows["000001"]["lane"] == "near_l2"
+    assert rows["000001"]["risk_evaluated"] is False
+    assert rows["000002"]["lane"] == "pre_breakout"
+    assert rows["000002"]["risk_evaluated"] is True
+
+
+def test_old_trace_without_the_field_stores_null_not_false() -> None:
+    """缺失必须留 null。写成 false 就是把「不知道」断言成「确定没查过」。"""
+    payload = _trace({"000001": {"stage": REVIEW_STAGE_TRIGGER_MISS, "l3_eligible": True}})
+
+    assert build_lane_rows(payload)[0]["risk_evaluated"] is None
+
+
+def test_risk_evaluated_column_is_nullable_without_default() -> None:
+    """加了 default 就没有第三态:老行会被填成某个确定值,混淆重新藏回去。"""
+    from core.review_shadow_lane_schema import COLUMNS
+
+    ddl_type = next(spec for name, spec, _ in COLUMNS if name == "risk_evaluated")
+    assert ddl_type == "boolean"
+    assert "not null" not in ddl_type
+    assert "default" not in ddl_type
 
 
 def test_payload_keys_match_schema_columns() -> None:

--- a/tests/workflows/test_review_shadow_backtest.py
+++ b/tests/workflows/test_review_shadow_backtest.py
@@ -166,3 +166,34 @@ def test_score_band_marks_rotation_setup_unrankable() -> None:
     # 不能说成「样本不足」:那会让人以为攒够数据就能分档,而这一层压根没有键。
     assert "无连续排序键" in band["reason"]
     assert "样本不足" not in band["reason"]
+
+
+def test_report_warns_when_screened_and_unscreened_lanes_share_one_table() -> None:
+    """三条车道并排放在一张表里,但风控筛选强度不同,不提示就会被读成车道优劣。
+
+    near_l2 来自 L2 未过的票,离场信号从没对它们算过,风控过滤在那条车道空转;
+    rotation_setup / pre_breakout 来自 L2 已过的票,带信号的被剔掉了。
+    """
+    from workflows.review_shadow_backtest import _markdown_report
+
+    text = _markdown_report({"by_lane": {"near_l2": {"count": 3}, "pre_breakout": {"count": 5}}})
+
+    assert "跨车道比较注意" in text
+    assert "空转" in text
+
+
+def test_report_omits_the_caveat_when_only_screened_lanes_are_present() -> None:
+    """只有同类车道时没有可比性问题,不要挂一句用不上的警告冲淡真警告。"""
+    from workflows.review_shadow_backtest import _markdown_report
+
+    text = _markdown_report({"by_lane": {"rotation_setup": {"count": 4}, "pre_breakout": {"count": 6}}})
+
+    assert "跨车道比较注意" not in text
+
+
+def test_report_omits_the_caveat_when_only_the_unscreened_lane_is_present() -> None:
+    from workflows.review_shadow_backtest import _markdown_report
+
+    text = _markdown_report({"by_lane": {"near_l2": {"count": 4}}})
+
+    assert "跨车道比较注意" not in text

--- a/workflows/review_shadow_backtest.py
+++ b/workflows/review_shadow_backtest.py
@@ -377,9 +377,42 @@ def _markdown_report(report: dict[str, Any]) -> str:
             f"| {shadow_lane_label(lane)} | {summary.get('count', 0)} | {_metric(t1, 'mean')} | "
             f"{_metric(t3, 'mean')} | {_metric(t5, 'mean')} | {_metric(t5, 'win_rate', percent=False)} |"
         )
+    lines.extend(_risk_screen_caveat_lines(report))
     lines.extend(_score_band_lines(report))
     lines.extend(["", *control_verdict_lines(report.get("momentum_control") or {})])
     return "\n".join(lines) + "\n"
+
+
+#: 这两条车道的行来自 L2 已通过的票,离场信号对它们算过,带信号的被
+#: shadow_signal_from_decision 剔掉了 —— 风控过滤对它们是真的。
+_RISK_SCREENED_LANES = frozenset({"rotation_setup", "pre_breakout"})
+#: 这条车道来自 L2 未过的票。离场信号只对 L2 通过池 + Markup + 战略旁路算
+#: (workflows/funnel_candidates.py),所以它们的 risk_signal 恒为空,同一道
+#: 过滤在这里是空转:带 stop_loss 的票照样进车道,只是没人知道。
+_RISK_UNSCREENED_LANES = frozenset({"near_l2"})
+
+
+def _risk_screen_caveat_lines(report: dict[str, Any]) -> list[str]:
+    """上表把三条车道并排放,但它们不是按同一套标准筛出来的。
+
+    不写这一句,读者会把「接近结构通道跑赢爆发前夜」读成车道优劣,而两组的
+    风控筛选强度本来就不同 —— 一组剔掉了带离场信号的票,另一组没剔(也没法剔:
+    那些票从没被算过)。只在两类车道同时出现在表里时才提示,单类时没有可比性问题。
+    """
+    lanes = set(report.get("by_lane") or {})
+    screened = sorted(lanes & _RISK_SCREENED_LANES)
+    unscreened = sorted(lanes & _RISK_UNSCREENED_LANES)
+    if not screened or not unscreened:
+        return []
+    screened_text = "、".join(shadow_lane_label(x) for x in screened)
+    unscreened_text = "、".join(shadow_lane_label(x) for x in unscreened)
+    return [
+        "",
+        f"> 跨车道比较注意：{screened_text}剔除了带离场信号的票，而{unscreened_text}没有剔除"
+        "——这层的票 L2 没过，离场信号从没对它们算过，同一道过滤在那里是空转。"
+        "两组的风控筛选强度不同，行与行之间的差不能直接读成车道优劣；"
+        f"要作同辈比较，只在{screened_text}之间比。",
+    ]
 
 
 def _score_band_lines(report: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## 问题

`shadow_signal_from_decision` 见到非空 `risk_signal` 就不给车道（`core/review_shadow_lanes.py:46`），而离场信号只对 `l2_passed + markup + strategic.pool` 算过（`workflows/funnel_candidates.py`）。同一道过滤因此对三条车道强度不同：

| 车道 | 来源 | risk_signal | 这道过滤 |
|---|---|---|---|
| `near_l2` | L2 未过（结构强度不足） | 恒为空 | **空转** —— 带 stop_loss 的票照样进车道 |
| `rotation_setup` | L2 已过（题材共振不足） | 真实 | 真过滤 —— 带信号的被剔掉 |
| `pre_breakout` | L2 已过（买点未确认） | 真实 | 真过滤 |

`review_shadow_lane_daily` 里没有记录这一位，而 `_markdown_report` 把三条车道并排放在一张表里。「接近结构通道跑赢爆发前夜」可以纯粹是筛选强度差，读者无从分辨，事后查表也查不出来。

2026-09-04 的量级：全市场 1246 只「结构强度不足」的票 `risk_signal` 全为空（从没算过），而隔壁算过的池子 68.4% 带 `stop_loss`。`near_l2` 就是从前者里选的。

## 改动

1. `review_shadow_lane_daily` 与 `review_capture_daily` 各加 `risk_evaluated`：**三态可空、不给 default**。填 `false` 会把「不知道」写成「确定没查过」，正是 #396 要治的病。
2. 写入侧 `_tribool` 透传 `None`，不用 `bool()`。
3. 回放报告在筛过/没筛过两类车道同时出现时挂一句可比性提示；只出现一类时不挂 —— 用不上的警告会冲淡真警告。

渲染实样：

> 跨车道比较注意：爆发前夜、轮动待确认剔除了带离场信号的票，而接近结构通道没有剔除——这层的票 L2 没过，离场信号从没对它们算过，同一道过滤在那里是空转。两组的风控筛选强度不同，行与行之间的差不能直接读成车道优劣；要作同辈比较，只在爆发前夜、轮动待确认之间比。

## 不做什么

不动车道准入规则。要让三条真正可比只有两条路：给全市场算离场信号（生产行为变更，且同一函数喂着候选评分），或把另两条的风控过滤去掉（重置历史样本）。两条都得先过同动量对照，现在改就是从结果选出的样本反推改动。

## 需要人工执行的 DDL

`review_shadow_lane_daily` 已有 5342 行，需 ALTER；`review_capture_daily` 尚未建表，新列随 `CREATE` 落地，无需额外动作。语句在 PR 讨论里给出。

## 验证

- 全套 `4721 passed, 22 skipped`
- `ruff check` / `ruff format --check` 7 个文件全过
- `quality_gate.py --check-no-sql` → `OK: 无 .sql 文件`
- 新增 6 个测试：三态透传、缺失存 null、列不可有 default、提示语在两类车道同现时出现、单类时两个方向都不出现