### PR TITLE
fix(exit): 节后宽限期按自然日算，把每个周一都当成节后，止损整段跳过

### DIFF
--- a/core/wyckoff_engine.py
+++ b/core/wyckoff_engine.py
@@ -374,7 +374,7 @@ class FunnelConfig:
     exit_trailing_drawdown_pct: float = -10.0  # 利润保护线：高位跟踪回撤止损幅度（%）
     exit_confirm_days: int = 2  # 洗盘过滤：连续 N 日收盘低于止损线才确认
     exit_vol_confirm_ratio: float = 0.8  # 确认期量比阈值（低于此值视为缩量洗盘不触发）
-    exit_holiday_grace_days: int = 1  # 节后宽限期：跨 ≥3 自然日后跳过 N 个交易日止损
+    exit_holiday_grace_days: int = 1  # 节后宽限期：整日休市后跳过 N 个交易日止损（普通周末不算）
     exit_holiday_grace_dynamic_enabled: bool = True
     exit_holiday_grace_max_days: int = 2
     exit_holiday_grace_min_money_flow_score: float = -5.0
@@ -2621,8 +2621,32 @@ def _detect_upthrust_after_distribution(df: pd.DataFrame, cfg: FunnelConfig) -> 
     }
 
 
+def _skipped_weekdays(prev: pd.Timestamp, curr: pd.Timestamp) -> int:
+    """两个相邻交易日之间被跳过的工作日数。0 = 连续交易日，**普通周末也算连续**。
+
+    判据是「中间有没有整个工作日没开盘」，不是「跨了几个自然日」。跨天数会两头出错：
+
+    - 周五 → 周一跨 3 自然日，中间只有周六周日，**是普通周末不是假日**；
+    - 周二 → 周四只跨 2 自然日，中间的周三是工作日却没开盘,**这才是假日**。
+    """
+    gap = (curr - prev).days
+    if gap <= 1:
+        return 0
+    return sum(1 for k in range(1, gap) if (prev + pd.Timedelta(days=k)).weekday() < 5)
+
+
 def _is_holiday_grace(df_s: pd.DataFrame, grace_days: int) -> bool:
-    """检测最近交易日是否处于节后宽限期（跨 ≥3 自然日后的 grace_days 个交易日内）。"""
+    """最近交易日是否在节后宽限期内（前 grace_days 个交易日里有过整日休市）。
+
+    **普通周末不算节后。** 原先的判据是「相邻交易日跨 ≥3 自然日」，而周五到周一
+    正好 3 天,于是**每个周一都被判成节后,止损整段跳过**。2026-08-13~09-07 的
+    生产 trace 里,5 个周一的 ``stop_loss`` 恰好为 0、17 个非周一是 518~1636;
+    风控拦截档周一均值 1.2、非周一 351.9;候选池带止损的票周一恒 0、非周一均值
+    34.9——那批本该吃 −35 分的票,周一一分不扣。
+
+    同一个阈值还漏掉周中单日假(周二→周四跨 2 天,判 False)。改成数「被跳过的
+    工作日」两头都对,见 :func:`_skipped_weekdays`。
+    """
     if grace_days <= 0 or "date" not in df_s.columns or len(df_s) < 2:
         return False
     dates = pd.to_datetime(df_s["date"], errors="coerce")
@@ -2631,7 +2655,7 @@ def _is_holiday_grace(df_s: pd.DataFrame, grace_days: int) -> bool:
     for i in range(1, check_pairs + 1):
         if dates.isna().iloc[-i] or dates.isna().iloc[-i - 1]:
             continue
-        if (dates.iloc[-i] - dates.iloc[-i - 1]).days >= 3:
+        if _skipped_weekdays(dates.iloc[-i - 1], dates.iloc[-i]) >= 1:
             return True
     return False
 

