### PR TITLE
fix(funnel-eval): 没拿到基准也报「跑赢基准」,NaN 价格还能吞掉整日读数

### DIFF
--- a/core/funnel_effect_eval.py
+++ b/core/funnel_effect_eval.py
@@ -35,6 +35,7 @@
 
 from __future__ import annotations
 
+import math
 import random
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -68,6 +69,24 @@ def tstat(values: list[float]) -> float | None:
 
 def _round(value: float | None, digits: int = 4) -> float | None:
     return None if value is None else round(float(value), digits)
+
+
+def _finite(value: Any) -> float | None:
+    """能当数用就返回 float，否则 None。行情里的缺失值判空必须走这里。
+
+    行情表缺值到手上是 ``NaN`` 而不是 ``None``（tushare / pandas 的常态），而
+    ``bool(NaN)`` 是 **True**、``NaN <= 0`` 是 **False**——``if not price``、
+    ``if o and c``、``price is not None`` 三种写法一个都拦不住它。放过去之后
+    ``100 * (c / o - 1)`` 得到 NaN，被 ``mean`` 一吃，**整日读数变成 NaN**，
+    而且不抛错、不告警，最后在报告里跟真实读数长得一样。
+    """
+    if value is None:
+        return None
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    return num if math.isfinite(num) else None
 
 
 @dataclass
@@ -161,6 +180,9 @@ class AbsoluteStat:
     ``positive_day_pct`` 这里算的是**净收益为正的交易日占比**（胜率），与
     ``GroupStat.positive_day_pct`` 的「超额为正日占比」不是一回事，不可混用。
 
+    ``bench_excess_pct`` 为 ``None`` 时判定句是「基准覆盖不足，超额未知」，**不是**
+    「跑赢基准」：没拿到基准就没这个资格说。读 ``bench_days`` 看基准站了几天。
+
     收益算在**全部候选**上（``net_abs``），不是配对子集：配对会丢掉找不到同动量
     对照的候选，而漏斗当天真正给出的就是全集。超额那一栏必须用配对子集（分母要
     和对照组一致），这一栏必须用全集（要如实反映持有这批票的结果）——两栏分母
@@ -185,11 +207,22 @@ class AbsoluteStat:
 
     @property
     def verdict(self) -> str:
-        if self.days < MIN_DAYS or self.net_pct is None:
+        """判定句。**"跑赢基准"只有在真拿到基准读数时才能说。**
+
+        原先缺基准时 ``bench_excess_pct`` 是 ``None``，"为负"和"跑输"两条都不触发，
+        直接落到最后一句——**没有基准却宣称跑赢**。脏数据那条更隐蔽：NaN 超额下
+        ``NaN <= 0`` 是 False，同样落到最后一句。两条都是「没测过」被说成「测过且赢了」，
+        与"样本不足 ≠ 对照未通过"是同一种错，方向还更坏：它是无据宣称。
+        """
+        net = _finite(self.net_pct)
+        if self.days < MIN_DAYS or net is None:
             return "样本不足"
-        if self.net_pct <= 0:
+        if net <= 0:
             return "绝对收益为负：这批票拿着是亏的"
-        if self.bench_excess_pct is not None and self.bench_excess_pct <= 0:
+        excess = _finite(self.bench_excess_pct)
+        if excess is None:
+            return "绝对收益为正；基准覆盖不足，超额未知"
+        if excess <= 0:
             return "绝对为正但跑输基准：只赚了市场的钱"
         return "绝对为正且跑赢基准"
 
@@ -218,11 +251,17 @@ def summarize_absolute(daily: list[dict[str, float]]) -> AbsoluteStat:
     基准差额只用**同时有 net_abs 和 bench 的日子**算，缺基准的日子不静默按 0
     处理——那会把无基准段当成「基准不涨不跌」，凭空造出超额。
     """
-    usable = [row for row in daily if row.get("net_abs") is not None and (row.get("size_abs") or 0) >= MIN_HITS_PER_DAY]
+    usable = [
+        row
+        for row in daily
+        if _finite(row.get("net_abs")) is not None and (row.get("size_abs") or 0) >= MIN_HITS_PER_DAY
+    ]
     if len(usable) < MIN_DAYS:
         return AbsoluteStat(len(usable), 0.0, None, None, None, None, None, None, None, None)
     nets = [float(row["net_abs"]) for row in usable]
-    paired = [(float(r["net_abs"]), float(r["bench"])) for r in usable if r.get("bench") is not None]
+    # 基准这一栏也要过 _finite：``is not None`` 放 NaN 过去，一天脏基准就让
+    # bench_excess_pct 变 NaN，再被 verdict 读成「跑赢」。
+    paired = [(float(r["net_abs"]), b) for r in usable if (b := _finite(r.get("bench"))) is not None]
     bench_diffs = [net - bench for net, bench in paired]
     # 股级胜率按**交易日等权**平均，不是把所有票混成一个大池：命中只数多的日子
     # 不该主导胜率，与 net_pct 的等权口径保持一致。
@@ -361,8 +400,9 @@ class Panels:
         必须与候选同窗口。用 buy_ds 收盘当起点会把 T+1 当天的涨跌从基准里剔掉、
         却留在候选里，跳空大的日子能凭空造出 1pct 以上的假超额。
         """
