### PR TITLE
feat(gate-alpha): L3 硬过滤那道闸的判别力，读 trace 真实放行结果

### DIFF
--- a/.github/workflows/gate_alpha_eval.yml
+++ b/.github/workflows/gate_alpha_eval.yml
@@ -6,6 +6,10 @@ name: Gate Alpha Eval
 #   止损各偏离档超额 -0.40 / -0.42 / -0.22 / +0.05，前三档为负说明止损触发后确实继续跑输。
 # 两条都未落到参数改动：题材层增益小于单次往返成本 0.202%；止损仅最陈旧档轻微为正。
 # 每周重跑的意义在于让这两个结论跨越更多行情段后再判，而不是靠单段拍板。
+#
+# 第三节（L3 硬过滤）量的是**生产那道闸**：两侧成员直接读 trace 的 l3_eligible，不像
+# 题材层那样用「行业动量 topN」当代理。它依赖 wyckoff_funnel 的 artifact，取不到就整节
+# 跳过，题材层与止损层照跑——artifact 有 90 天保留期，这一节的窗口只会短不会错。
 on:
   schedule:
     # UTC 周六 02:40 = 北京时间周六 10:40，紧随 regime 与卖出归因之后。
@@ -13,8 +17,11 @@ on:
   workflow_dispatch:
     inputs:
       horizon:
-        description: "前瞻交易日数"
+        description: "前瞻交易日数(题材层与止损层用;L3 那一节自带持有期网格)"
         default: "5"
+      max_artifacts:
+        description: "回溯多少次漏斗运行取 trace"
+        default: "40"
 
 concurrency:
   group: gate-alpha-${{ github.ref }}
@@ -22,6 +29,8 @@ concurrency:
 
 permissions:
   contents: read
+  # 下载 wyckoff_funnel 的 artifact 取 review trace,L3 那一节要用。
+  actions: read
 
 jobs:
   run:
@@ -48,9 +57,50 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
+      - name: Collect production review traces
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IN_MAX_ARTIFACTS: ${{ github.event.inputs.max_artifacts || '40' }}
+          TRACE_DIR: ${{ github.workspace }}/gate-alpha-traces
+        run: |
+          set -euo pipefail
+          mkdir -p "$TRACE_DIR"
+          listing="$RUNNER_TEMP/funnel-runs.txt"
+          # 按 workflow 直接列 run(一次调用,实测 2.3s)。不要改成遍历
+          # `actions/artifacts?per_page=100`——仓库里近 6000 份 artifact,--paginate 要走
+          # 60 页、实测 50s。也不要按 conclusion 过滤:漏斗 failure 的 run 因为
+          # if: always() 照样上传,里面的 trace 是完整的,失败多发生在 trace 落盘之后。
+          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/wyckoff_funnel.yml/runs?branch=${GITHUB_REF_NAME}&per_page=${IN_MAX_ARTIFACTS}" \
+            --jq '.workflow_runs[].id' \
+            > "$listing"
+
+          scanned=0
+          while read -r run_id; do
+            test -n "$run_id" || continue
+            scanned=$((scanned + 1))
+            # 每次 run 解到自己的子目录,**不要**平铺 cp 到一处。同一交易日可能有多份
+            # trace(漏斗当天重跑),实测 2026-08-24 三份里 L3 分别是 732/732/449——
+            # 同一个 config_digest,数却不一样。平铺 `cp -n` 保留哪一份取决于 find 的
+            # 顺序,同一批证据能跑出两个数。这里全留着,由 latest_trace_per_date 按
+            # generated_at 定夺。
+            if ! gh run download "$run_id" --dir "$TRACE_DIR/${run_id}" --pattern 'daily-job-artifacts-*' >/dev/null 2>&1; then
+              rm -rf "$TRACE_DIR/${run_id}"
+              continue
+            fi
+          done < "$listing"
+
+          files="$(find "$TRACE_DIR" -type f -name 'review_trace_*.json.gz' | wc -l | tr -d ' ')"
+          echo "[gate-alpha] 扫描 ${scanned} 次漏斗运行,收集到 ${files} 份 trace(含同日重跑)"
+          echo "TRACE_DIR=${TRACE_DIR}" >> "$GITHUB_ENV"
+
       - name: Evaluate gate alpha
         run: |
-          python scripts/evaluate_gate_alpha.py --horizon "${{ github.event.inputs.horizon || '5' }}"
+          # trace 取不到就不传 --trace-dir,脚本跳过 L3 那一节继续跑题材层与止损层。
+          # 那一节是增量,不该让它的缺失拖挂整个任务。
+          python scripts/evaluate_gate_alpha.py \
+            --horizon "${{ github.event.inputs.horizon || '5' }}" \
+            --trace-dir "${TRACE_DIR:-}"
 
       - name: Upload evidence
         uses: actions/upload-artifact@v7

--- a/core/funnel_effect_panels.py
+++ b/core/funnel_effect_panels.py
@@ -25,24 +25,38 @@ from core.funnel_effect_eval import Panels
 DEFAULT_MIN_AMOUNT_WAN = 8000.0
 
 
+def normalize_market_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    """把两种来源的行情表规整成 code/ds/open/close/amt_wan。
+
+    兼容快照的 date/symbol/amount(元) 与 tushare 的 trade_date/ts_code/amount(千元)。
+    两者 amount 差 1000 倍，换算只写在这里一处：写第二遍就会错第二遍，而错了不报错，
+    只是流动性池悄悄大一千倍或小一千倍。内存里已有的行情表（比如按交易日批量取回来的）
+    直接调这个，不必先落盘再 ``load_market_frame`` 读回来。
+    """
+    out = frame.copy()
+    if "symbol" in out.columns:
+        out["code"] = out.symbol.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
+        out["ds"] = pd.to_datetime(out.date).dt.strftime("%Y-%m-%d")
+        out["amt_wan"] = pd.to_numeric(out.amount, errors="coerce") / 1e4
+    else:
+        out["code"] = out.ts_code.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
+        out["ds"] = pd.to_datetime(out.trade_date.astype(str), format="%Y%m%d").dt.strftime("%Y-%m-%d")
+        out["amt_wan"] = pd.to_numeric(out.amount, errors="coerce") / 10.0
+    for col in ("open", "close"):
+        out[col] = pd.to_numeric(out[col], errors="coerce")
+    return out.dropna(subset=["open", "close"]).sort_values(["code", "ds"])
+
+
 def load_market_frame(path: str | Path) -> pd.DataFrame:
     """兼容两种列名：快照的 date/symbol/amount(元)，与 tushare 的 trade_date/ts_code/amount(千元)。"""
     text = str(path)
     compression = "gzip" if text.endswith(".gz") else None
     head = pd.read_csv(text, nrows=1, compression=compression)
     if "symbol" in head.columns:
-        frame = pd.read_csv(text, usecols=["date", "open", "close", "amount", "symbol"], compression=compression)
-        frame["code"] = frame.symbol.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
-        frame["ds"] = pd.to_datetime(frame.date).dt.strftime("%Y-%m-%d")
-        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 1e4
+        cols = ["date", "open", "close", "amount", "symbol"]
     else:
-        frame = pd.read_csv(text, usecols=["ts_code", "trade_date", "open", "close", "amount"], compression=compression)
-        frame["code"] = frame.ts_code.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
-        frame["ds"] = pd.to_datetime(frame.trade_date.astype(str), format="%Y%m%d").dt.strftime("%Y-%m-%d")
-        frame["amt_wan"] = pd.to_numeric(frame.amount, errors="coerce") / 10.0
-    for col in ("open", "close"):
-        frame[col] = pd.to_numeric(frame[col], errors="coerce")
-    return frame.dropna(subset=["open", "close"]).sort_values(["code", "ds"])
+        cols = ["ts_code", "trade_date", "open", "close", "amount"]
+    return normalize_market_frame(pd.read_csv(text, usecols=cols, compression=compression))
 
 
 def load_benchmark_prices(path: str | Path) -> tuple[dict[str, float], dict[str, float]]:

