### PR TITLE
feat(market-gate): RISK_OFF 可降为小仓试探,删掉被实测冲掉的禁买依据

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,11 @@ STEP4_BUY_STOP_MODE=floor
 STEP4_BUY_BLOCK_REGIMES=UNKNOWN,NEUTRAL,PANIC_REPAIR,RISK_OFF,CRASH,BLACK_SWAN
 # 从禁买名单豁免（只作用于下单闸门，不影响 AI 复核/推荐写入）。留空=沿用全部禁买。
 STEP4_BUY_ALLOW_REGIMES=BEAR_REBOUND
+# 把硬防守档降为「小仓试探」而不是完全禁买。只认 RISK_OFF（白名单
+# core/market_trade_mode.PROBE_DOWNGRADABLE_REGIMES）；CRASH/BLACK_SWAN/UNKNOWN 写进去无效，
+# 因为左尾从未量过，且 UNKNOWN 兼作取数失败兜底。留空 = 行为与改动前逐位相同。
+# 开启后 RISK_OFF 走 confirmation_only：写入/AI 打开，配额压到 1 只，禁 ATTACK、禁满配额 L4。
+STEP4_BUY_PROBE_REGIMES=
 # 有离场工单连续多日未执行时冻结新开仓（只拦 PROBE/ATTACK，不影响 EXIT/TRIM/HOLD）
 # 持仓已跌破止损却连续多日未离场时，禁止 ATTACK 重仓（小额 PROBE 仍放行）
 STEP4_BLOCK_BUY_ON_STALE_EXIT=1

--- a/.github/workflows/backtest_grid.yml
+++ b/.github/workflows/backtest_grid.yml
@@ -274,6 +274,9 @@ jobs:
       # PR #305 把 RISK_ON 移出豁免时漏改此处，导致 run 32537955220 的回测仍放行 RISK_ON
       # 并产生 6 笔成交（胜率 16.7%、均收 -5.03%），与实盘口径不符。
       STEP4_BUY_ALLOW_REGIMES: ${{ vars.STEP4_BUY_ALLOW_REGIMES || 'BEAR_REBOUND' }}
+      # 降档档在回测里必须同样可买且同样限 1 只，否则量的不是即将上线的闸门：
+      # 能不能买由 _live_buy_block_regimes 决定，买多少由 _limit_probe_only_selection 决定。
+      STEP4_BUY_PROBE_REGIMES: ${{ vars.STEP4_BUY_PROBE_REGIMES || '' }}
       STEP4_BLOCK_BUY_SIGNAL_TYPES: ${{ vars.STEP4_BLOCK_BUY_SIGNAL_TYPES || '' }}
       FUNNEL_DYNAMIC_POLICY: ${{ vars.FUNNEL_DYNAMIC_POLICY || 'shadow' }}
       FUNNEL_DYNAMIC_POLICY_HORIZON: "5"

--- a/.github/workflows/step4_from_supabase.yml
+++ b/.github/workflows/step4_from_supabase.yml
@@ -59,6 +59,10 @@ jobs:
       # 不以近期样本收益解禁」。样本仍偏小（6 笔），但两次同向为负、方向与放开依据相反，
       # 且禁买是保守侧，故先恢复禁买。
       STEP4_BUY_ALLOW_REGIMES: BEAR_REBOUND
+      # 硬防守档降为小仓试探（只认 RISK_OFF）。留空 = 与此前行为逐位相同。
+      # 必须与 wyckoff_funnel.yml 同源：两个 workflow 都调 complete_step4_decisions，
+      # 只在一边设会让同一天的配额按入口不同而不同。
+      STEP4_BUY_PROBE_REGIMES: ${{ vars.STEP4_BUY_PROBE_REGIMES || '' }}
       STEP4_BLOCK_BUY_SIGNAL_TYPES: ""
       STEP4_REQUIRE_CONFIRMED_BUY_CANDIDATE: "1"
       STEP4_RECOMMEND_DATE: ${{ github.event.inputs.recommend_date }}

--- a/.github/workflows/wyckoff_funnel.yml
+++ b/.github/workflows/wyckoff_funnel.yml
@@ -104,6 +104,16 @@ jobs:
       # 不以近期样本收益解禁」。样本仍偏小（6 笔），但两次同向为负、方向与放开依据相反，
       # 且禁买是保守侧，故先恢复禁买。
       STEP4_BUY_ALLOW_REGIMES: "BEAR_REBOUND"
+      # 把硬防守档降为「小仓试探」而非完全禁买（只认 RISK_OFF，白名单见
+      # core/market_trade_mode.PROBE_DOWNGRADABLE_REGIMES）。默认留空 = 行为与此前逐位相同。
+      # 与 ALLOW 分开是刻意的：ALLOW 在 resolve_market_trade_mode 里对硬防守档故意无效，
+      # 有两条回归测试钉住（test_hard_defense_regimes_ignore_allow_list /
+      # test_defensive_regimes_never_openable_by_allow），不能借道它开这个口。
+      # 开启后 RISK_OFF 走 confirmation_only：配额压到 1 只、禁 ATTACK、禁满配额 L4。
+      # 依据与边界见 _probe_downgraded_regimes 文档串——要点是那句「回测全周期弱势」
+      # 已被实测冲掉（换窗口符号整列翻转、环移 p 全不显著），但漏斗在这些天的选票
+      # 也没跑赢动量匹配对照，故只降档限仓、不整层放开。
+      STEP4_BUY_PROBE_REGIMES: ${{ vars.STEP4_BUY_PROBE_REGIMES || '' }}
       # 留空：叠加验证显示该改动与 5% 止损重复用药。同区间 66 交易日：
       #   仅止损 -5%          总收益 +7.31%  夏普 +0.871  Accum +1.776
       #   禁 evr/sos + 止损5%  总收益 -0.14%  夏普 -0.122  Accum +0.610