-        start, end = self.bench_open.get(buy_ds), self.bench_close.get(sell_ds)
-        if not start or not end or start <= 0:
+        start = _finite(self.bench_open.get(buy_ds))
+        end = _finite(self.bench_close.get(sell_ds))
+        if start is None or end is None or start <= 0 or end <= 0:
             return None
         return 100.0 * (end / start - 1.0)
 
@@ -382,13 +422,20 @@ class Panels:
         return mean(rets) if rets else None
 
     def per_stock_returns(self, codes: list[str], buy_ds: str, sell_ds: str) -> list[float]:
-        """逐只毛收益（%），未扣成本。缺开盘或收盘的票直接不收录。"""
+        """逐只毛收益（%），未扣成本。缺开盘或收盘的票直接不收录。
+
+        判空走 ``_finite``：原先的 ``if o and c and o > 0`` 只对 ``o`` 查了正负，
+        ``c`` 是裸真值判断，NaN 收盘价能穿过去，算出的 NaN 被 ``mean`` 一吃就把
+        **整日**读数变成 NaN。这是全链唯一的取价口，``gross_return`` 与
+        ``stock_win_rate`` 都走它，所以这一处修完那两个也就干净了。
+        """
         opens, closes = self.open.get(buy_ds, {}), self.close.get(sell_ds, {})
         rets = []
         for code in codes:
-            o, c = opens.get(code), closes.get(code)
-            if o and c and o > 0:
-                rets.append(100.0 * (c / o - 1.0))
+            o, c = _finite(opens.get(code)), _finite(closes.get(code))
+            if o is None or c is None or o <= 0 or c <= 0:
+                continue
+            rets.append(100.0 * (c / o - 1.0))
         return rets
 
     def stock_win_rate(self, codes: list[str], buy_ds: str, sell_ds: str) -> float | None:

--- a/tests/core/test_funnel_effect_eval.py
+++ b/tests/core/test_funnel_effect_eval.py
@@ -346,10 +346,16 @@ class TestSummarizeAbsolute:
         assert stat.bench_excess_pct == pytest.approx(-1.0)
 
     def test_bench_columns_absent_without_benchmark(self):
+        """整段没有基准时,判定句不能说「跑赢基准」——没拿到基准就没资格说。
+
+        这条原先断言的是「绝对为正且跑赢基准」,把 bug 钉住了:缺基准时
+        ``bench_excess_pct`` 是 None,「为负」和「跑输」两条都不触发,直接落到最后一句。
+        """
         stat = summarize_absolute(_abs_daily([1.0] * MIN_DAYS))
         assert stat.bench_days == 0
         assert (stat.bench_pct, stat.bench_excess_pct, stat.bench_excess_t) == (None, None, None)
-        assert stat.verdict == "绝对为正且跑赢基准"
+        assert stat.verdict == "绝对收益为正；基准覆盖不足，超额未知"
+        assert "跑赢" not in stat.verdict
 
     def test_bench_excess_needs_its_own_sample_floor(self):
         """基准日数不够时只压掉基准三列,绝对收益本身照出。"""
@@ -358,6 +364,38 @@ class TestSummarizeAbsolute:
         assert stat.net_pct == pytest.approx(1.0)
         assert stat.bench_days == MIN_DAYS - 1
         assert stat.bench_excess_pct is None
