### PR TITLE
fix(review-trace): L3 降级日的反事实通过集算完就丢,白扔 6 天同日对照

### DIFF
--- a/integrations/supabase_review_shadow_lane.py
+++ b/integrations/supabase_review_shadow_lane.py
@@ -4,9 +4,11 @@
 重跑同一天覆盖而非累积。建表语句由
 `python scripts/print_review_shadow_lane_ddl.py` 输出。
 
-为什么必须落库:trace 只活在 `daily-job-artifacts-*` 里(retention-days: 30,与日志
-同包),而且**补不回来**——回测引擎不重放漏斗分层,没有任何路径能从快照倒推出
-「某日某票卡在哪一层、watch_score 多少」。每过一天没留存就永久少一天样本。
+为什么必须落库:trace 只活在 `daily-job-artifacts-*` 里(retention-days: 90,与日志
+同包),过期即永久少一天样本。「补不回来」只针对**快照**——回测引擎不重放漏斗
+分层,没有任何路径能从快照倒推出「某日某票卡在哪一层」;但只要 artifact 还在
+retention 窗口内,`build_lane_rows(payload)` 就能直接吃 trace 补历史。别把这句
+读成「已有 artifact 也补不了」而放弃回填。
 
 行来源只有 trace 一处:车道判定走 core.review_shadow_lanes,不在这里重新分类,
 否则报告与落库两套口径会漂移(见 memory two-gates-must-share-one-source)。

--- a/tests/workflows/test_review_list_replay.py
+++ b/tests/workflows/test_review_list_replay.py
@@ -631,6 +631,79 @@ def test_review_trace_records_as_run_stages_without_ohlcv(tmp_path):
         load_review_trace_artifact(path, date(2026, 5, 11))
 
 