--- a/core/backtest_config.py
+++ b/core/backtest_config.py
@@ -16,7 +16,7 @@ from core.backtest_replay import BacktestReplayConfig, MarketBreadthCalculator, 
 from core.candidate_policy import CandidatePolicyConfig
 from core.cash_portfolio import CashPortfolioConfig, expand_portfolio_styles
 from core.mainline_engine import MainlineEngineConfig
-from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES
+from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES, PROBE_DOWNGRADABLE_REGIMES
 
 
 @dataclass(frozen=True)
@@ -203,6 +203,11 @@ def _live_buy_block_regimes() -> frozenset[str]:
     此前误写成 ``BLOCK or 默认集``（取其一而非并集），导致默认集独有的档位在回测里
     仍可买：例如 RISK_ON 只在默认集、不在生产 BLOCK env 里，实盘因并入而禁买，
     回测却放行——恰好是需要验证的那一档。
+
+    STEP4_BUY_PROBE_REGIMES 同样要减掉，且必须与实盘一样先与
+    ``PROBE_DOWNGRADABLE_REGIMES`` 求交：降档后的水温实盘买得到（只是限 1 只），
+    回测若仍当禁买，量出来的就不是即将上线的那套闸门。限仓数量由
+    core.backtest_replay._limit_probe_only_selection 负责，本函数只管「能不能买」。
     """
     import os
 
@@ -211,7 +216,8 @@ def _live_buy_block_regimes() -> frozenset[str]:
         return {item.strip().upper() for item in raw.split(",") if item.strip()}
 
     blocked = _parse("STEP4_BUY_BLOCK_REGIMES") | set(EXECUTE_BLOCK_NEW_BUY_REGIMES)
-    return frozenset(blocked - _parse("STEP4_BUY_ALLOW_REGIMES"))
+    exempt = _parse("STEP4_BUY_ALLOW_REGIMES") | (_parse("STEP4_BUY_PROBE_REGIMES") & set(PROBE_DOWNGRADABLE_REGIMES))
+    return frozenset(blocked - exempt)
 
 
 def _validate_dates_and_trade_params(

--- a/core/backtest_replay.py
+++ b/core/backtest_replay.py
@@ -43,7 +43,7 @@ from core.candidate_ranker import rank_l3_candidates
 from core.candidate_tracks import candidate_entry_track
 from core.mainline_engine import MainlineEngineConfig
 from core.market_breadth import calc_market_breadth
-from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES, PROBE_ONLY_REGIMES, normalize_regime
+from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES, normalize_regime, probe_only_regimes
 from core.signal_confirmation import PendingPool, score_springboard_abc
 from core.wyckoff_engine import FunnelConfig, FunnelResult, run_funnel
 
@@ -401,7 +401,7 @@ def _limit_probe_only_selection(
     regime: str,
     mode: str,
 ) -> tuple[_RankedSelection, int]:
-    if mode != "live" or normalize_regime(regime) not in PROBE_ONLY_REGIMES or len(selected.codes) <= 1:
+    if mode != "live" or normalize_regime(regime) not in probe_only_regimes() or len(selected.codes) <= 1:
         return selected, 0
     kept = selected.codes[:1]
     return (

--- a/core/market_trade_mode.py
+++ b/core/market_trade_mode.py
@@ -11,6 +11,9 @@ OVERHEAT_SHADOW_REGIMES = frozenset({"RISK_ON"})
 REPAIR_REVIEW_REGIMES = frozenset({"BEAR_REBOUND", "PANIC_REPAIR"})
 REPAIR_PROBE_REGIMES = frozenset({"PANIC_REPAIR_CONFIRMED", "PANIC_REPAIR_INTRADAY"})
 CAUTION_ONLY_REGIMES = frozenset({"CAUTION"})
+# 运维可以显式降到 PROBE 档（而非完全禁买）的硬防守水温白名单。
+# 只有 RISK_OFF：CRASH/BLACK_SWAN/UNKNOWN 不在其中，见 _probe_downgraded_regimes 的实测依据。
+PROBE_DOWNGRADABLE_REGIMES = frozenset({"RISK_OFF"})
 # 盘前取数失败的专用标记：与 UNKNOWN（盘前模型明确判定「看不清」）区分开，
 # 让外部数据源抖动不再冒充风险事件。下游按「缺失」处理，回落到收盘态 benchmark。
 PREMARKET_DATA_GAP = "DATA_GAP"
@@ -147,7 +150,9 @@ def oms_buy_block_regimes() -> frozenset[str]:
     raw = os.getenv("STEP4_BUY_BLOCK_REGIMES", _DEFAULT_OMS_BUY_BLOCK)
     values = {item.strip().upper() for item in raw.split(",") if item.strip() and item.strip().upper() != "COOLDOWN"}
     merged = values | set(EXECUTE_BLOCK_NEW_BUY_REGIMES)
-    return frozenset(merged - _explicitly_allowed_regimes())
+    # PROBE 降档也必须在这里减掉，否则又是上面那种错位的镜像：写入侧按 PROBE 放行、
+    # OMS 侧仍禁买，报告写「谨慎试探」而一股也买不到。降档水温买得少，但买得到。
+    return frozenset(merged - _explicitly_allowed_regimes() - _probe_downgraded_regimes())
 
 
 def _shadow_only_trade_mode(
@@ -211,22 +216,130 @@ def _explicitly_allowed_regimes() -> frozenset[str]:
     return frozenset(item.strip().upper() for item in raw.split(",") if item.strip())
 
 
+def _probe_downgraded_regimes() -> frozenset[str]:
+    """读 STEP4_BUY_PROBE_REGIMES —— 把硬防守档降为 PROBE 档，而不是完全禁买。
+
+    **为什么不复用 STEP4_BUY_ALLOW_REGIMES**：ALLOW 表示「完全豁免」，落到
+    ``mainline_active``（全 L4 + 主题晋级 + 满配额）。硬防守档需要的是「小仓」而不是
+    「满仓」，语义不同。且 ALLOW 对 NO_NEW_BUY 无效是**有意设计**，由
+    ``test_hard_defense_regimes_ignore_allow_list`` 与
+    ``test_defensive_regimes_never_openable_by_allow`` 两处钉住，不能当疏漏去补——
+    补了等于把 CRASH/BLACK_SWAN/UNKNOWN 一起打开。故另开一个更窄的入口。
+
+    **白名单只有 RISK_OFF**（``PROBE_DOWNGRADABLE_REGIMES``）。写死不读 env，是因为
+    下面的依据只覆盖 RISK_OFF 一档：
+
+    1. ``observe_only`` 那句 reason 原文是「回测全周期弱势，新开仓胜率不足」。拿全市场
+       前瞻收益量两个面板窗口、配环移控制（保 run 结构，不是打散日期，故标签的连续段
+       长度不变），**这句立论不成立**：
+
+       | 窗口 | 天数 | h=1 | h=2 | h=3 | h=5 | h=10 |
+       |------|-----:|----:|----:|----:|----:|-----:|
+       | 2026-07-01..09-07 | 35 | -0.16 | -0.57 | -1.05 | -1.56 | -0.72 |
+       | 2026-04-20..09-07 | 67 | **+0.53** | **+0.99** | **+0.25** | **+0.73** | **+1.26** |
+
+       （禁新仓日均值 − 允许日均值，负值=闸门拦对了。）换个窗口符号整列翻转，环移 p
+       从 0.147 到 0.977 无一显著，不重叠日相位扫描在 h=2/3/5 上符号不一致。即这个
+       标签**没有携带关于市场强弱的稳定信息**。
+
+    2. 那些被拦的天里市场有右尾：全市场中位数每个 h 都为正（+0.13/+0.29/+0.45/+0.50/
+       +2.08），胜率 49.2~59.1%，p90 +5.25~+16.21，头部一成均值 +8.98~+25.41。
+       即「熊市也有主线」在数据上站得住，那些天不是买不了。
+
+    **为什么仍然默认关闭**（本函数默认返回空集）：同期被拦日的漏斗自选票，对照同日
+    同流动性池、同 20 日动量（±3.0pct 逐只最近邻无放回替换，残差动量 +0.13~+0.15）
+    并没有量到正 edge——h=3 差 8.37 点、h=5 差 5.49 点。但被拦日只有 14/13/12/12/7 天，
+    全在 MIN_DAYS=20 门槛下，所以那是**尚未可知**而非「已证明更差」。开这道门的目的
+    正是攒够这批天数：PROBE 档每天最多 1 只、禁 ATTACK、额度受
+    ``STEP4_REPAIR_PROBE_BUDGET_LIMIT`` 限制，敞口远小于 ``mainline_active``。
+
+    **CRASH/BLACK_SWAN/UNKNOWN 为何不进白名单**：上面量的是均值与胜率，**没有量左尾**。
+    一个在均值上没判别力的标签仍可能在尾部有用，而这三档正是尾部兜底。UNKNOWN 另有
+    独立理由——它同时是取数失败的兜底值（见 merge_premarket_regime），放开它等于让
+    数据抖动变成开仓许可。
+
+    回退：清空 STEP4_BUY_PROBE_REGIMES 即刻恢复禁买，两侧同时关闭。
+    """
+    import os
+
+    raw = os.getenv("STEP4_BUY_PROBE_REGIMES", "").strip()
+    requested = {item.strip().upper() for item in raw.split(",") if item.strip()}
+    return frozenset(requested & PROBE_DOWNGRADABLE_REGIMES)
+
+
+def probe_only_regimes() -> frozenset[str]:
+    """当前实际按 PROBE 档限仓的水温集合 —— 限仓侧的唯一真源。
+
+    在静态的 ``PROBE_ONLY_REGIMES`` 之外并入被 ``STEP4_BUY_PROBE_REGIMES`` 降档的
+    硬防守水温。所有限仓判定都必须走本函数而不是那个常量：漏一处，降档后的水温就会
+    掉到满配额分支（``max_new_buy_names`` 的 ``limits.neutral``），从「硬拦」直接跳成
+    「满仓」——恰好是这次改动要避免的那个反面。
+    """
+    return frozenset(PROBE_ONLY_REGIMES | _probe_downgraded_regimes())
+
+
+def _confirmation_only_trade_mode(regime: str, *, reason: str) -> MarketTradeMode:
+    """「最多一只二次确认 PROBE」档（CAUTION 与降档后的硬防守档共用）。
+
+    共用同一个构造器是刻意的：两者的权限位必须逐字一致，否则降档路径会悄悄拿到
+    CAUTION 没有的权限。``mode`` 也刻意复用 ``confirmation_only`` —— 下游有十余处按
+    mode 字符串分发（screen_tools、funnel_render、execution_playbook、candidate_actions
+    的 readiness 映射），新增一个 mode 值会让这些分发全部落到 default，而
+    ``candidate_action_info`` 对未注册状态的兜底是 ``blocks_direct_buy=False``（放行），
+    静默走错的方向恰好是放松。只有 ``reason`` 按水温区分，供运维回溯。
+    """
+    return MarketTradeMode(
+        regime=regime,
+        mode="confirmation_only",
+        label="谨慎试探",
+        action="谨慎试探：最多一只二次确认后的 PROBE，禁止 ATTACK",
+        reason=reason,
+        allow_ai_review=True,
+        allow_recommendation_write=True,
+        allow_full_l4=False,
+        allow_bypass_review=False,
+        allow_theme_promotion=False,
+    )
+
+
+def _hard_defense_trade_mode(regime_norm: str) -> MarketTradeMode | None:
+    """硬防守档的两种落点：降档小仓，或整层禁新仓。非硬防守档返回 None。
+
+    抽成一支是为了让「降档」与「禁买」在同一处相邻可读——两者必须一起改，
+    分散到主分发链里容易只动一半。注意顺序：降档判定要在 NO_NEW_BUY 之前，
+    否则永远短路不到。
+    """
+    if regime_norm in _probe_downgraded_regimes():
+        return _confirmation_only_trade_mode(
+            regime_norm,
+            reason=f"{regime_norm} 已按 STEP4_BUY_PROBE_REGIMES 降为小仓试探：只开放一只二次确认 PROBE",
+        )
+    if regime_norm not in NO_NEW_BUY_REGIMES:
+        return None
+    return MarketTradeMode(
+        regime=regime_norm,
+        mode="observe_only",
+        label="禁止新仓",
+        action="禁止新仓：仅影子观察，不送AI、不写推荐、不生成新买入",
+        # 注意别写回「回测全周期弱势／新开仓胜率不足」：那句已被实测冲掉——67 天面板上
+        # 禁新仓日的全市场胜率反而比允许日高 3~7 点，且换窗口符号整列翻转、环移 p
+        # 全不显著（见 _probe_downgraded_regimes）。这一档现在的依据是「左尾未量过」
+        # 的防守性保留，而不是已证明的弱势。
+        reason=f"{regime_norm} 属硬防守档：左尾风险未经检验，默认不新开（可按 STEP4_BUY_PROBE_REGIMES 降为小仓）",
+        allow_ai_review=False,
+        allow_recommendation_write=False,
+        allow_full_l4=False,
+        allow_bypass_review=False,
+        allow_theme_promotion=False,
+    )
+
+
 def resolve_market_trade_mode(regime: str | None) -> MarketTradeMode:
     regime_norm = normalize_regime(regime)
     allowed = _explicitly_allowed_regimes()
-    if regime_norm in NO_NEW_BUY_REGIMES:
-        return MarketTradeMode(
-            regime=regime_norm,
-            mode="observe_only",
-            label="禁止新仓",
-            action="禁止新仓：仅影子观察，不送AI、不写推荐、不生成新买入",
-            reason=f"{regime_norm} 回测全周期弱势，新开仓胜率不足",
-            allow_ai_review=False,
-            allow_recommendation_write=False,
-            allow_full_l4=False,
-            allow_bypass_review=False,
-            allow_theme_promotion=False,
-        )
+    hard_defense = _hard_defense_trade_mode(regime_norm)
+    if hard_defense is not None:
+        return hard_defense
     if regime_norm in OVERHEAT_SHADOW_REGIMES and regime_norm not in allowed:
         return _shadow_only_trade_mode(
             regime_norm,
@@ -246,17 +359,9 @@ def resolve_market_trade_mode(regime: str | None) -> MarketTradeMode:
     if regime_norm in REPAIR_PROBE_REGIMES:
         return _confirmed_repair_trade_mode(regime_norm)
     if regime_norm in CAUTION_ONLY_REGIMES:
-        return MarketTradeMode(
-            regime=regime_norm,
-            mode="confirmation_only",
-            label="谨慎试探",
-            action="谨慎试探：最多一只二次确认后的 PROBE，禁止 ATTACK",
+        return _confirmation_only_trade_mode(
+            regime_norm,
             reason="情绪扰动期只开放小额试探，候选必须经过确认支撑",
-            allow_ai_review=True,
-            allow_recommendation_write=True,
-            allow_full_l4=False,
-            allow_bypass_review=False,
-            allow_theme_promotion=False,
         )
     if regime_norm in oms_buy_block_regimes():
         # 运维把这一档加进了 STEP4_BUY_BLOCK_REGIMES：买不到就别写成正式推荐。

--- a/integrations/supabase_market_signal.py
+++ b/integrations/supabase_market_signal.py
@@ -18,8 +18,8 @@ from supabase import Client
 from core.constants import TABLE_MARKET_SIGNAL_DAILY
 from core.market_trade_mode import (
     KNOWN_MARKET_REGIMES,
-    PROBE_ONLY_REGIMES,
     merge_premarket_regime,
+    probe_only_regimes,
     resolve_market_trade_mode,
 )
 from integrations.supabase_base import create_admin_client as _get_supabase_admin_client
@@ -381,7 +381,7 @@ def _select_market_strategy(
     trade_mode = resolve_market_trade_mode(merge_premarket_regime(permission_basis, premarket_slot))
     if not trade_mode.allow_recommendation_write:
         return {**strategy, "action": "只管理已有仓位，禁止新开仓"}
-    if trade_mode.regime in PROBE_ONLY_REGIMES:
+    if trade_mode.regime in probe_only_regimes():
         return {**strategy, "action": "最多一只二次确认候选执行小额 PROBE，禁止 ATTACK"}
     return strategy
 

--- a/tests/integrations/test_supabase_market_signal.py
+++ b/tests/integrations/test_supabase_market_signal.py
@@ -1,5 +1,5 @@
 import integrations.supabase_market_signal as market_signal_module
-from core.market_trade_mode import PROBE_ONLY_REGIMES, merge_premarket_regime, resolve_market_trade_mode
+from core.market_trade_mode import merge_premarket_regime, probe_only_regimes, resolve_market_trade_mode
 from integrations.supabase_market_signal import (
     _merge_latest_market_signal_rows,
     compose_market_state,
@@ -57,7 +57,7 @@ def _assert_banner_matches_trade_mode(benchmark: str, premarket: str) -> None:
         assert "禁止新开仓" in action, f"{where} 横幅越过执行层闸门"
     else:
         assert "禁止新开仓" not in action, f"{where} 横幅比执行层更严"
-        if mode.regime in PROBE_ONLY_REGIMES:
+        if mode.regime in probe_only_regimes():
             assert "PROBE" in action and "禁止 ATTACK" in action, where
 
 

--- a/tests/workflows/test_probe_regimes_chain.py
+++ b/tests/workflows/test_probe_regimes_chain.py
@@ -1,0 +1,324 @@
+"""Tests for STEP4_BUY_PROBE_REGIMES：把硬防守档降为小仓试探，而不是完全禁买。
+
+起因是一个实测结论：NO_NEW_BUY 那句「回测全周期弱势、新开仓胜率不足」的依据不成立。
+按全市场前瞻收益、用保留 run 结构的环移控制量（h ∈ {1,2,3,5,10}，非固定 T+5）：
+
+- 49 天面板（2026-07-01~09-07，35 个可评估日）：禁新仓日**更差**，均值差
+  -0.16 / -0.57 / -1.05 / -1.56 / -0.72。
+- 97 天面板（2026-04-20~09-07，67 个可评估日）：禁新仓日**更好**，均值差
+  +0.53 / +0.99 / +0.73 / +1.26，胜率差 +5.43 / +7.10 / +3.75 / +3.48 / +3.03。
+- 两个面板环移 p 全在 0.147~0.977（无一显著），开启率在各次环移下守在 [48%,52%]；
+  不重叠相位扫描在 h=2/3/5 上符号不一致。
+
+换窗口就翻号，所以两个方向都不能单独引用——这个标签对市场强弱没有稳定信息。
+但禁新仓日的全市场中位数在每个 h 上都为正（+0.13 / +0.29 / +0.45 / +0.50 / +2.08），
+胜率 49.2%~59.1%，顶部十分位均值 +8.98~+25.41：那些天是买得到东西的。
+
+反过来，漏斗自己在这些天的选票**没有**跑赢动量匹配对照（逐只 ±3.0pct 近邻替换、
+不放回、5 个种子；禁新仓日 14/13/12/12/7 天，均低于 MIN_DAYS=20，判定是
+「尚未可知（天数不足）」而非「跑输」）。所以不能整层放开，只能降档限仓。
+
+因此本变量的语义是「小仓试探」而不是「解除拦截」：走既有 confirmation_only 档，
+配额压到 1 只、禁 ATTACK、禁满配额 L4。默认不设该变量，行为与改动前逐位相同。
+
+CRASH/BLACK_SWAN/UNKNOWN 不在白名单：左尾从未量过（上面全是均值与胜率），
+且 UNKNOWN 兼作取数失败的兜底档，放开它等于把数据源抖动变成买入许可。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.market_trade_mode import (
+    PROBE_DOWNGRADABLE_REGIMES,
+    oms_buy_block_regimes,
+    probe_only_regimes,
+    resolve_market_trade_mode,
+)
+from workflows.step4_decision_parser import NewBuyLimits, max_new_buy_names
+from workflows.step4_decisions import complete_step4_decisions
+from workflows.step4_models import DecisionItem, PortfolioState, Step4RuntimeConfig
+
+# neutral=3 是刻意的：两者都取 1 时「压到 1 只」与「满配额」数值相同，
+# 断言会同时通过，看不出降档到底有没有生效。
+LIMITS = NewBuyLimits(neutral=3, caution=1)
+PROD_BLOCK = "UNKNOWN,NEUTRAL,PANIC_REPAIR,RISK_OFF,CRASH,BLACK_SWAN"
+
+
+@pytest.fixture(autouse=True)
+def _prod_env(monkeypatch):
+    monkeypatch.setenv("STEP4_BUY_BLOCK_REGIMES", PROD_BLOCK)
+    monkeypatch.setenv("STEP4_BUY_ALLOW_REGIMES", "BEAR_REBOUND")
+    monkeypatch.delenv("STEP4_BUY_PROBE_REGIMES", raising=False)
+
+
+def _blocked() -> frozenset[str]:
+    from workflows.step4_order_config import step4_order_config_from_env
+
+    return frozenset(step4_order_config_from_env().buy_block_regimes)
+
+
+def _new_buy(code: str, score: float, *, action: str = "PROBE") -> DecisionItem:
+    return DecisionItem(
+        code=code,
+        name="测试",
+        action=action,
+        entry_zone_min=10.0,
+        entry_zone_max=11.0,
+        stop_loss=9.0,
+        trim_ratio=None,
+        tape_condition="",
+        invalidate_condition="",
+        is_add_on=False,
+        reason="主线买点确认",
+        confidence=0.7,
+        funnel_score=score,
+    )
+
+
+def _complete(regime: str, decisions: list[DecisionItem]):
+    from workflows.step4_order_config import step4_order_config_from_env
+
+    return complete_step4_decisions(
+        decisions,
+        PortfolioState(positions=[], free_cash=100_000.0, total_equity=100_000.0),
+        {},
+        regime,
+        Step4RuntimeConfig(new_buy_limits=LIMITS),
+        step4_order_config_from_env(),
+    )
+
+
+class TestDefaultClosed:
+    """不设变量时必须与改动前逐位相同——这是回退路径，不是可选项。"""
+
+    def test_risk_off_still_observe_only(self):
+        mode = resolve_market_trade_mode("RISK_OFF")
+        assert mode.mode == "observe_only"
+        assert mode.allow_recommendation_write is False
+        assert mode.allow_ai_review is False
+
+    def test_risk_off_still_blocked_everywhere(self):
+        from core.backtest_config import _live_buy_block_regimes
+
+        assert "RISK_OFF" in _blocked()
+        assert "RISK_OFF" in _live_buy_block_regimes()
+        assert max_new_buy_names("RISK_OFF", LIMITS, _blocked()) == 0
+
+    def test_probe_set_unchanged(self):
+        assert probe_only_regimes() == frozenset({"CAUTION", "PANIC_REPAIR_CONFIRMED", "PANIC_REPAIR_INTRADAY"})
+
+    def test_empty_value_is_not_a_wildcard(self, monkeypatch):
+        """空串/纯逗号不得被解析成「全部降档」。"""
+        for raw in ("", "   ", ",", " , ,"):
+            monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", raw)
+            assert resolve_market_trade_mode("RISK_OFF").mode == "observe_only", raw
+            assert "RISK_OFF" in _blocked(), raw
+
+
+class TestRiskOffDowngradedToProbe:
+    @pytest.fixture(autouse=True)
+    def _open_probe(self, monkeypatch):
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", "RISK_OFF")
+
+    def test_mode_is_confirmation_only(self):
+        """复用既有 mode 字符串：下游十余处按 mode 分发，新值会静默落到 default 分支。"""
+        mode = resolve_market_trade_mode("RISK_OFF")
+        assert mode.mode == "confirmation_only"
+        assert mode.label == "谨慎试探"
+
+    def test_write_and_ai_open(self):
+        """两者都要开：write 关着候选进不了推荐，等于降档白做。"""
+        mode = resolve_market_trade_mode("RISK_OFF")
+        assert mode.allow_recommendation_write is True
+        assert mode.allow_ai_review is True
+
+    def test_full_quota_paths_stay_shut(self):
+        """降档只放开「买不买」，不放开「买多少」与「凭什么买」。"""
+        mode = resolve_market_trade_mode("RISK_OFF")
+        assert mode.allow_full_l4 is False
+        assert mode.allow_bypass_review is False
+        assert mode.allow_theme_promotion is False
+
+    def test_reason_no_longer_claims_measured_weakness(self):
+        """旧那句「回测全周期弱势／新开仓胜率不足」已被实测冲掉，不得再出现。"""
+        reason = resolve_market_trade_mode("RISK_OFF").reason
+        assert "胜率不足" not in reason
+        assert "全周期弱势" not in reason
+
+    def test_oms_no_longer_blocks(self):
+        assert "RISK_OFF" not in _blocked()
+
+    def test_backtest_gate_agrees(self):
+        """回测与实盘同向，否则量的不是即将上线的这套闸门。"""
+        from core.backtest_config import _live_buy_block_regimes
+
+        assert "RISK_OFF" not in _live_buy_block_regimes()
+
+    def test_quota_is_exactly_one_not_full(self):
+        """这条是整个改动的要害。
+
+        ``max_new_buy_names`` 先看 blocked（已减豁免）再看 probe 集合：RISK_OFF 过了
+        第一道却不在第二道里，就会掉到 ``limits.neutral`` 满配额分支——「硬拦」直接
+        跳成「满仓」，恰是用户要的「熊市小仓」的反面。
+        """
+        assert max_new_buy_names("RISK_OFF", LIMITS, _blocked()) == 1
+        assert LIMITS.neutral > 1, "neutral 必须 >1，否则本断言无区分力"
+
+    def test_actual_trim_keeps_exactly_one(self):
+        """提示词说 1 只、真实裁剪也要留 1 只——两处读同一份集合。"""
+        out = _complete("RISK_OFF", [_new_buy(f"00000{i}", 100.0 - i) for i in range(1, 5)])
+        kept = [d for d in out if not d.system_reject_reason]
+        assert len(kept) == 1
+        assert kept[0].code == "000001"
+
+    def test_order_engine_approves_probe_and_rejects_attack(self):
+        """小仓的另一半在下单层：PROBE 过、ATTACK 拒。
+
+        engine 先按 ``config.buy_block_regimes`` 整体拦截，再按 probe 集合拒 ATTACK。
+        两处必须都读到降档后的集合，否则要么全拒（等于没降档）、要么 ATTACK 也放过
+        （等于满仓）。
+        """
+        engine = self._engine("RISK_OFF")
+        probe_tickets, _ = engine.process([_new_buy("000001", 100.0, action="PROBE")])
+        attack_tickets, _ = engine.process([_new_buy("000001", 100.0, action="ATTACK")])
+
+        assert probe_tickets[0].status == "APPROVED"
+        assert attack_tickets[0].status == "NO_TRADE"
+        assert "只允许小额 PROBE" in attack_tickets[0].reason
+
+    def test_order_engine_rejects_both_when_var_unset(self, monkeypatch):
+        """同一段代码，变量收回就该两边都拒——证明上一条测的是降档而非默认行为。"""
+        monkeypatch.delenv("STEP4_BUY_PROBE_REGIMES", raising=False)
+        engine = self._engine("RISK_OFF")
+        for action in ("PROBE", "ATTACK"):
+            tickets, _ = engine.process([_new_buy("000001", 100.0, action=action)])
+            assert tickets[0].status == "NO_TRADE", action
+            assert "系统性风控拦截" in tickets[0].reason, action
+
+    @staticmethod
+    def _engine(regime: str):
+        from workflows.step4_order_config import step4_order_config_from_env
+        from workflows.step4_order_engine import WyckoffOrderEngine
+
+        return WyckoffOrderEngine(
+            total_equity=100_000,
+            free_cash=50_000,
+            position_map={},
+            latest_price_map={"000001": 10.5},
+            atr_map={"000001": 0.2},
+            market_regime=regime,
+            config=step4_order_config_from_env(),
+        )
+
+    def test_replay_truncates_live_selection_to_one(self):
+        """回测 live 模式的限仓也走同一函数，否则回测按满仓量、实盘按 1 只买。"""
+        from core.backtest_replay import _limit_probe_only_selection, _RankedSelection
+
+        selection = _RankedSelection(
+            ["000001", "000002", "000003"],
+            {"000001": 100.0, "000002": 90.0, "000003": 80.0},
+            {},
+            {},
+        )
+        kept, dropped = _limit_probe_only_selection(selection, "RISK_OFF", "live")
+        assert kept.codes == ["000001"]
+        assert dropped == 2
+        assert kept.score_map == {"000001": 100.0}
+
+    def test_replay_keeps_all_when_var_unset(self, monkeypatch):
+        monkeypatch.delenv("STEP4_BUY_PROBE_REGIMES", raising=False)
+        from core.backtest_replay import _limit_probe_only_selection, _RankedSelection
+
+        selection = _RankedSelection(["000001", "000002"], {}, {}, {})
+        kept, dropped = _limit_probe_only_selection(selection, "RISK_OFF", "live")
+        assert kept.codes == ["000001", "000002"]
+        assert dropped == 0
+
+
+class TestWhitelistHolds:
+    """白名单求交是唯一防线：变量里写别的档位必须无效。"""
+
+    def test_whitelist_is_risk_off_only(self):
+        assert PROBE_DOWNGRADABLE_REGIMES == frozenset({"RISK_OFF"})
+
+    def test_left_tail_unmeasured_regimes_stay_shut(self, monkeypatch):
+        """CRASH/BLACK_SWAN/UNKNOWN 左尾未量过，UNKNOWN 还兼取数失败兜底。"""
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", "CRASH,BLACK_SWAN,UNKNOWN")
+        for regime in ("CRASH", "BLACK_SWAN", "UNKNOWN"):
+            mode = resolve_market_trade_mode(regime)
+            assert mode.mode == "observe_only", regime
+            assert mode.allow_recommendation_write is False, regime
+            assert regime in _blocked(), regime
+            assert max_new_buy_names(regime, LIMITS, _blocked()) == 0, regime
+
+    def test_probe_var_cannot_open_neutral_or_panic_repair(self, monkeypatch):
+        """非硬防守档也不能被这个变量顺带改语义。"""
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", "NEUTRAL,PANIC_REPAIR,RISK_ON")
+        assert resolve_market_trade_mode("NEUTRAL").mode == "execution_blocked"
+        assert resolve_market_trade_mode("PANIC_REPAIR").mode == "repair_review"
+        assert resolve_market_trade_mode("RISK_ON").allow_recommendation_write is False
+
+    def test_mixed_value_keeps_only_whitelisted(self, monkeypatch):
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", "CRASH,RISK_OFF,BLACK_SWAN")
+        assert probe_only_regimes() & {"CRASH", "BLACK_SWAN"} == frozenset()
+        assert "RISK_OFF" in probe_only_regimes()
+
+    def test_value_is_case_and_space_insensitive(self, monkeypatch):
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", "  risk_off , ")
+        assert resolve_market_trade_mode("RISK_OFF").mode == "confirmation_only"
+
+
+class TestCautionUnchanged:
+    """CAUTION 与降档档共用构造器，权限位必须逐字一致，且 CAUTION 自身不能被改到。"""
+
+    def test_caution_matches_downgraded_risk_off(self, monkeypatch):
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", "RISK_OFF")
+        caution = resolve_market_trade_mode("CAUTION")
+        risk_off = resolve_market_trade_mode("RISK_OFF")
+        for field in (
+            "mode",
+            "label",
+            "action",
+            "allow_ai_review",
+            "allow_recommendation_write",
+            "allow_full_l4",
+            "allow_bypass_review",
+            "allow_theme_promotion",
+        ):
+            assert getattr(caution, field) == getattr(risk_off, field), field
+        # 只有 reason 按水温区分，供运维回溯是哪条路径放行的。
+        assert caution.reason != risk_off.reason
+
+    def test_caution_quota_still_one(self):
+        assert max_new_buy_names("CAUTION", LIMITS, _blocked()) == 1
+
+    def test_caution_action_text_is_regime_agnostic(self):
+        """不能复用 repair_probe：它的下游文案硬编码「修复成立」，
+        在 RISK_OFF 日会印出一句假话。"""
+        action = resolve_market_trade_mode("CAUTION").action
+        assert "修复成立" not in action
+        assert "PROBE" in action and "禁止 ATTACK" in action
+
+
+class TestBothGatesMoveTogether:
+    """写入侧与 OMS 侧必须同源。
+
+    2026-08 的事故形态：运维把 NEUTRAL 加进 BLOCK，只有 OMS 照办，写入侧照写，
+    留下 16 行买不到的正式推荐（20260720×9 / 20260721×4 / 20260723×3，全 l4_springboard）。
+    降档是那次错位的镜像风险：写入侧放行而 OMS 仍禁买，报告写「谨慎试探」而一股买不到。
+    """
+
+    @pytest.mark.parametrize("probe_value", ["", "RISK_OFF"])
+    def test_write_and_oms_agree(self, monkeypatch, probe_value):
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", probe_value)
+        write_open = resolve_market_trade_mode("RISK_OFF").allow_recommendation_write
+        oms_open = "RISK_OFF" not in oms_buy_block_regimes()
+        assert write_open is oms_open
+
+    @pytest.mark.parametrize("probe_value", ["", "RISK_OFF"])
+    def test_quota_and_write_agree(self, monkeypatch, probe_value):
+        monkeypatch.setenv("STEP4_BUY_PROBE_REGIMES", probe_value)
+        write_open = resolve_market_trade_mode("RISK_OFF").allow_recommendation_write
+        quota = max_new_buy_names("RISK_OFF", LIMITS, _blocked())
+        assert write_open is (quota > 0)