+        # 基准站不满 MIN_DAYS 也是「未知」,同样不能宣称跑赢。
+        assert stat.verdict == "绝对收益为正；基准覆盖不足，超额未知"
+
+    def test_nan_bench_does_not_become_beating_the_market(self):
+        """脏基准价比缺基准更隐蔽:NaN 超额下 ``NaN <= 0`` 是 False,也落到「跑赢」。
+
+        ``is not None`` 拦不住 NaN(行情缺值到手上就是 NaN 而不是 None),一天脏基准
+        就能让 bench_excess_pct 变 NaN,再被判定句读成跑赢。这与「样本不足不是对照
+        未通过」是同一种错,方向更坏:它是无据宣称。
+        """
+        nan = float("nan")
+        benches: list[float | None] = [nan] * MIN_DAYS
+        stat = summarize_absolute(_abs_daily([1.0] * MIN_DAYS, benches))
+        assert stat.bench_days == 0, "NaN 基准不该被算作有效基准日"
+        assert stat.bench_excess_pct is None
+        assert stat.verdict == "绝对收益为正；基准覆盖不足，超额未知"
+
+    def test_one_nan_bench_day_does_not_poison_the_column(self):
+        """单日脏基准只该丢那一天,不该把整栏拖成 NaH。"""
+        benches: list[float | None] = [float("nan")] + [2.0] * MIN_DAYS
+        stat = summarize_absolute(_abs_daily([1.0] * (MIN_DAYS + 1), benches))
+        assert stat.bench_days == MIN_DAYS
+        assert stat.bench_excess_pct == pytest.approx(-1.0)
+        assert stat.verdict == "绝对为正但跑输基准：只赚了市场的钱"
+
+    def test_nan_net_day_is_dropped_not_counted(self):
+        """NaN 净收益的日子要当缺失丢掉,不能进分母也不能污染均值。"""
+        rows = _abs_daily([1.0] * (MIN_DAYS + 1))
+        rows[0]["net_abs"] = float("nan")
+        stat = summarize_absolute(rows)
+        assert stat.days == MIN_DAYS
+        assert stat.net_pct == pytest.approx(1.0)
 
 
 def _panels(n_days: int = 40, *, codes: list[str] | None = None) -> Panels:
@@ -401,6 +439,33 @@ class TestPanels:
         panels = _panels(5, codes=["a"])
         assert panels.gross_return(["ghost"], "2026-06-02", "2026-06-03") is None
 
+    def test_one_nan_close_does_not_poison_the_whole_day(self):
+        """一只脏收盘价不能把整日读数变成 NaN。
+
+        原先的 ``if o and c and o > 0`` 只对 ``o`` 查了正负,``c`` 是裸真值判断,而
+        ``bool(NaN)`` 是 True。NaN 混进逐只收益后被 ``mean`` 一吃,当天的绝对收益、
+        股级胜率全变 NaN,报告里跟真实读数长得一样。
+        """
+        panels = _panels(5, codes=["a", "b"])
+        panels.open["2026-06-02"] = {"a": 100.0, "b": 100.0}
+        panels.close["2026-06-03"] = {"a": 110.0, "b": float("nan")}
+        rets = panels.per_stock_returns(["a", "b"], "2026-06-02", "2026-06-03")
+        assert rets == pytest.approx([10.0]), "NaN 那只该被丢掉,不是记成 NaN"
+        assert panels.gross_return(["a", "b"], "2026-06-02", "2026-06-03") == pytest.approx(10.0)
+
+    def test_nan_open_is_dropped_too(self):
+        panels = _panels(5, codes=["a", "b"])
+        panels.open["2026-06-02"] = {"a": float("nan"), "b": 100.0}
+        panels.close["2026-06-03"] = {"a": 110.0, "b": 90.0}
+        assert panels.per_stock_returns(["a", "b"], "2026-06-02", "2026-06-03") == pytest.approx([-10.0])
+
+    def test_negative_close_is_dropped(self):
+        """负收盘价是脏数据,不该算出 -200% 这种收益。"""
+        panels = _panels(5, codes=["a", "b"])
+        panels.open["2026-06-02"] = {"a": 100.0, "b": 100.0}
+        panels.close["2026-06-03"] = {"a": -100.0, "b": 110.0}
+        assert panels.per_stock_returns(["a", "b"], "2026-06-02", "2026-06-03") == pytest.approx([10.0])
+
     def test_bench_return_spans_the_same_window_as_candidates(self):
         """基准必须 T+1 开盘进、T+1+H 收盘出。用 buy_ds 收盘当起点会把 T+1 的涨跌
         从基准里剔掉却留在候选里,跳空日能造出假超额。"""
@@ -420,6 +485,25 @@ class TestPanels:
         panels = _panels(5, codes=["a"])
         panels.bench_open = {"2026-06-02": 0.0}
         panels.bench_close = {"2026-06-04": 110.0}