--- a/core/gate_alpha_eval.py
+++ b/core/gate_alpha_eval.py
@@ -84,6 +84,11 @@ STALE_BANDS: tuple[tuple[float, float, str], ...] = (
 MIN_DAYS = 5
 MIN_GROUP = 3
 
+# 持有期网格。单一持有期的读数是切片不是结论：跨持有期同向才说明标签本身含信息，
+# 只在某一格显著更可能是窗口挑出来的。代价要一并报——可评估日 = trace 天数 − h，
+# 所以 h 越大天数越少、离 funnel_effect_eval.MIN_DAYS 越远。
+TRACE_HORIZONS = (1, 2, 3, 5, 10)
+
 
 @dataclass
 class GateStat:
@@ -140,15 +145,110 @@ def _round(value: float | None, digits: int = 4) -> float | None:
     return None if value is None else round(float(value), digits)
 
 
+def latest_trace_per_date(payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """同一交易日多份 trace 时，只留 ``generated_at`` 最新的一份。
+
+    同日重复是常态：一天可能跑过多次（重跑、补跑），每次都上传一份同名 artifact。实测
+    2026-08-24 有三份，L2 都是 1810/1812 但 L3 是 732、732、449——config_digest 相同，
+    差在取数快照。工作流按 ``cp -n`` 平铺到一个目录，留下哪一份取决于 ``find`` 的顺序，
+    于是同一份证据两次跑出两个数。这里显式按 ``generated_at`` 取最新，读数才可复现。
+    """
+    best: dict[str, dict[str, Any]] = {}
+    for payload in payloads:
+        ds = str(payload.get("trade_date") or "")
+        if not ds:
+            continue
+        current = best.get(ds)
+        if current is None or str(payload.get("generated_at") or "") > str(current.get("generated_at") or ""):
+            best[ds] = payload
+    return [best[ds] for ds in sorted(best)]
+
+
+def split_l3_hard_filter_days(
+    payloads: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """按「当天 L3 是不是硬过滤」把 trace 分成两堆，返回 (硬过滤日, 降级日)。
+
+    判定用 **L2 与 L3 成员集合是否相等**，不用水温白名单：降级发生时
+    ``workflows/funnel_layers.py`` 直接令 ``l3_passed = l2_passed``，两个集合逐一相等，
+    这是降级留在 trace 里的确定痕迹。按水温名单反推会漏——实测 2026-08-07/08-10/08-12
+    三天 ``market_context.regime`` 是空字符串（盘前 A50 缺数据导致 UNKNOWN），但它们确实
+    走了降级；而同样空水温的 2026-08-11 是硬过滤日（L2=866 / L3=199）。空水温本身不决定
+    任何事，集合相等才决定。
+
+    不用 ``l3_eligible_strict``：那一位要到它上线之后的 trace 才有，历史 trace 全是 None。
+    """
+    hard: dict[str, dict[str, Any]] = {}
+    demoted: dict[str, dict[str, Any]] = {}
+    for payload in latest_trace_per_date(payloads):
+        symbols = payload.get("symbols") or {}
+        if not isinstance(symbols, dict) or not symbols:
+            continue
+        l2 = {str(code) for code, row in symbols.items() if (row or {}).get("l2_eligible")}
+        l3 = {str(code) for code, row in symbols.items() if (row or {}).get("l3_eligible")}
+        if not l2 or not l3:
+            continue
+        row = {
+            "regime": str((payload.get("market_context") or {}).get("regime") or ""),
+            "l2": sorted(l2),
+            "l3": sorted(l3),
+        }
+        (demoted if l2 == l3 else hard)[str(payload["trade_date"])] = row
+    return hard, demoted
+
+
+@dataclass
+class L3GateStat:
+    """L3 硬过滤那道闸的判别力，一个持有期一行。
+
+    与 ``GateStat`` 的题材层区别在量的是**哪道闸**：题材层用「行业动量 topN」当代理，
+    ``core/gate_alpha_eval`` 的文档开头已写明那不是生产那道闸；这里的两侧成员直接读
+    trace 的 ``l3_eligible``，是生产四路取或（含 ``len(filtered) < 3`` 兜底放行）的真实
+    结果。两侧都已过 L2，唯一差别就是 L3，与 ``resolve_layer`` 的 ``l4_vs_rest`` 同构。
+
+    待测组取**被 L3 拒掉**的那一侧：问的是「把这道硬过滤拆掉会不会更好」，被拒的那批
+    正是拆掉后会进来的票。于是 ``observed_pct`` 为正 = 拆掉更好 = 这道闸在反向筛。
+    """
+
+    horizon: int
+    days: int
+    avg_pairs: float
+    regimes: dict[str, int] = field(default_factory=dict)
+    swap: dict[str, SwapTest] | None = None
+
+    @property
+    def verdict(self) -> str:
+        if self.swap is None or "stock_win" not in self.swap:
+            return "对照未跑出结果：尚未可知"
+        win = self.swap["stock_win"]
+        ret = self.swap.get("gross_return")
+        tail = "" if ret is None else f"；收益栏 {ret.observed_pct:+.3f}pct（双侧 p={ret.p_two_sided:.3f}）"
+        return f"被拒 vs 留下（动量配平）→ {win.verdict}{tail}"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "horizon_days": self.horizon,
+            "days": self.days,
+            "avg_pairs": _round(self.avg_pairs, 2),
+            "regimes": dict(sorted(self.regimes.items())),
+            "swap": None if not self.swap else {col: test.as_dict() for col, test in self.swap.items()},
+            "verdict": self.verdict,
+        }
+
+
 @dataclass
 class GateReport:
     theme: list[GateStat] = field(default_factory=list)
     stop_loss: list[GateStat] = field(default_factory=list)
+    l3_gate: list[L3GateStat] = field(default_factory=list)
+    l3_gate_note: str = ""
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "theme_resonance": [stat.as_dict() for stat in self.theme],
             "stop_loss_staleness": [stat.as_dict() for stat in self.stop_loss],
+            "l3_hard_filter": [stat.as_dict() for stat in self.l3_gate],
+            "l3_hard_filter_note": self.l3_gate_note,
             "production": {
                 "top_n_sectors": PROD_TOP_N_SECTORS,
                 "trailing_drawdown_pct": PROD_TRAILING_DRAWDOWN_PCT,
@@ -194,6 +294,50 @@ def summarize(
     )
 
 
+def summarize_l3_gate(
+    horizon: int,
+    hard_days: dict[str, dict[str, Any]],
+    swap: dict[str, SwapTest] | None,
+) -> L3GateStat:
+    """把一个持有期的 L3 互换否证结果收成一行。
+
+    ``days`` / ``avg_pairs`` 取自 ``SwapTest`` 自己报的数，不用 ``len(hard_days)``：
+    ``swap_falsification`` 会丢掉配对数不足 ``MIN_HITS_PER_DAY`` 的日子，也丢掉前瞻窗口
+    落在行情尾部之外的日子（可评估日 = trace 天数 − horizon），两个数天生不等。
+
+    ``regimes`` 统的是**入选那批硬过滤日**的水温分布，不是最终参与检验的那批——后者
+    ``SwapTest`` 没有回传日期清单。两个口径差在被丢掉的尾部几天，读的时候按上限看。
+    """
+    win = (swap or {}).get("stock_win")
+    regimes: dict[str, int] = {}
+    for row in hard_days.values():
+        key = str(row.get("regime") or "") or "(空)"
+        regimes[key] = regimes.get(key, 0) + 1
+    return L3GateStat(
+        horizon=horizon,
+        days=0 if win is None else int(win.days),
+        avg_pairs=0.0 if win is None else float(win.avg_pairs),
+        regimes=regimes,
+        swap=swap,
+    )
+
+
+def l3_window_note(hard_days: dict[str, dict[str, Any]], demoted_days: dict[str, dict[str, Any]]) -> str:
+    """描述这次 L3 检验站在什么窗口上。窗口不写清楚，读数就没有意义。"""
+    if not hard_days:
+        return "没有可用的硬过滤日：这一层没有读数。"
+    dates = sorted(hard_days)
+    regimes: dict[str, int] = {}
+    for row in hard_days.values():
+        key = str(row.get("regime") or "") or "(空)"
+        regimes[key] = regimes.get(key, 0) + 1
+    composition = "、".join(f"{name} {count}" for name, count in sorted(regimes.items(), key=lambda kv: -kv[1]))
+    return (
+        f"硬过滤日 {len(hard_days)} 天（{dates[0]}..{dates[-1]}），水温构成：{composition}；"
+        f"另有 {len(demoted_days)} 天 L3 被降级（l3_passed = l2_passed，成员集合逐一相等）已排除。"
+    )
+
+
 def band_of(deviation_pct: float) -> str | None:
     """参考价偏离幅度归档。负偏离（参考价低于现价）不属于陈旧问题，返回 None。"""
     if deviation_pct < 0:
@@ -220,6 +364,8 @@ def render(report: GateReport) -> str:
     ]
     for stat in report.stop_loss:
         lines.append(_row(stat))
+    if report.l3_gate:
+        lines += _l3_section(report)
     lines += [
         "",
         "**读法**　差值一栏是**裸日均差，两侧动量没配平，只作描述**：题材层的「热门」按定义就是成分股"
@@ -234,6 +380,46 @@ def render(report: GateReport) -> str:
         "互换否证的 p 值偏乐观——持有窗口逐日重叠、日间观测不独立，而置换零分布按独立处理。",
     ]
     return "\n".join(lines)
+
+
+def _l3_section(report: GateReport) -> list[str]:
+    """L3 硬过滤那道闸，按持有期成网格出。
+
+    单看一格没有意义：跨持有期同向才说明标签含信息。天数一栏必须显示——每一格的天数
+    都不一样（可评估日 = trace 天数 − h），拿天数多的格子和天数少的格子比大小，比到的
+    是日期构成不是持有期。
+    """
+    lines = [
+        "",
+        f"**L3 硬过滤（生产口径，读 trace 的 l3_eligible）**　{report.l3_gate_note}",
+        "",
+        "| 持有期 | 可评估日 | 日均配对 | 胜率差 pct | p（双侧） | 收益差 pct | p（双侧） | 判定 |",
+        "| --- | --: | --: | --: | --: | --: | --: | --- |",
+    ]
+    for stat in report.l3_gate:
+        win = (stat.swap or {}).get("stock_win")
+        ret = (stat.swap or {}).get("gross_return")
+        lines.append(
+            f"| T+{stat.horizon} | {stat.days} | {stat.avg_pairs:.0f} | "
+            f"{'—' if win is None else f'{win.observed_pct:+.3f}'} | "
+            f"{'—' if win is None else f'{win.p_two_sided:.3f}'} | "
+            f"{'—' if ret is None else f'{ret.observed_pct:+.3f}'} | "
+            f"{'—' if ret is None else f'{ret.p_two_sided:.3f}'} | "
+            f"{'样本不足' if win is None else win.verdict} |"
+        )
+    lines += [
+        "",
+        "**这一栏怎么读**　两侧都已过 L2，唯一差别是 L3，与 `resolve_layer` 的 `l4_vs_rest` 同构。"
+        "待测组是**被 L3 拒掉**的那批（拆掉这道闸就会进来的票），所以**为正 = 拆掉更好 = 这道闸在反向筛**。"
+        "与上面题材层那两张表不同：题材层用「行业动量 topN」当代理，本模块开头已写明那不是生产那道闸；"
+        "这一栏读的是 trace 里的真实放行结果（候选内复合百分位中位数 + 四路取或 + `len(filtered) < 3` 兜底）。",
+        "- 跨持有期只看**符号是否同向**。各格天数不同，数值大小不可横向相减——天数多的格子必然"
+        "偏向窗口里较早那批日子，把日期构成读成「持有越久效应越大」是常见的错。",
+        "- 每格天数都要与 `funnel_effect_eval.MIN_DAYS` 比：不够就是「尚未可知」，**不是「没通过」**。",
+        "- 水温构成决定这条读数能外推到哪。若窗口里几乎只有 RISK_OFF/CRASH，那它只是一条熊市窗口的"
+        "暂时读数，不能当作改 L3 的依据。",
+    ]
+    return lines
 
 
 def _signed(value: float | None) -> str:

--- a/integrations/supabase_review_shadow_lane.py
+++ b/integrations/supabase_review_shadow_lane.py
@@ -4,9 +4,11 @@
 重跑同一天覆盖而非累积。建表语句由
 `python scripts/print_review_shadow_lane_ddl.py` 输出。
 
-为什么必须落库:trace 只活在 `daily-job-artifacts-*` 里(retention-days: 30,与日志
-同包),而且**补不回来**——回测引擎不重放漏斗分层,没有任何路径能从快照倒推出
-「某日某票卡在哪一层、watch_score 多少」。每过一天没留存就永久少一天样本。
+为什么必须落库:trace 只活在 `daily-job-artifacts-*` 里(retention-days: 90,与日志
+同包),过期即永久少一天样本。「补不回来」只针对**快照**——回测引擎不重放漏斗
+分层,没有任何路径能从快照倒推出「某日某票卡在哪一层」;但只要 artifact 还在
+retention 窗口内,`build_lane_rows(payload)` 就能直接吃 trace 补历史。别把这句
+读成「已有 artifact 也补不了」而放弃回填。
 
 行来源只有 trace 一处:车道判定走 core.review_shadow_lanes,不在这里重新分类,
 否则报告与落库两套口径会漂移(见 memory two-gates-must-share-one-source)。

--- a/scripts/evaluate_gate_alpha.py
+++ b/scripts/evaluate_gate_alpha.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import json
 import os
 from collections.abc import Callable
@@ -38,6 +39,7 @@ from core.funnel_effect_eval import (
     match_by_momentum,
     swap_falsification,
 )
+from core.funnel_effect_panels import build_panels, normalize_market_frame
 from core.gate_alpha_eval import (
     MIN_GROUP,
     PROD_RECENT_HIGH_WINDOW,
@@ -45,10 +47,14 @@ from core.gate_alpha_eval import (
     PROD_TRAILING_DRAWDOWN_PCT,
     STALE_BANDS,
     TOP_N_GRID,
+    TRACE_HORIZONS,
     GateReport,
     band_of,
+    l3_window_note,
     render,
+    split_l3_hard_filter_days,
     summarize,
+    summarize_l3_gate,
 )
 
 WARMUP_BARS = 60
@@ -65,6 +71,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="跳过逐对互换否证，只出裸差值（判定里会明写不是结论）",
     )
+    parser.add_argument(
+        "--trace-dir",
+        default="",
+        help="review_trace_*.json.gz 所在目录（递归找）。给了才跑 L3 硬过滤那一节；不给就跳过",
+    )
+    parser.add_argument(
+        "--trace-horizons",
+        default=",".join(str(h) for h in TRACE_HORIZONS),
+        help="L3 那一节的持有期网格，逗号分隔",
+    )
     return parser.parse_args()
 
 
@@ -73,6 +89,9 @@ def load_market(start: str) -> pd.DataFrame:
 
     ``open`` 是对照要用的：互换否证按 T+1 开盘买入、T+1+H 收盘卖出，与
     ``core/funnel_effect_eval`` 同口径。裸差值那部分仍用收盘→收盘，两者不混在一栏里。
+
+    ``amount`` 只有 L3 那一节用：它要建生产同款面板（流动性池 + 20 日动量），缺成交额
+    ``build_panels`` 的流动性池会是空的，而空池不报错——只会让筛选悄悄失效。
     """
     from integrations.fetch_a_share_csv import cached_trade_dates
     from integrations.tushare_client import get_pro
@@ -85,7 +104,7 @@ def load_market(start: str) -> pd.DataFrame:
     frames = []
     for day in days:
         try:
-            frame = pro.daily(trade_date=day.replace("-", ""), fields="ts_code,trade_date,open,high,close")
+            frame = pro.daily(trade_date=day.replace("-", ""), fields="ts_code,trade_date,open,high,close,amount")
             if frame is not None and not frame.empty:
                 frames.append(frame)
         except Exception as exc:  # noqa: BLE001 - 单日失败不应中断整体检验
@@ -244,6 +263,91 @@ def _stop_control(members: list[dict[str, Any]], panels: Panels, horizon: int, b
     return swap_falsification(days, panels) or None
 
 
+def load_trace_payloads(trace_dir: str) -> list[dict[str, Any]]:
+    """递归读 review_trace_*.json.gz。目录不存在或没有文件返回空列表，不抛。
+
+    递归是必需的：工作流把每天的 artifact 各解一个子目录，平铺（``cp -n``）会因为同名
+    覆盖丢掉重跑那份，而留下哪一份取决于 ``find`` 的顺序。这里全都读进来，再由
+    ``latest_trace_per_date`` 按 ``generated_at`` 定夺。
+    """
+    root = Path(trace_dir)
+    if not root.exists():
+        print(f"[gate] trace 目录不存在: {root}")
+        return []
+    payloads: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("review_trace_*.json.gz")):
+        try:
+            with gzip.open(path, "rt", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except Exception as exc:  # noqa: BLE001 - 单份坏文件不该拖挂整体
+            print(f"[gate] {path.name} 读取失败: {str(exc)[:60]}")
+            continue
+        if isinstance(payload, dict) and payload.get("trade_date") and isinstance(payload.get("symbols"), dict):
+            payloads.append(payload)
+    print(f"[gate] trace {len(payloads)} 份")
+    return payloads
+
+
+def build_l3_days(
+    hard_days: dict[str, dict[str, Any]],
+    panels: Panels,
+    horizon: int,
+) -> list[SwapDay]:
+    """把硬过滤日变成配好对的 SwapDay。待测=被 L3 拒的 L2 票，对照=L3 留下的票。
+
+    两侧先与「流动性池 ∩ 有 20 日动量」取交集，和生产漏斗同一把尺子——不取交集会把
+    动量缺失的票塞进配对，``match_by_momentum`` 只能按缺省值处理它们。
+    """
+    days: list[SwapDay] = []
+    for ds in sorted(hard_days):
+        window = panels.window(ds, horizon)
+        if window is None:
+            continue
+        usable = panels.liquid.get(ds, set()) & set(panels.mom20.get(ds, {}))
+        kept = set(hard_days[ds]["l3"]) & usable
+        rejected = (set(hard_days[ds]["l2"]) - set(hard_days[ds]["l3"])) & usable
+        if len(kept) < MIN_GROUP or len(rejected) < MIN_GROUP:
+            continue
+        pairs = _pairs_oriented(sorted(rejected), sorted(kept), panels.mom20[ds])
+        if pairs:
+            days.append(SwapDay(date=ds, buy_ds=window[0], sell_ds=window[1], pairs=pairs))
+    return days
+
+
+def attach_l3_gate(
+    report: GateReport,
+    market: pd.DataFrame,
+    trace_dir: str,
+    horizons: tuple[int, ...],
+) -> None:
+    """在报告上挂 L3 硬过滤那一节。任何一步取不到数就跳过，不抛——这一节是增量。"""
+    payloads = load_trace_payloads(trace_dir)
+    if not payloads:
+        report.l3_gate_note = "没有可用 trace：这一层没有读数（不是没通过）。"
+        return
+    hard_days, demoted_days = split_l3_hard_filter_days(payloads)
+    report.l3_gate_note = l3_window_note(hard_days, demoted_days)
+    print(f"[gate] L3 硬过滤日 {len(hard_days)} / 降级日 {len(demoted_days)}")
+    if not hard_days:
+        return
+    if "amount" not in market.columns:
+        report.l3_gate_note += "　**行情缺 amount 列，建不出流动性池，这一节跳过**。"
+        print("[gate] 行情缺 amount 列，L3 那一节跳过")
+        return
+    panels = build_panels(normalize_market_frame(market))
+    # 空池会让每一天都被跳过，最后判定读成「尚未可知」——与「数据确实不够」同形。
+    # 生产漏斗必然有流动性池，这里量到空池只可能是取数或单位换算坏了，必须出声。
+    if not any(panels.liquid.values()):
+        report.l3_gate_note += "　**流动性池为空（检查 amount 单位换算），这一节跳过**。"
+        print("[gate] 流动性池为空，L3 那一节跳过")
+        return
+    for horizon in horizons:
+        days = build_l3_days(hard_days, panels, horizon)
+        swap = swap_falsification(days, panels) or None
+        report.l3_gate.append(summarize_l3_gate(horizon, hard_days, swap))
+        print(f"[gate] L3 T+{horizon}: 可评估日 {len(days)}")
+
+
 def _collect_theme(
     frame: pd.DataFrame,
     sector_map: dict[str, str],
@@ -331,6 +435,8 @@ def main() -> int:
     market = load_market(args.start)
     print(f"[gate] 行情 {len(market):,} 行 / {market.ts_code.nunique()} 只")
     report = build_report(market, sector_map, max(int(args.horizon), 1), with_control=not args.no_control)
+    if args.trace_dir:
+        attach_l3_gate(report, market, args.trace_dir, _parse_horizons(args.trace_horizons))
     payload = report.as_dict()
     payload["horizon_days"] = int(args.horizon)
     payload["control_ran"] = not args.no_control
@@ -344,6 +450,11 @@ def main() -> int:
     if not args.no_notify:
         _notify(text, int(args.horizon))
     return 0
+
+
+def _parse_horizons(raw: str) -> tuple[int, ...]:
+    out = sorted({int(part) for part in str(raw).split(",") if part.strip().isdigit() and int(part) >= 1})
+    return tuple(out) or TRACE_HORIZONS
 
 
 def _notify(markdown: str, horizon: int) -> None:

--- a/tests/core/test_gate_alpha_eval.py
+++ b/tests/core/test_gate_alpha_eval.py
@@ -16,8 +16,12 @@ from core.gate_alpha_eval import (
     GateReport,
     GateStat,
     band_of,
+    l3_window_note,
+    latest_trace_per_date,
     render,
+    split_l3_hard_filter_days,
     summarize,
+    summarize_l3_gate,
 )
 
 
@@ -205,6 +209,179 @@ class TestRender:
     def test_p_value_optimism_is_disclosed(self):
         """持有期重叠 → 观测不独立,而置换零分布当它们独立,p 偏乐观,必须写出来。"""
         assert "偏乐观" in render(self._report(-0.59, [-0.4] * 4))
+
+
+def _trace(ds: str, l2: list[str], l3: list[str], *, regime: str = "RISK_OFF", generated_at: str = "") -> dict:
+    symbols = {code: {"l2_eligible": True, "l3_eligible": code in set(l3)} for code in sorted(set(l2) | set(l3))}
+    return {
+        "trade_date": ds,
+        "generated_at": generated_at or f"{ds}T09:00:00",
+        "market_context": {"regime": regime},
+        "symbols": symbols,
+    }
+
+
+class TestLatestTracePerDate:
+    """同日多份 trace 必须按 generated_at 定夺,否则同一份证据两次跑出两个数。"""
+
+    def test_keeps_latest_generated_at(self):
+        early = _trace("2026-08-24", ["1", "2", "3"], ["1"], generated_at="2026-08-24T12:44:00")
+        late = _trace("2026-08-24", ["1", "2", "3"], ["1", "2"], generated_at="2026-08-24T23:24:00")
+        kept = latest_trace_per_date([early, late])
+        assert len(kept) == 1
+        assert kept[0]["generated_at"] == "2026-08-24T23:24:00"
+
+    def test_order_of_input_does_not_matter(self):
+        """实测就是靠 find 的顺序决定留哪一份——顺序反过来结果必须不变。"""
+        early = _trace("2026-08-24", ["1", "2", "3"], ["1"], generated_at="2026-08-24T12:44:00")
+        late = _trace("2026-08-24", ["1", "2", "3"], ["1", "2"], generated_at="2026-08-24T23:24:00")
+        assert latest_trace_per_date([late, early]) == latest_trace_per_date([early, late])
+
+    def test_returns_dates_sorted(self):
+        out = latest_trace_per_date([_trace("2026-08-25", ["1"], ["1"]), _trace("2026-08-11", ["1"], ["1"])])
+        assert [row["trade_date"] for row in out] == ["2026-08-11", "2026-08-25"]
+
+    def test_drops_payload_without_trade_date(self):
+        assert latest_trace_per_date([{"symbols": {"1": {}}}]) == []
+
+
+class TestSplitL3HardFilterDays:
+    def test_equal_sets_are_demoted(self):
+        """降级时 l3_passed = l2_passed,两个集合逐一相等——这是 trace 里的确定痕迹。"""
+        hard, demoted = split_l3_hard_filter_days([_trace("2026-08-17", ["1", "2", "3"], ["1", "2", "3"])])
+        assert hard == {}
+        assert "2026-08-17" in demoted
+
+    def test_strict_subset_is_hard_filter(self):
+        hard, demoted = split_l3_hard_filter_days([_trace("2026-08-11", ["1", "2", "3"], ["1"])])
+        assert demoted == {}
+        assert hard["2026-08-11"]["l2"] == ["1", "2", "3"]
+        assert hard["2026-08-11"]["l3"] == ["1"]
+
+    def test_blank_regime_does_not_decide(self):
+        """实测 08-11 水温为空但是硬过滤日,08-12 水温为空却是降级日。只有集合相等能决定。"""
+        payloads = [
+            _trace("2026-08-11", ["1", "2", "3"], ["1"], regime=""),
+            _trace("2026-08-12", ["1", "2", "3"], ["1", "2", "3"], regime=""),
+        ]
+        hard, demoted = split_l3_hard_filter_days(payloads)
+        assert list(hard) == ["2026-08-11"]
+        assert list(demoted) == ["2026-08-12"]
+
+    def test_dedupes_before_classifying(self):
+        """同日两份一份看着降级一份看着硬过滤时,分类必须跟着最新那份走。"""
+        payloads = [
+            _trace("2026-08-24", ["1", "2", "3"], ["1", "2", "3"], generated_at="2026-08-24T12:44:00"),
+            _trace("2026-08-24", ["1", "2", "3"], ["1"], generated_at="2026-08-24T23:24:00"),
+        ]
+        hard, demoted = split_l3_hard_filter_days(payloads)
+        assert list(hard) == ["2026-08-24"]
+        assert demoted == {}
+
+    def test_empty_l3_is_skipped(self):
+        hard, demoted = split_l3_hard_filter_days([_trace("2026-08-11", ["1", "2"], [])])
+        assert hard == {} and demoted == {}
+
+
+class TestL3GateStat:
+    def _hard(self, days: int, regime: str = "RISK_OFF") -> dict:
+        return {f"2026-08-{11 + i:02d}": {"regime": regime, "l2": ["1"], "l3": ["1"]} for i in range(days)}
+
+    def test_days_come_from_swap_not_input_days(self):
+        """可评估日 = trace 天数 − h,并且配对不足的日子还会再被丢掉,两个数天生不等。"""
+        stat = summarize_l3_gate(5, self._hard(16), {"stock_win": _swap(4.764, 0.005, days=12)})
+        assert stat.days == 12
+
+    def test_positive_reads_as_removing_the_gate_helps(self):
+        stat = summarize_l3_gate(5, self._hard(16), {"stock_win": _swap(4.764, 0.005, days=100)})
+        assert "被拒 vs 留下" in stat.verdict
+        assert "超出互换零分布" in stat.verdict
+
+    def test_short_window_is_not_a_failure(self):
+        """天数不够是「尚未可知」。判定句必须自己否掉「没通过」这个读法,不能只说尚未可知。"""
+        stat = summarize_l3_gate(10, self._hard(16), {"stock_win": _swap(11.374, 0.005, days=7)})
+        assert "尚未可知，不是没通过" in stat.verdict
+        assert "超出互换零分布" not in stat.verdict
+
+    def test_missing_swap_is_not_a_conclusion(self):
+        assert summarize_l3_gate(5, self._hard(16), None).verdict == "对照未跑出结果：尚未可知"
+
+    def test_regime_composition_is_counted(self):
+        hard = {**self._hard(9), "2026-08-24": {"regime": "CRASH", "l2": ["1"], "l3": ["1"]}}
+        assert summarize_l3_gate(5, hard, None).regimes == {"CRASH": 1, "RISK_OFF": 9}
+
+    def test_blank_regime_is_labelled_not_dropped(self):
+        hard = {"2026-08-11": {"regime": "", "l2": ["1"], "l3": ["1"]}}
+        assert summarize_l3_gate(5, hard, None).regimes == {"(空)": 1}
+
+    def test_return_column_is_reported_alongside(self):
+        stat = summarize_l3_gate(
+            5,
+            self._hard(16),
+            {"stock_win": _swap(4.764, 0.005, days=100), "gross_return": _swap(0.995, 0.005, column="gross_return")},
+        )
+        assert "+0.995" in stat.verdict
+
+
+class TestL3WindowNote:
+    def test_states_window_and_regime_composition(self):
+        hard = {
+            "2026-08-11": {"regime": "", "l2": ["1"], "l3": ["1"]},
+            "2026-08-19": {"regime": "CRASH", "l2": ["1"], "l3": ["1"]},
+        }
+        note = l3_window_note(hard, {"2026-08-17": {"regime": "BEAR_REBOUND"}})
+        assert "2026-08-11..2026-08-19" in note
+        assert "CRASH 1" in note
+        assert "降级" in note
+
+    def test_no_days_says_no_reading_not_failure(self):
+        assert "没有读数" in l3_window_note({}, {})
+
+
+class TestL3Render:
+    def _report(self, swap: dict[str, SwapTest] | None) -> GateReport:
+        report = GateReport()
+        report.theme = [GateStat("topN=5", 100, 240, -0.95, -0.36, -0.59, 48.0, True)]
+        report.stop_loss = [GateStat("0~15%", 100, 500, -0.75, -0.35, -0.40, 46.0)]
+        report.l3_gate_note = "硬过滤日 16 天（2026-08-11..2026-09-07），水温构成：RISK_OFF 11、CRASH 2"
+        report.l3_gate = [summarize_l3_gate(h, {"2026-08-11": {"regime": "RISK_OFF"}}, swap) for h in (1, 5, 10)]
+        return report
+
+    def test_section_absent_when_no_trace(self):
+        report = GateReport()
+        report.theme = [GateStat("topN=5", 100, 240, -0.95, -0.36, -0.59, 48.0, True)]
+        assert "L3 硬过滤" not in render(report)
+
+    def test_orientation_is_spelled_out(self):
+        """为正 = 拆掉更好。不写清方向,读者会把它读成「L3 有效」。"""
+        text = render(self._report({"stock_win": _swap(4.764, 0.005, days=12)}))
+        assert "被 L3 拒掉" in text
+        assert "拆掉更好" in text
+
+    def test_says_it_reads_production_gate_not_proxy(self):
+        text = render(self._report({"stock_win": _swap(4.764, 0.005, days=12)}))
+        assert "l3_eligible" in text
+        assert "不是生产那道闸" in text  # 与上面题材层代理的区别必须写明
+
+    def test_warns_against_comparing_horizons_by_magnitude(self):
+        """各格天数不同,横向比大小比到的是日期构成。"""
+        text = render(self._report({"stock_win": _swap(4.764, 0.005, days=12)}))
+        assert "符号是否同向" in text
+        assert "日期构成" in text
+
+    def test_window_note_is_carried_into_output(self):
+        assert "RISK_OFF 11" in render(self._report({"stock_win": _swap(4.764, 0.005, days=12)}))
+
+    def test_regime_composition_limits_extrapolation(self):
+        assert "熊市窗口" in render(self._report({"stock_win": _swap(4.764, 0.005, days=12)}))
+
+    def test_days_column_每格都要出现(self):
+        text = render(self._report({"stock_win": _swap(4.764, 0.005, days=12)}))
+        assert "| T+1 | 12 |" in text
+        assert "| T+10 | 12 |" in text
+
+    def test_missing_swap_row_says_insufficient(self):
+        assert "样本不足" in render(self._report(None))
 
 
 class TestReportSerialization:

--- a/tests/scripts/test_evaluate_gate_alpha_l3.py
+++ b/tests/scripts/test_evaluate_gate_alpha_l3.py
@@ -1,0 +1,184 @@
+"""L3 硬过滤那一节的取数与配对。
+
+这一节量的是**生产那道闸**：两侧成员直接读 trace 的 ``l3_eligible``，不像题材层那样用
+「行业动量 topN」当代理。所以它的正确性全押在两件事上——同日多份 trace 谁说话（
+``latest_trace_per_date``），以及两侧成员是不是站在同一把尺子上（流动性池 ∩ 有动量）。
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from core.funnel_effect_panels import build_panels, normalize_market_frame
+from core.gate_alpha_eval import GateReport
+from scripts.evaluate_gate_alpha import attach_l3_gate, build_l3_days, load_trace_payloads
+
+
+def _write_trace(root: Path, ds: str, l2: list[str], l3: list[str], *, generated_at: str = "") -> None:
+    payload = {
+        "trade_date": ds,
+        "generated_at": generated_at or f"{ds}T09:00:00",
+        "market_context": {"regime": "RISK_OFF"},
+        "symbols": {code: {"l2_eligible": True, "l3_eligible": code in set(l3)} for code in sorted(set(l2))},
+    }
+    root.mkdir(parents=True, exist_ok=True)
+    stamp = (generated_at or ds).replace(":", "").replace("-", "")
+    with gzip.open(root / f"review_trace_{ds}_{stamp}.json.gz", "wt", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+
+
+def _market(codes: list[str], days: int = 40, *, amount: float = 5e8) -> pd.DataFrame:
+    """造一段够长的行情：``build_panels`` 的 20 日动量与 20 日均额都要预热。"""
+    rows = []
+    for code in codes:
+        for i in range(days):
+            rows.append(
+                {
+                    "ts_code": f"{code}.SZ",
+                    "trade_date": (pd.Timestamp("2026-07-01") + pd.Timedelta(days=i)).strftime("%Y%m%d"),
+                    "open": 10.0 + i * 0.1,
+                    "close": 10.0 + i * 0.1,
+                    "amount": amount,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _panels(codes: list[str], days: int = 40, *, amount: float = 5e8):
+    return build_panels(normalize_market_frame(_market(codes, days, amount=amount)))
+
+
+class TestLoadTracePayloads:
+    def test_reads_recursively(self, tmp_path: Path):
+        """工作流按天各解一个子目录,平铺会因同名覆盖丢掉重跑那份。"""
+        _write_trace(tmp_path / "day-a", "2026-08-11", ["000001", "000002"], ["000001"])
+        _write_trace(tmp_path / "nested" / "day-b", "2026-08-12", ["000001", "000002"], ["000001"])
+        assert len(load_trace_payloads(str(tmp_path))) == 2
+
+    def test_keeps_both_copies_of_same_date(self, tmp_path: Path):
+        """同日两份都要读进来,由 latest_trace_per_date 定夺——这里不能提前挑。"""
+        codes = ["000001", "000002"]
+        _write_trace(tmp_path / "a", "2026-08-24", codes, ["000001"], generated_at="2026-08-24T12:44:00")
+        _write_trace(tmp_path / "b", "2026-08-24", codes, ["000002"], generated_at="2026-08-24T23:24:00")
+        assert len(load_trace_payloads(str(tmp_path))) == 2
+
+    def test_missing_dir_returns_empty_not_raise(self, tmp_path: Path):
+        assert load_trace_payloads(str(tmp_path / "nope")) == []
+
+    def test_corrupt_file_is_skipped(self, tmp_path: Path):
+        _write_trace(tmp_path, "2026-08-11", ["000001", "000002"], ["000001"])
+        (tmp_path / "review_trace_bad.json.gz").write_bytes(b"not gzip")
+        assert len(load_trace_payloads(str(tmp_path))) == 1
+
+    def test_payload_without_symbols_is_rejected(self, tmp_path: Path):
+        with gzip.open(tmp_path / "review_trace_x.json.gz", "wt", encoding="utf-8") as handle:
+            json.dump({"trade_date": "2026-08-11"}, handle)
+        assert load_trace_payloads(str(tmp_path)) == []
+
+
+class TestAttachL3Gate:
+    """降级路径要能被读者看见。空池/缺列会让每天都被跳过,最终判定读成「尚未可知」——
+    与「数据确实不够」同形,这是已咬过的那类静默早返回。"""
+
+    def _traces(self, root: Path, codes: list[str], kept: list[str]) -> str:
+        for i in range(6):
+            ds = (pd.Timestamp("2026-07-20") + pd.Timedelta(days=i)).strftime("%Y-%m-%d")
+            _write_trace(root, ds, codes, kept)
+        return str(root)
+
+    def test_missing_amount_column_says_so(self, tmp_path: Path):
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        report = GateReport()
+        attach_l3_gate(report, _market(codes).drop(columns=["amount"]), self._traces(tmp_path, codes, codes[:5]), (5,))
+        assert "缺 amount" in report.l3_gate_note
+        assert report.l3_gate == []
+
+    def test_empty_liquidity_pool_says_so(self, tmp_path: Path):
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        report = GateReport()
+        attach_l3_gate(report, _market(codes, amount=1e4), self._traces(tmp_path, codes, codes[:5]), (5,))
+        assert "流动性池为空" in report.l3_gate_note
+        assert report.l3_gate == []
+
+    def test_no_trace_is_not_a_failed_control(self, tmp_path: Path):
+        report = GateReport()
+        attach_l3_gate(report, _market(["000001"]), str(tmp_path / "empty"), (5,))
+        assert "不是没通过" in report.l3_gate_note
+
+    def test_normal_path_emits_one_row_per_horizon(self, tmp_path: Path):
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        report = GateReport()
+        attach_l3_gate(report, _market(codes), self._traces(tmp_path, codes, codes[:5]), (1, 3, 5))
+        assert [stat.horizon for stat in report.l3_gate] == [1, 3, 5]
+        assert "硬过滤日 6 天" in report.l3_gate_note
+
+    def test_同日重跑取最新那份而不是先读到的那份(self, tmp_path: Path):
+        """同一交易日多份 trace,配对数必须来自 generated_at 最新的那份。
+
+        这不是假想:2026-08-24 真有三份(12:44 / 14:51 / 23:24),L3 分别 732/732/449,
+        config_digest 还是同一个。按平铺 `cp -n` 留下 14:51 那份(L3=732),T+5 胜率差读
+        +3.844;留下 23:24 那份(L3=449)读 +4.764。同一批证据两个数,差别全在谁说话。
+        所以工作流必须按 run 各解一个子目录,由这里按时间定夺。
+        """
+        codes = [f"{i:06d}" for i in range(1, 21)]
+        for i in range(6):
+            ds = (pd.Timestamp("2026-07-20") + pd.Timedelta(days=i)).strftime("%Y-%m-%d")
+            # 先写的那份留 4 只,后写的留 12 只;若取错,配对数会被 4 只那侧卡住。
+            _write_trace(tmp_path / "early", ds, codes, codes[:4], generated_at=f"{ds}T12:44:00")
+            _write_trace(tmp_path / "late", ds, codes, codes[:12], generated_at=f"{ds}T23:24:00")
+        report = GateReport()
+        attach_l3_gate(report, _market(codes), str(tmp_path), (1,))
+        # 配对数上限 = min(留下, 被拒) = min(12, 8) = 8;取错那份会是 min(4, 16) = 4。
+        assert report.l3_gate[0].avg_pairs == 8.0
+
+
+class TestBuildL3Days:
+    def _hard(self, ds: str, l2: list[str], l3: list[str]) -> dict:
+        return {ds: {"regime": "RISK_OFF", "l2": sorted(l2), "l3": sorted(l3)}}
+
+    def test_tested_side_is_the_rejected_basket(self):
+        """待测=被 L3 拒的票。方向错了整节的符号就反了,而反了不会报错。"""
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        kept, rejected = codes[:5], codes[5:]
+        days = build_l3_days(self._hard("2026-07-25", codes, kept), _panels(codes), 5)
+        assert len(days) == 1
+        assert {pair[0] for pair in days[0].pairs} <= set(rejected)
+        assert {pair[1] for pair in days[0].pairs} <= set(kept)
+
+    def test_skips_day_when_either_side_too_small(self):
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        assert build_l3_days(self._hard("2026-07-25", codes, codes[:2]), _panels(codes), 5) == []
+
+    def test_skips_day_without_forward_window(self):
+        """前瞻窗口落在行情尾部之外的日子必须丢掉,否则收益读的是别的天。"""
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        panels = _panels(codes)
+        last = panels.dates[-1]
+        assert build_l3_days(self._hard(last, codes, codes[:5]), panels, 5) == []
+
+    def test_illiquid_codes_are_excluded_from_both_sides(self):
+        """两侧都要过流动性池——生产漏斗那把尺子。只筛一侧就是两套标准。"""
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        # tushare 的 amount 是千元,normalize 除以 10 得万元：1e4 千元 = 1000 万元 < 8000 万门槛。
+        panels = _panels(codes, amount=1e4)
+        assert build_l3_days(self._hard("2026-07-25", codes, codes[:5]), panels, 5) == []
+
+    def test_pairs_are_capped_by_smaller_basket(self):
+        """1:1 无放回,配对数上限是小的那一侧。"""
+        codes = [f"{i:06d}" for i in range(1, 21)]
+        kept = codes[:4]
+        days = build_l3_days(self._hard("2026-07-25", codes, kept), _panels(codes), 5)
+        assert len(days[0].pairs) <= len(kept)
+
+    def test_buy_and_sell_dates_span_the_horizon(self):
+        """T+1 开盘买 / T+1+H 收盘卖,与 funnel_effect_eval 同口径。"""
+        codes = [f"{i:06d}" for i in range(1, 11)]
+        panels = _panels(codes)
+        days = build_l3_days(self._hard("2026-07-25", codes, codes[:5]), panels, 3)
+        buy_index = panels.dates.index(days[0].buy_ds)
+        assert panels.dates.index(days[0].sell_ds) - buy_index == 3
+        assert buy_index == panels.dates.index("2026-07-25") + 1

--- a/tests/workflows/test_review_list_replay.py
+++ b/tests/workflows/test_review_list_replay.py
@@ -631,6 +631,79 @@ def test_review_trace_records_as_run_stages_without_ohlcv(tmp_path):
         load_review_trace_artifact(path, date(2026, 5, 11))
 
 
+def _l3_strict_inputs() -> SimpleNamespace:
+    """L2 过 3 只、L3 按降级口径全放行的最小夹具。"""
+    frame = pd.DataFrame(
+        {
+            "date": pd.bdate_range("2025-08-01", periods=220),
+            "close": [10.0] * 220,
+            "amount": [100_000_000.0] * 220,
+        }
+    )
+    codes = ["000001", "000002", "000003"]
+    return SimpleNamespace(
+        cfg=FunnelConfig(),
+        window=SimpleNamespace(end_trade_date=date(2026, 8, 31)),
+        pool=SimpleNamespace(symbols=codes),
+        ref_data=SimpleNamespace(
+            name_map={code: code for code in codes},
+            sector_map={"000001": "银行", "000002": "地产", "000003": "券商"},
+            market_cap_map={code: 100.0 for code in codes},
+            financial_map={},
+        ),
+        all_df_map={code: frame for code in codes},
+        layers=SimpleNamespace(
+            l1_passed=list(codes),
+            l2_passed=list(codes),
+            # 降级日:l3_passed 等于 l2_passed,这正是那 6 天 L3/L2=100.0% 的成因。
+            l3_passed=list(codes),
+            l2_channel_map={code: "点火破局" for code in codes},
+            l2_rejections={},
+        ),
+        candidates=SimpleNamespace(candidate_entries=[], exit_signals={}),
+    )
+
+
+def test_review_trace_keeps_l3_demotion_counterfactual() -> None:
+    """修复期 L3 降级日,trace 要留下「照常过滤会留下谁」。
+
+    BEAR_REBOUND 那 6 天 Layer 3 从硬过滤降级成 +8 加分项(funnel_layers 里显式
+    分支 + 日志),l3_passed 等于 l2_passed。降级时算出的严格口径通过集此前只存在
+    benchmark_context 里、没人落盘——22 份产物里 l3_passed_normal 零命中,等于每个
+    降级日都白算了一次同日同水温的「L3 开 vs 关」对照。
+    """
+    inputs = _l3_strict_inputs()
+    metrics = {"benchmark_context": {"regime": "BEAR_REBOUND", "l3_passed_normal": ["000001"]}}
+
+    rows = build_review_trace(inputs, {}, metrics)["symbols"]
+
+    # 降级口径:三只都算过 L3。
+    assert [rows[code]["l3_eligible"] for code in ("000001", "000002", "000003")] == [True, True, True]
+    # 严格口径:只有 000001 会留下。这一对差值才是可用的同日对照。
+    assert rows["000001"]["l3_eligible_strict"] is True
+    assert rows["000002"]["l3_eligible_strict"] is False
+    assert rows["000003"]["l3_eligible_strict"] is False
+
+
+def test_review_trace_l3_strict_is_none_on_normal_days() -> None:
+    """非降级日必须是 None,不能是 False。
+
+    `or set()` 兜底会把「今天 L3 就是硬过滤」和「今天降级了且严格口径一只不留」
+    压成同一个空集合,于是 20 个正常日全被读成「L3 本来会全灭」——把缺失读成事实。
+    """
+    inputs = _l3_strict_inputs()
+
+    rows = build_review_trace(inputs, {}, {"benchmark_context": {"regime": "RISK_OFF"}})["symbols"]
+    assert all(rows[code]["l3_eligible_strict"] is None for code in ("000001", "000002", "000003"))
+
+    # metrics 整个缺失(回放路径传 {})也要退成 None,不能抛。
+    assert build_review_trace(inputs, {}, {})["symbols"]["000001"]["l3_eligible_strict"] is None
+
+    # 降级日而严格口径真的一只不留:是 False,与上面的 None 必须分得开。
+    empty = build_review_trace(inputs, {}, {"benchmark_context": {"l3_passed_normal": []}})["symbols"]
+    assert all(empty[code]["l3_eligible_strict"] is False for code in ("000001", "000002", "000003"))
+
+
 def test_review_trace_separates_unevaluated_risk_from_clean_risk() -> None:
     """空的 risk_signal 有两种来源,trace 必须分得开。
 

--- a/workflows/review_list_replay.py
+++ b/workflows/review_list_replay.py
@@ -312,6 +312,9 @@ def _build_replay_row(
         "execution_reason": str(execution.get("reason", "") or ""),
         "l2_eligible": code in ctx.l2_set,
         "l3_eligible": code in ctx.l3_set,
+        # 直接透传,不从 ctx.l3_set 反推:降级日 l3_set 已等于 l2_set,
+        # 反推只会得到 l3_eligible 的副本,把反事实抹平。老 trace 缺这个键取到 None。
+        "l3_eligible_strict": decision.get("l3_eligible_strict"),
         "trigger_labels": list(decision.get("trigger_labels") or []),
         "risk_signal": str(decision.get("risk_signal") or ""),
         # 老 trace 没有这个键,取不到就传 None,渲染侧只在显式 False 时标「未评估」,

--- a/workflows/review_trace.py
+++ b/workflows/review_trace.py
@@ -59,7 +59,7 @@ def dump_review_trace_artifact(payload: dict[str, Any], output_dir: str) -> Path
 def build_review_trace(inputs: Any, triggers: dict, metrics: dict) -> dict[str, Any]:
     layers = inputs.layers
     candidates = inputs.candidates
-    symbols = _decision_rows(inputs, triggers)
+    symbols = _decision_rows(inputs, triggers, metrics)
     config_payload = asdict(inputs.cfg)
     return {
         "schema_version": REVIEW_TRACE_SCHEMA,
@@ -102,12 +102,18 @@ def load_review_trace_artifact(path: str | Path, expected_trade_date: date | str
     return payload
 
 
-def _decision_rows(inputs: Any, triggers: dict) -> dict[str, dict[str, Any]]:
+def _decision_rows(inputs: Any, triggers: dict, metrics: dict | None = None) -> dict[str, dict[str, Any]]:
     layers = inputs.layers
     candidates = inputs.candidates
     l1_set = set(layers.l1_passed)
     l2_set = set(layers.l2_passed)
     l3_set = set(layers.l3_passed)
+    # 修复期(BEAR_REBOUND/PANIC_REPAIR*)Layer 3 从硬过滤降级为 +8 加分项,
+    # l3_passed 会等于 l2_passed——那 6 天 L3/L2 恰好 100.0%,不是 bug 是设计。
+    # 降级时 funnel_layers 把「照常过滤会留下谁」存进 benchmark_context,
+    # 但此前没人落盘:每个降级日都白算了一次同日同水温的「L3 开 vs 关」对照。
+    # 落成逐行三态,原地就能分组比前向收益,不必再去反推分数断层。
+    l3_normal_set = _l3_normal_set(metrics)
     entry_map = best_candidate_entry_map(candidates.candidate_entries)
     hit_map = _trigger_labels(triggers)
     blocked = _blocked_exit_map(candidates.exit_signals)
@@ -125,7 +131,19 @@ def _decision_rows(inputs: Any, triggers: dict) -> dict[str, dict[str, Any]]:
     score_map = {str(k): v for k, v in (getattr(candidates, "l3_score_map", None) or {}).items()}
     return {
         code: attach_shadow_signal(
-            _decision_row(code, inputs, l1_set, l2_set, l3_set, entry_map, hit_map, blocked, score_map, evaluated),
+            _decision_row(
+                code,
+                inputs,
+                l1_set,
+                l2_set,
+                l3_set,
+                entry_map,
+                hit_map,
+                blocked,
+                score_map,
+                evaluated,
+                l3_normal_set,
+            ),
             near_l2_max_gap_pct=_SHADOW_NEAR_L2_MAX_GAP_PCT,
         )
         for code in inputs.pool.symbols
@@ -143,6 +161,7 @@ def _decision_row(
     blocked: dict[str, dict],
     score_map: dict[str, Any] | None = None,
     evaluated: set[str] | None = None,
+    l3_normal_set: set[str] | None = None,
 ) -> dict[str, Any]:
     name = str(inputs.ref_data.name_map.get(code, code)).strip() or code
     sector = str(inputs.ref_data.sector_map.get(code, "")).strip()
@@ -152,6 +171,9 @@ def _decision_row(
         "l1_eligible": code in l1_set,
         "l2_eligible": code in l2_set,
         "l3_eligible": code in l3_set,
+        # None=当天 L3 按硬过滤跑,l3_eligible 本身就是严格口径;
+        # True/False=当天 L3 被降级,这一位是「照常过滤会不会留下它」的反事实。
+        "l3_eligible_strict": code in l3_normal_set if l3_normal_set is not None else None,
         "l2_channel": str(inputs.layers.l2_channel_map.get(code, "")),
         "layer3_quality_score": _score_or_none((score_map or {}).get(code)),
         "trigger_labels": list(hit_map.get(code, [])),
@@ -346,6 +368,20 @@ def _market_context(metrics: dict[str, Any]) -> dict[str, Any]:
         "rps_fast_min": _float(tuned.get("rps_fast_min")),
         "rps_slow_min": _float(tuned.get("rps_slow_min")),
     }
+
+
+def _l3_normal_set(metrics: dict | None) -> set[str] | None:
+    """降级日 Layer 3 的严格口径通过集;非降级日返回 None。
+
+    `None` 与 `set()` 必须区分:前者是「今天 L3 就是硬过滤,别去比」,后者是
+    「今天降级了,而且严格口径一只都不留」。用 `or set()` 兜底会把前者也变成
+    空集合,于是 20 个正常日全被读成「L3 本来会全灭」——把缺失读成事实。
+    """
+    context = (metrics or {}).get("benchmark_context") or {}
+    raw = context.get("l3_passed_normal")
+    if raw is None:
+        return None
+    return {str(code) for code in raw}
 
 
 def _digest(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## 摘要

给 `gate_alpha_eval` 补第三节:**L3 硬过滤那道闸的判别力**。与上面两节的区别在量的是哪道闸——题材层用「行业动量 topN」当代理,`core/gate_alpha_eval` 文档开头自己就写了那不是生产那道闸;这一节两侧成员直接读 trace 的 `l3_eligible`,是生产四路取或(候选内复合百分位中位数 + `len(filtered) < 3` 兜底)的真实结果。两侧都已过 L2,唯一差别是 L3,与 `resolve_layer` 的 `l4_vs_rest` 同构。

方向约定:待测组取**被 L3 拒掉**的那批(拆掉这道闸就会进来的票),所以读数为正 = 拆掉更好 = 这道闸在反向筛。

## 问题

落地过程中撞出两个证据管线上的缺陷,都不是这一节独有的:

**同日多份 trace 谁说话。** 2026-08-24 线上真有三份(12:44 / 14:51 / 23:24),L3 分别 732 / 732 / 449,`config_digest` 还是同一个 `517b8b1e`、水温同为 CRASH。工作流原先把 trace 平铺 `cp -n` 到一处,留下哪一份取决于 `find` 的顺序。实测同一批证据能读出两个数:

| 08-24 留下哪份 | T+1 | T+2 | T+3 | T+5 |
| --- | --: | --: | --: | --: |
| 14:51(L3=732) | −0.207 | +0.440 | +1.671 | +3.844 |
| 23:24(L3=449,正确) | +0.448 | +1.160 | +2.280 | +4.764 |

T+1 连符号都翻了。改为按 run 各解一个子目录、全部读进来,由 `latest_trace_per_date` 按 `generated_at` 定夺。

**静默降级。** 缺 `amount` 列或流动性池为空,会让每一天都被跳过、`swap=None`、判定读成「尚未可知」——与「数据确实不够」同形。两处改成出声(写进 `l3_gate_note` 并打印),另加逐持有期的可评估日打印。

## 改动

- `core/gate_alpha_eval.py`:`TRACE_HORIZONS`、`latest_trace_per_date`、`split_l3_hard_filter_days`、`L3GateStat`、`summarize_l3_gate`、`l3_window_note`、`_l3_section`,以及 `GateReport.l3_gate` / `.l3_gate_note`。
- `scripts/evaluate_gate_alpha.py`:`--trace-dir` / `--trace-horizons`,tushare 取数补 `amount`,`load_trace_payloads` / `build_l3_days` / `attach_l3_gate`,两处降级出声。
- `core/funnel_effect_panels.py`:抽出 `normalize_market_frame`,内存里的行情表不必先落盘再读回来;成交额单位换算仍只写在一处。
- `.github/workflows/gate_alpha_eval.yml`:补 `actions: read`,按 run 各解子目录收 trace,`continue-on-error` — 这一节是增量,取不到 trace 时题材层与止损层照跑。

硬过滤日的判据是 **L2/L3 成员集合逐一相等**(降级时 `l3_passed = l2_passed`),不是水温白名单:08-07 / 08-10 / 08-12 水温为空且被降级,而同样空水温的 08-11 是硬过滤日(866/199)。`l3_eligible_strict` 还不能当判据——#398 合并前全表为 `None`。

## 验证

1471 个测试通过(`tests/core` + `tests/scripts`),其中这一节新增 33 个;`ruff check` / `ruff format` / `quality_gate.py --ci` / `--check-no-sql` 均通过。

拿线上 22 份 trace(26 个文件,含同日重跑)跑通端到端,复现了 `/tmp` 一次性脚本的同一组数,逐格一致。回归用例 `test_同日重跑取最新那份而不是先读到的那份` 把上面那张表的成因钉住:同日两份分别留 4 只和 12 只,取错会让配对数从 8 掉到 4。

**读数本身还不构成结论。** 硬过滤日 16 天(2026-08-11..09-07),水温 RISK_OFF 13 / CRASH 2 / 空 1;每个持有期的可评估日 = trace 天数 − h,分别 14 / 13 / 12 / 12 / 7,**全部低于 `MIN_DAYS=20`**,所以十条判定一律是「尚未可知,**不是**没通过」。窗口里几乎只有 RISK_OFF/CRASH,外推不了。

## 生效范围

只加一节读数,不动任何生产路径。`workflows/funnel_layers.py:257` 的降级水温名单(`PANIC_REPAIR*` / `BEAR_REBOUND`,不含 `RISK_OFF` / `CRASH`)有意保持原样。