--- a/tests/core/test_wyckoff_engine.py
+++ b/tests/core/test_wyckoff_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from core.wyckoff_engine import (
     FunnelConfig,
@@ -24,6 +25,7 @@ from core.wyckoff_engine import (
     _latest_trade_date,
     _lps_creek_confirmed,
     _recent_sequence_events,
+    _skipped_weekdays,
     _sos_volume_ratio,
     _spring_support_level,
     build_candidate_entries,
@@ -231,7 +233,32 @@ class TestIsHolidayGrace:
         assert _is_holiday_grace(df, 1) is False
 
     def test_weekend_no_grace(self):
+        """周五 → 周一是普通周末,不是节后。
+
+        这条原先断言的是 ``is True``——用例名写着「weekend no grace」,断言写的是给了宽限,
+        把 bug 钉住了。周五到周一正好跨 3 自然日,撞上旧判据 ``>= 3``,于是**每个周一都被
+        判成节后、止损整段跳过**:生产 trace 里 5 个周一 stop_loss 恰好 0,17 个非周一
+        518~1636。
+        """
         df = _make_df(["2024-01-05", "2024-01-08"], [10, 11])
+        assert _is_holiday_grace(df, 1) is False
+
+    def test_midweek_single_day_holiday_triggers_grace(self):
+        """周二 → 周四只跨 2 自然日,但周三整日没开盘,这才是节后。
+
+        旧判据 ``>= 3`` 在这里判 False——它按跨天数算,周中单日假一律漏掉。
+        """
+        df = _make_df(["2024-04-02", "2024-04-04"], [10, 11])
+        assert _is_holiday_grace(df, 1) is True
+
+    def test_monday_holiday_triggers_grace(self):
+        """周五 → 周二:中间的周一整日休市,是节后。跟普通周末只差一个工作日。"""
+        df = _make_df(["2024-01-05", "2024-01-09"], [10, 11])
+        assert _is_holiday_grace(df, 1) is True
+
+    def test_friday_holiday_triggers_grace(self):
+        """周四 → 周一:中间的周五整日休市,是节后。"""
+        df = _make_df(["2024-01-04", "2024-01-08"], [10, 11])
         assert _is_holiday_grace(df, 1) is True
 
     def test_holiday_gap_triggers_grace(self):
@@ -254,6 +281,35 @@ class TestIsHolidayGrace:
         )
         assert _is_holiday_grace(df, 2) is False
         assert _is_holiday_grace(df, 3) is True
+
+    def test_weekend_inside_lookback_does_not_trigger(self):
+        """回看窗里夹着周末也不该触发——每周都有周末,否则这道闸等于常开。
+
+        grace_days=3 时会回看 3 对相邻交易日,周三往前数必然跨过一个周末。
+        """
+        df = _make_df(["2024-01-04", "2024-01-05", "2024-01-08", "2024-01-09"], [10, 11, 12, 13])
+        assert _is_holiday_grace(df, 3) is False
+
+
+class TestSkippedWeekdays:
+    """判据是「中间有几个工作日没开盘」,不是「跨了几个自然日」。"""
+
+    @pytest.mark.parametrize(
+        ("prev", "curr", "expected", "label"),
+        [
+            ("2024-01-04", "2024-01-05", 0, "周四→周五 连续"),
+            ("2024-01-05", "2024-01-08", 0, "周五→周一 普通周末"),
+            ("2024-01-05", "2024-01-09", 1, "周五→周二 周一放假"),
+            ("2024-01-04", "2024-01-08", 1, "周四→周一 周五放假"),
+            ("2024-04-02", "2024-04-04", 1, "周二→周四 周三放假"),
+            ("2024-09-27", "2024-10-08", 6, "国庆长假"),
+        ],
+    )
+    def test_counts_only_missing_weekdays(self, prev, curr, expected, label):
+        assert _skipped_weekdays(pd.Timestamp(prev), pd.Timestamp(curr)) == expected, label
+
+    def test_same_day_is_zero(self):
+        assert _skipped_weekdays(pd.Timestamp("2024-01-05"), pd.Timestamp("2024-01-05")) == 0
 
 
 class TestComputeStopLoss:


### PR DESCRIPTION
## 问题

`_is_holiday_grace` 判「节后」用的是相邻交易日跨了几个自然日,阈值 `>= 3`。周五到周一正好跨 3 天,于是**每个周一都被判成节后**,`_stop_loss_exit_signal` 第一句就 `return None`,止损整段不算。

2026-08-13~09-07 生产 trace(26 天,同日多份按 `generated_at` 取最新):

| 指标 | 周一(5 天) | 非周一(17 天) |
|---|---|---|
| `stop_loss` 计数 | **恰好 0** | 518 ~ 1636 |
| 风控拦截档均值 | 1.2 | 351.9 |
| 候选池里带止损的票 | **恒 0** | 均值 34.9 |
| 候选池总数 | 146.2 | 137.1 |

周一剩下的那点信号全是派发类(2/5/4/6)。宽限期的设计是**跳止损但仍查派发**,这个不对称正是它自己的签名。候选数周一还略高,排除「周一票少」这种解释。

风控拦截档的证据回溯到 08-10,早于 `risk_signal` 列上线,所以不是发布产物。

同一个阈值还漏掉**周中单日假**:周二→周四只跨 2 自然日,中间的周三整日没开盘,旧判据返回 `False`。判据换成数「被跳过的工作日」,两头都对。

`tests/core/test_wyckoff_engine.py:233` 的 `test_weekend_no_grace` 用例名写着周末不给宽限,断言写的却是 `is True`,把 bug 钉住了——跟 #400 的 `test_bench_columns_absent_without_benchmark` 同一个形状。

## 影响范围

**堵住漏算,不是修正已发布的读数。**

`-35` 是 `_formal_candidate_entries`(`core/wyckoff_engine.py:2347-2353`)里的软性排序扣分:`stop_loss` → `risk=1.0`,派发类 → `0.45`,作用是 `- risk * 35.0`。基础分 52~70,扣掉 35 差不多砍半,会把票挤出 `_dedup_candidate_entries` 的前 N,但**不是准入拦截**。四条候选产线只有正式威科夫这一路读 `exit_signals`。

风控拦截档在 `_decision_row` 里排在候选池已捕获**之后**,所以那个档只给没出买点的 L3 通过者打标,不参与筛选。

## 那道闸值不值得开:两个池子结论相反

只用非周一(周一空值是「没查过」不是「查过干净」),日内动量配对,待测 = 被标 `stop_loss`,**负值 = 被标的更差 = 标对了**:

| h | 宽 L2 池 胜率差 / p | 候选池内部 胜率差 / p |
|---|---|---|
| 1 | +1.434 / 0.055 | −2.399 / 0.453 |
| 2 | −2.839 / **0.005** | −5.085 / 0.169 |
| 3 | −4.521 / **0.005** | −2.048 / 0.567 |
| 5 | −6.054 / **0.005** | **+1.436** / 0.687 |
| 10 | −10.782 / **0.005** | **+0.640** / 0.876 |

宽池上这道闸从 T+2 起指对方向且随持有期走强,容差收到 0.25 和留一法都还在。但在 `-35` **实际作用的候选池里,p 值 0.17~0.88 全不显著,符号在 T+5 翻正**。票走到候选池已经过了 L1/L2/L3 加买点确认,`stop_loss` 那点信息前面几层已经吃掉了。

所以这个 PR **不主张提胜率**,只主张判据本身是错的。把 `-35` 推广到另外三条产线的提案随之撤回——依据在错的池子上。

两个池子的可评估日都只有 10~14 天(门槛 `MIN_DAYS=20`),十条判定句全是「尚未可知,不是没通过」。方向可读,量级不可引用。

## 验证

- 定向用例 17 条通过(`-k "grace or SkippedWeekdays"`),含 4 条新增宽限期用例和参数化的 `TestSkippedWeekdays`
- 旧判据 vs 新判据在 7 个场景上逐条对比:3 条钉住真实缺陷(周末误判、周中单日假漏判、回看窗夹周末),4 条是边界补全
  - `git stash` 这条路走不通:删掉实现也删掉了 `_skipped_weekdays`,测试模块 import 失败、pytest 收集就中止,那个 run 什么都证明不了。改成在探针里把旧判据内联重写,两边同时跟预期对比
- 全量 4784 passed / 22 skipped
- `ruff check` 与 `ruff format` 干净
- `scripts/quality_gate.py --ci` 与 `--check-no-sql` 干净