--- a/workflows/step4_decision_parser.py
+++ b/workflows/step4_decision_parser.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
-from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES, PROBE_ONLY_REGIMES, normalize_regime
+from core.market_trade_mode import EXECUTE_BLOCK_NEW_BUY_REGIMES, normalize_regime, probe_only_regimes
 from core.portfolio_symbol import normalize_portfolio_code
 from utils.json_text import extract_json_block
 from workflows.step4_models import DecisionItem, NewBuyLimits
@@ -98,7 +98,7 @@ def max_new_buy_names(
     blocked = blocked_regimes if blocked_regimes is not None else EXECUTE_BLOCK_NEW_BUY_REGIMES
     if regime in blocked:
         return 0
-    if regime in PROBE_ONLY_REGIMES:
+    if regime in probe_only_regimes():
         return max(min(limits.caution, 1), 0)
     return max(limits.neutral, 0)
 

--- a/workflows/step4_order_engine.py
+++ b/workflows/step4_order_engine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 
-from core.market_trade_mode import PROBE_ONLY_REGIMES, normalize_regime
+from core.market_trade_mode import normalize_regime, probe_only_regimes
 from core.portfolio_symbol import portfolio_lot_size
 from core.portfolio_valuation import portfolio_currency
 from workflows.step4_models import (
@@ -650,7 +650,7 @@ class WyckoffOrderEngine:
             )
         if ctx.action in {"PROBE", "ATTACK"} and self.market_regime in self.config.buy_block_regimes:
             return self._no_trade(ctx.dec, ctx.name, f"系统性风控拦截: regime={self.market_regime} 禁止买入")
-        if ctx.action == "ATTACK" and self.market_regime in PROBE_ONLY_REGIMES:
+        if ctx.action == "ATTACK" and self.market_regime in probe_only_regimes():
             return self._no_trade(ctx.dec, ctx.name, "防守试探阶段只允许小额 PROBE，禁止 ATTACK")
         for validator in (self._validate_buy_stop, self._validate_add_on):
             ticket = validator(ctx)


### PR DESCRIPTION
## 问题 / 变更摘要

`NO_NEW_BUY` 档的 `reason` 写着「回测全周期弱势、新开仓胜率不足」。这句话不成立。

按全市场前瞻收益、用保留 run 结构的环移控制去量（h ∈ {1,2,3,5,10}，不是单个 T+5）：

| 面板 | 可评估日 | 均值差（禁新仓日 − 允许日） |
|---|---|---|
| 49 天（07-01~09-07） | 35 | −0.16 / −0.57 / −1.05 / −1.56 / −0.72 → **更差** |
| 97 天（04-20~09-07） | 67 | +0.53 / +0.99 / +0.73 / +1.26 → **更好** |

97 天面板上胜率差 +5.43 / +7.10 / +3.75 / +3.48 / +3.03。

换窗口符号整列翻转；环移 p 全在 0.147~0.977（无一显著，且各次环移下开启率守在
[48%,52%]，控制没漂）；不重叠相位扫描在 h=2/3/5 上符号不一致。

**两个方向都不能单独引用**——这个标签对市场强弱没有稳定信息。所以那句依据先删掉，
换成「左尾未量过的防守性保留」，这是它现在真实的依据。

同时这些天确实买得到东西：禁新仓日全市场中位数在每个 h 上都为正（+0.13 / +0.29 /
+0.45 / +0.50 / +2.08），胜率 49.2%~59.1%，顶部十分位均值 +8.98~+25.41。

**但漏斗自己在这些天的选票没有跑赢动量匹配对照**（逐只 ±3.0pct 近邻替换、不放回、
5 个种子）。禁新仓日只有 14/13/12/12/7 天，全部低于 `MIN_DAYS=20`，判定是
**「尚未可知（天数不足）」而不是「跑输」**。

所以不整层放开，只降档限仓。

## 改了什么

新增 `STEP4_BUY_PROBE_REGIMES`，白名单 `PROBE_DOWNGRADABLE_REGIMES = {RISK_OFF}`。

**默认留空，行为与改动前逐位相同。** 开启后 RISK_OFF 走既有 `confirmation_only` 档：
写入/AI 打开，配额压到 1 只，禁 ATTACK，禁满配额 L4。

### 三个刻意的选择

1. **不走 `STEP4_BUY_ALLOW_REGIMES`。** 它对硬防守档故意无效，有两条回归测试钉住
   （`test_hard_defense_regimes_ignore_allow_list` /
   `test_defensive_regimes_never_openable_by_allow`）。借道它会连带打开
   CRASH/BLACK_SWAN/UNKNOWN。两条老测试原样保留、未改一字。
2. **不引入新 mode 字符串。** 下游十余处按 mode 分发，新值会静默落到 default 分支；
   而 `candidate_action_info` 对未注册状态的兜底是 `blocks_direct_buy=False`——静默
   走错的方向恰好是放松。也没复用 `repair_probe`：它的下游文案硬编码「修复成立」，
   在 RISK_OFF 日会印出一句假话。
3. **五个限仓消费方全部改读 `probe_only_regimes()`。** 漏一处，降档后的水温会掉到
   `max_new_buy_names` 的 `limits.neutral` 满配额分支，从「硬拦」直接跳成「满仓」。

CRASH/BLACK_SWAN/UNKNOWN 不进白名单：上面全是均值与胜率，**左尾从未量过**；
UNKNOWN 还兼作取数失败兜底，放开它等于把数据源抖动变成买入许可。

两侧闸门减同一个集合（写入侧 `resolve_market_trade_mode`、下单侧
`oms_buy_block_regimes`、回测侧 `_live_buy_block_regimes`），避免 2026-08 那次错位的
镜像：写入侧放行而 OMS 仍禁买，报告写「谨慎试探」而一股也买不到。

## 验证

逐个还原每个改动点，确认都有测试变红（不是只看绿灯）：

| 还原的改动点 | 变红的测试 |
|---|---|
| `step4_decision_parser` | `test_quota_is_exactly_one_not_full` |
| `step4_order_engine` | `test_order_engine_approves_probe_and_rejects_attack` |
| `backtest_replay` | `test_replay_truncates_live_selection_to_one` |
| `backtest_config` | `test_backtest_gate_agrees` |
| `market_trade_mode`（OMS 侧） | 红 6 条 |

新测试 28 条，`LIMITS.neutral=3` 是刻意的——两者都取 1 时「压到 1 只」与「满配额」
数值相同，断言会同时通过、看不出降档有没有生效，所以另加一条
`assert LIMITS.neutral > 1` 钉住这个前提。

- 全量：**4812 passed, 22 skipped**
- `quality_gate.py --ci`：通过（`resolve_market_trade_mode` 因新分支涨到 73 行超限，
  把降档与禁新仓抽成 `_hard_defense_trade_mode`——两者必须一起改，放相邻处比散在
  分发链里安全）
- `quality_gate.py --check-no-sql`：通过

## 上线动作

合并后**什么都不会变**。要开启需在仓库 Variables 里设
`STEP4_BUY_PROBE_REGIMES=RISK_OFF`（三个 workflow 都读 `vars.`，回测侧也读同一个，
便于先在回测里量再上生产）。收回该变量即刻恢复原状，两侧同时关闭。

建议先在 `backtest_grid` 里跑一轮再决定是否上生产——毕竟选票层在这些天还没量出
正向优势，降档买的是「小仓」，赌的是那条中位数为正。