+def _l3_strict_inputs() -> SimpleNamespace:
+    """L2 过 3 只、L3 按降级口径全放行的最小夹具。"""
+    frame = pd.DataFrame(
+        {
+            "date": pd.bdate_range("2025-08-01", periods=220),
+            "close": [10.0] * 220,
+            "amount": [100_000_000.0] * 220,
+        }
+    )
+    codes = ["000001", "000002", "000003"]
+    return SimpleNamespace(
+        cfg=FunnelConfig(),
+        window=SimpleNamespace(end_trade_date=date(2026, 8, 31)),
+        pool=SimpleNamespace(symbols=codes),
+        ref_data=SimpleNamespace(
+            name_map={code: code for code in codes},
+            sector_map={"000001": "银行", "000002": "地产", "000003": "券商"},
+            market_cap_map={code: 100.0 for code in codes},
+            financial_map={},
+        ),
+        all_df_map={code: frame for code in codes},
+        layers=SimpleNamespace(
+            l1_passed=list(codes),
+            l2_passed=list(codes),
+            # 降级日:l3_passed 等于 l2_passed,这正是那 6 天 L3/L2=100.0% 的成因。
+            l3_passed=list(codes),
+            l2_channel_map={code: "点火破局" for code in codes},
+            l2_rejections={},
+        ),
+        candidates=SimpleNamespace(candidate_entries=[], exit_signals={}),
+    )
+
+
+def test_review_trace_keeps_l3_demotion_counterfactual() -> None:
+    """修复期 L3 降级日,trace 要留下「照常过滤会留下谁」。
+
+    BEAR_REBOUND 那 6 天 Layer 3 从硬过滤降级成 +8 加分项(funnel_layers 里显式
+    分支 + 日志),l3_passed 等于 l2_passed。降级时算出的严格口径通过集此前只存在
+    benchmark_context 里、没人落盘——22 份产物里 l3_passed_normal 零命中,等于每个
+    降级日都白算了一次同日同水温的「L3 开 vs 关」对照。
+    """
+    inputs = _l3_strict_inputs()
+    metrics = {"benchmark_context": {"regime": "BEAR_REBOUND", "l3_passed_normal": ["000001"]}}
+
+    rows = build_review_trace(inputs, {}, metrics)["symbols"]
+
+    # 降级口径:三只都算过 L3。
+    assert [rows[code]["l3_eligible"] for code in ("000001", "000002", "000003")] == [True, True, True]
+    # 严格口径:只有 000001 会留下。这一对差值才是可用的同日对照。
+    assert rows["000001"]["l3_eligible_strict"] is True
+    assert rows["000002"]["l3_eligible_strict"] is False
+    assert rows["000003"]["l3_eligible_strict"] is False
+
+
+def test_review_trace_l3_strict_is_none_on_normal_days() -> None:
+    """非降级日必须是 None,不能是 False。
+
+    `or set()` 兜底会把「今天 L3 就是硬过滤」和「今天降级了且严格口径一只不留」
+    压成同一个空集合,于是 20 个正常日全被读成「L3 本来会全灭」——把缺失读成事实。
+    """
+    inputs = _l3_strict_inputs()
+
+    rows = build_review_trace(inputs, {}, {"benchmark_context": {"regime": "RISK_OFF"}})["symbols"]
+    assert all(rows[code]["l3_eligible_strict"] is None for code in ("000001", "000002", "000003"))
+
+    # metrics 整个缺失(回放路径传 {})也要退成 None,不能抛。
+    assert build_review_trace(inputs, {}, {})["symbols"]["000001"]["l3_eligible_strict"] is None
+
+    # 降级日而严格口径真的一只不留:是 False,与上面的 None 必须分得开。
+    empty = build_review_trace(inputs, {}, {"benchmark_context": {"l3_passed_normal": []}})["symbols"]
+    assert all(empty[code]["l3_eligible_strict"] is False for code in ("000001", "000002", "000003"))
+
+
 def test_review_trace_separates_unevaluated_risk_from_clean_risk() -> None:
     """空的 risk_signal 有两种来源,trace 必须分得开。
 

--- a/workflows/review_list_replay.py
+++ b/workflows/review_list_replay.py
@@ -312,6 +312,9 @@ def _build_replay_row(
         "execution_reason": str(execution.get("reason", "") or ""),
         "l2_eligible": code in ctx.l2_set,
         "l3_eligible": code in ctx.l3_set,
+        # 直接透传,不从 ctx.l3_set 反推:降级日 l3_set 已等于 l2_set,
+        # 反推只会得到 l3_eligible 的副本,把反事实抹平。老 trace 缺这个键取到 None。
+        "l3_eligible_strict": decision.get("l3_eligible_strict"),
         "trigger_labels": list(decision.get("trigger_labels") or []),
         "risk_signal": str(decision.get("risk_signal") or ""),
         # 老 trace 没有这个键,取不到就传 None,渲染侧只在显式 False 时标「未评估」,

--- a/workflows/review_trace.py
+++ b/workflows/review_trace.py
@@ -59,7 +59,7 @@ def dump_review_trace_artifact(payload: dict[str, Any], output_dir: str) -> Path
 def build_review_trace(inputs: Any, triggers: dict, metrics: dict) -> dict[str, Any]:
     layers = inputs.layers
     candidates = inputs.candidates
-    symbols = _decision_rows(inputs, triggers)
+    symbols = _decision_rows(inputs, triggers, metrics)
     config_payload = asdict(inputs.cfg)
     return {
         "schema_version": REVIEW_TRACE_SCHEMA,
@@ -102,12 +102,18 @@ def load_review_trace_artifact(path: str | Path, expected_trade_date: date | str
     return payload
 
 
-def _decision_rows(inputs: Any, triggers: dict) -> dict[str, dict[str, Any]]:
+def _decision_rows(inputs: Any, triggers: dict, metrics: dict | None = None) -> dict[str, dict[str, Any]]:
     layers = inputs.layers
     candidates = inputs.candidates
     l1_set = set(layers.l1_passed)
     l2_set = set(layers.l2_passed)
     l3_set = set(layers.l3_passed)
+    # 修复期(BEAR_REBOUND/PANIC_REPAIR*)Layer 3 从硬过滤降级为 +8 加分项,
+    # l3_passed 会等于 l2_passed——那 6 天 L3/L2 恰好 100.0%,不是 bug 是设计。
+    # 降级时 funnel_layers 把「照常过滤会留下谁」存进 benchmark_context,
+    # 但此前没人落盘:每个降级日都白算了一次同日同水温的「L3 开 vs 关」对照。
+    # 落成逐行三态,原地就能分组比前向收益,不必再去反推分数断层。
+    l3_normal_set = _l3_normal_set(metrics)
     entry_map = best_candidate_entry_map(candidates.candidate_entries)
     hit_map = _trigger_labels(triggers)
     blocked = _blocked_exit_map(candidates.exit_signals)
@@ -125,7 +131,19 @@ def _decision_rows(inputs: Any, triggers: dict) -> dict[str, dict[str, Any]]:
     score_map = {str(k): v for k, v in (getattr(candidates, "l3_score_map", None) or {}).items()}
     return {
         code: attach_shadow_signal(
-            _decision_row(code, inputs, l1_set, l2_set, l3_set, entry_map, hit_map, blocked, score_map, evaluated),
+            _decision_row(
+                code,
+                inputs,
+                l1_set,
+                l2_set,
+                l3_set,
+                entry_map,
+                hit_map,
+                blocked,
+                score_map,
+                evaluated,
+                l3_normal_set,
+            ),
             near_l2_max_gap_pct=_SHADOW_NEAR_L2_MAX_GAP_PCT,
         )
         for code in inputs.pool.symbols
@@ -143,6 +161,7 @@ def _decision_row(
     blocked: dict[str, dict],
     score_map: dict[str, Any] | None = None,
     evaluated: set[str] | None = None,
+    l3_normal_set: set[str] | None = None,
 ) -> dict[str, Any]:
     name = str(inputs.ref_data.name_map.get(code, code)).strip() or code
     sector = str(inputs.ref_data.sector_map.get(code, "")).strip()
@@ -152,6 +171,9 @@ def _decision_row(
         "l1_eligible": code in l1_set,
         "l2_eligible": code in l2_set,
         "l3_eligible": code in l3_set,
+        # None=当天 L3 按硬过滤跑,l3_eligible 本身就是严格口径;
+        # True/False=当天 L3 被降级,这一位是「照常过滤会不会留下它」的反事实。
+        "l3_eligible_strict": code in l3_normal_set if l3_normal_set is not None else None,
         "l2_channel": str(inputs.layers.l2_channel_map.get(code, "")),
         "layer3_quality_score": _score_or_none((score_map or {}).get(code)),
         "trigger_labels": list(hit_map.get(code, [])),
@@ -346,6 +368,20 @@ def _market_context(metrics: dict[str, Any]) -> dict[str, Any]:
         "rps_fast_min": _float(tuned.get("rps_fast_min")),
         "rps_slow_min": _float(tuned.get("rps_slow_min")),
     }
+
+
+def _l3_normal_set(metrics: dict | None) -> set[str] | None:
+    """降级日 Layer 3 的严格口径通过集;非降级日返回 None。
+
+    `None` 与 `set()` 必须区分:前者是「今天 L3 就是硬过滤,别去比」,后者是
+    「今天降级了,而且严格口径一只都不留」。用 `or set()` 兜底会把前者也变成
+    空集合,于是 20 个正常日全被读成「L3 本来会全灭」——把缺失读成事实。
+    """
+    context = (metrics or {}).get("benchmark_context") or {}
+    raw = context.get("l3_passed_normal")
+    if raw is None:
+        return None
+    return {str(code) for code in raw}
 
 
 def _digest(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## 摘要

查「L3/L2 恰好 100.0%」时先误判成缺陷,查到底是**有意设计**:修复期
(`BEAR_REBOUND`/`PANIC_REPAIR*`)Layer 3 从硬过滤降级为 +8 加分项,
`workflows/funnel_layers.py:257` 显式分支 + 日志,加分实现在
`funnel_render_context.py:456-461`。22 天产物交叉核对:6 个 100.0% 的日子
全是 `BEAR_REBOUND`,6 个 `BEAR_REBOUND` 日全是 100.0%,完美分离;另外 20 天
(RISK_OFF 16 / CRASH 4)通过率 16.6%~41.4%。那 6 天的收益也早就量过了
(`core/market_trade_mode.py:187`:超额 −0.04pct、为正日恰好 50%),多进来的
3~4 倍候选没有 alpha。**不需要修。**

## 问题

降级时 `funnel_layers` 把「照常过滤会留下谁」存进
`benchmark_context["l3_passed_normal"]`,但没有任何路径把它落盘——22 份线上产物
里这个键**零命中**。每个降级日都算出了一次同日、同水温、同 L2 池的
「L3 开 vs 关」对照,然后原地丢掉。

这是漏斗里唯一不花额外样本就能拿到的 L3 效果对照,而 trace 天数正是所有漏斗
评估的约束项。

## 改动

逐行落 `l3_eligible_strict` 三态:

| 值 | 含义 |
|---|---|
| `None` | 当天 L3 按硬过滤跑,`l3_eligible` 本身就是严格口径 |
| `True`/`False` | 当天降级,这一位是严格口径的反事实 |

三态而非布尔:`or set()` 兜底会把「今天没降级」和「今天降级且严格口径一只不留」
压成同一个空集合,于是 20 个正常日全被读成「L3 本来会全灭」——把缺失读成事实,
正是这个字段要治的病。同 `risk_evaluated` 的处理方式。

回放侧**直接透传**,不从 `ctx.l3_set` 反推:降级日 `l3_set` 已等于 `l2_set`,
反推只会得到 `l3_eligible` 的副本,把反事实抹平。老 trace 缺这个键取到 `None`。

`schema_version` 仍为 `v1`——新增可选字段向后兼容,两处落库都用显式列白名单,
不会漏进表。

顺带修 `supabase_review_shadow_lane` 文档两处失效说法:retention 是 **90** 不是 30
(`wyckoff_funnel.yml:190` 有原因注释);「补不回来」只针对**快照**,artifact 还在
窗口内时 `build_lane_rows(payload)` 能直接吃 trace 补历史,别把这句读成
「已有 artifact 也补不了」而放弃回填。

## 验证

- 新增 2 个用例。其中 `None`/`False` 那条**对 `or set()` 退化有判别力**:临时改成
  兜底写法即失败,改回即通过,已实测(避免写出恒过的回归用例)。
- 另跑通 `_run_sector_layer` → `benchmark_context` → `_l3_normal_set` 全链:
  `BEAR_REBOUND` 写键且读出、`RISK_OFF` 不写键且读出 `None`。
- 71 个相关用例全过;`ruff check` / `ruff format --check` / `quality_gate --check-no-sql` 干净。

## 生效范围

只影响往后的产物——**不能回填历史**,因为 `l3_passed_normal` 从来没落过盘。
下一个 `BEAR_REBOUND` 日起自动积累真对照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