+        assert panels.bench_return("2026-06-02", "2026-06-04") is None
+
+    def test_bench_return_none_on_nan_price(self):
+        """``if not start`` 拦不住 NaN(``not NaN`` 是 False),基准会变成 NaN。
+
+        NaN 基准往下走成 NaN 超额,再被 AbsoluteStat.verdict 读成「跑赢基准」——
+        整条链一次都不抛错、不告警。
+        """
+        nan = float("nan")
+        panels = _panels(5, codes=["a"])
+        panels.bench_open = {"2026-06-02": nan, "2026-06-03": 100.0}
+        panels.bench_close = {"2026-06-04": 110.0, "2026-06-05": nan}
+        assert panels.bench_return("2026-06-02", "2026-06-04") is None, "NaN 起点"
+        assert panels.bench_return("2026-06-03", "2026-06-05") is None, "NaN 终点"
+
+    def test_bench_return_none_on_nonpositive_end(self):
+        panels = _panels(5, codes=["a"])
+        panels.bench_open = {"2026-06-02": 100.0}
+        panels.bench_close = {"2026-06-04": 0.0}
         assert panels.bench_return("2026-06-02", "2026-06-04") is None
 
     def test_bench_panels_default_to_empty(self):


### PR DESCRIPTION
## 摘要

绝对收益那一栏的判定句有条**无据宣称**的路径：没拿到基准也会说「跑赢基准」。顺带
修掉三处拦不住 NaN 的判空，它们串起来能让一天脏行情吞掉整日读数。

## 问题

`AbsoluteStat.verdict` 原先是三条 if：

```python
if self.days < MIN_DAYS or self.net_pct is None:  return "样本不足"
if self.net_pct <= 0:                              return "绝对收益为负..."
if self.bench_excess_pct is not None and self.bench_excess_pct <= 0:
                                                   return "绝对为正但跑输基准..."
return "绝对为正且跑赢基准"
```

缺基准时 `bench_excess_pct` 是 `None`，第三条被 `is not None` 短路，直接落到最后一
句。**没有基准，却宣称跑赢基准。** 原有用例
`test_bench_columns_absent_without_benchmark` 恰好断言了这个行为，所以它一直是绿的
——bug 被用例钉住了。

脏数据那条更隐蔽。行情缺值到手上是 `NaN` 而不是 `None`，而 `bool(NaN)` 是 **True**、
`NaN <= 0` 是 **False**，于是三种常见判空一个都拦不住：

| 位置 | 原写法 | NaN 穿过去的后果 |
| --- | --- | --- |
| `bench_return` | `if not start or not end` | 基准收益成 NaN |
| `per_stock_returns` | `if o and c and o > 0` | `c` 是裸真值判断，NaN 收盘价进逐只收益，被 `mean` 一吃**整日**变 NaN |
| `summarize_absolute` | `r.get("bench") is not None` | NaN 进 `bench_diffs`，超额整栏变 NaN |

四处串起来是一条完整的静默失效链：脏基准价 → NaN 基准 → NaN 超额 → 判定句说「跑赢
基准」。全程不抛错、不告警，落到报告里跟真实读数长得一样。

## 改法

加 `_finite()` 统一判空（同时挡 `None`、非数、`inf`、`NaN`），取价与判定都走它。
`per_stock_returns` 是全链唯一取价口，`gross_return` / `stock_win_rate` 都走它，所以
那一处修完这两个也就干净了。

判定句在超额取不到时改口「绝对收益为正；基准覆盖不足，超额未知」。这与「样本不足不
是对照未通过」是同一种说法：**没测过就不说测过了**，而无据宣称比说「未通过」更坏。

只修判空与判定，没有动口径。`price_coverage` 那套缺价披露是 #393 的设计，留给它。

## 影响范围

现有 15 份 `docs/evidence/*.json` 全扫了一遍，**0 条命中**——基准数据目前是全的，这
条路还没咬到已发布的读数。所以这是**堵路不是纠错**，此前的结论不受影响。

## 与 #393 的关系

#393（draft）修了其中两处：`per_stock_returns` 的有限性判断，和 `verdict` 的 `None`
分支。但它**没碰 `bench_return`**，而那是喂给 verdict 的上游——即使 #393 合了，NaN
基准价照样能走到「跑赢」。两边不冲突：这个 PR 只改判空与判定句，#393 那套
`price_coverage` 缺价披露重构完整保留。

## 验证

- 8 个新用例在旧代码上逐一确认失败（`git stash` 掉修复后重跑）；另 2 个（NaN 开盘价、
  零收盘价）旧代码本来就挡住了，留作边界补全，如实标注。
- `2251 passed`：`tests/core` + `tests/scripts` + `tests/workflows`。
- `ruff check` / `ruff format` / `quality_gate.py --ci` / `--check-no-sql` 均通过。
- LOC warning 是既有累计基线漂移，本 PR 净增约 60 行。
