### PR TITLE
fix(confirm): days_elapsed 按调用次数计价，同日跑两轮就烧掉一天确认窗

### DIFF
--- a/core/signal_confirmation.py
+++ b/core/signal_confirmation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 import pandas as pd
@@ -65,9 +66,17 @@ def _close_position(today: dict[str, float], reference_close: float = 0.0) -> fl
 
 
 def _confirm_sos(snap: dict, today: dict, days_elapsed: int) -> tuple[str, str]:
-    # 实盘K线复算：SOS/EVR 点火类信号胜率仅 10-20%（trend_pullback/LPS(确认) 44-47%），
-    # 根因是"低乖离处的放量假突破"——仅"不跌破+缩量"就放行过于宽松，还需确认日
-    # 站稳 MA20 附近，验证点火后确有资金承接而非一日游脉冲。
+    # 收紧依据：仅"不跌破+缩量"就放行过于宽松，补充确认日站稳 MA20 附近，验证点火后
+    # 确有资金承接而非一日游脉冲。
+    #
+    # 注：这里原先写着"点火类胜率仅 10-20%，回踩/LPS 44-47%"。2026-09 用 T+1 复权开盘
+    # 买入、第 h 日复权收盘卖出、扣双边 0.15% 后为正算胜率复算(窗口 05-25~09-08)，
+    # 这个 2~4 倍的差距不存在，点火在短持有期反而略高：
+    #   h=1  sos 44.9 (n=661) / trend_pullback 40.1 (n=374) / lps 37.8 (n=394)
+    #   h=5  sos 38.9 (n=620) / trend_pullback 36.1 (n=338) / lps 35.8 (n=360)
+    # 原数字出自 signal_outcomes.return_pct，那一列从信号日收盘起算——点火当天大涨、
+    # 次日跳空，收盘价买不到，这个偏差对点火类系统性更重，两族不可比。
+    # 下面的 MA20 要求不依赖那组数字，保留。
     snap_low, snap_close, snap_vol = snap.get("snap_low", 0), snap.get("snap_close", 0), snap.get("snap_volume", 0)
     ma20 = today.get("ma20", 0)
     if today["low"] < snap_low:
@@ -117,8 +126,13 @@ def _confirm_lps(snap: dict, today: dict, days_elapsed: int) -> tuple[str, str]:
 
 
 def _confirm_evr(snap: dict, today: dict, days_elapsed: int) -> tuple[str, str]:
-    # 同 _confirm_sos：EVR(二次确认) 实盘胜率仅 9.7%，比未确认样本更差，说明单纯
-    # "收盘不跌破事件低点"不足以过滤滞涨假企稳，补充站稳 MA20 的结构性要求。
+    # 同 _confirm_sos：单纯"收盘不跌破事件低点"不足以过滤滞涨假企稳，补充站稳 MA20。
+    #
+    # 注：这里原先写着"EVR(二次确认) 实盘胜率仅 9.7%，比未确认样本更差"。两点都复现不了。
+    # 一是量级：同口径(T+1 复权开盘进、第 h 日复权收盘出、扣双边 0.15%)下 EVR 是
+    # h=1 46.8 / h=3 40.3 / h=5 47.4 / h=10 36.4 (n=154)，和 sos/回踩/LPS 完全重叠，
+    # 没有一个 horizon 接近 9.7。二是"二次确认"这个子集不存在：signal_pending 全表
+    # 642 行里 evr 是 0 行，EVR 从未进过确认池，也就没有确认/未确认可比。
     event_low, snap_close = snap.get("snap_support", 0), snap.get("snap_close", 0)
     ma20 = today.get("ma20", 0)
     if today["close"] < event_low:
@@ -363,6 +377,18 @@ def build_snap(
     return snap
 
 
+def has_bar_on(df: pd.DataFrame | None, trade_date: str) -> bool:
+    """df 最后一根 K 线是否正好是 trade_date。
+
+    实盘不做 as-of 裁切,停牌股会留着停牌前那根旧 bar；拿它当"今天"去判确认,
+    等于用过期价格决定信号生死。
+    """
+    if df is None or getattr(df, "empty", True) or "date" not in df.columns:
+        return False
+    df_s = df.sort_values("date")
+    return str(df_s["date"].iloc[-1])[:10] == str(trade_date)[:10]
+
+
 def build_today_ohlcv(df: pd.DataFrame) -> dict[str, float]:
     """从 DataFrame 最后一根 K 线构建 today_ohlcv dict。"""
     df_s = df.sort_values("date") if "date" in df.columns else df
@@ -431,6 +457,50 @@ def _pending_code_key(code: Any) -> str:
     return str(code)
 
 
+# 取全市场日历时每只票只看尾部这么多根：max(TTL) 之外再留几天缓冲，
+# 避免为了几个日期去 union 五千多个 DataFrame 的全部行。
+_CALENDAR_TAIL_BARS = 12
+
+
+def market_trade_calendar(df_map: dict[str, pd.DataFrame], trade_date: str) -> list[str]:
+    """从 df_map 里汇出 <= trade_date 的全市场交易日(升序)。
+
+    TTL 以「交易日」计价，不能按函数调用次数计价：同一个 trade_date 被跑两轮
+    (人工重跑、周日补跑) 时，逐次自增会凭空烧掉一天确认窗。这里用全市场日历
+    重算 days_elapsed，让一天内跑几轮都得到同一个结果。
+    """
+    end = str(trade_date)[:10]
+    days: set[str] = set()
+    for frame in df_map.values():
+        if frame is None or getattr(frame, "empty", True) or "date" not in frame.columns:
+            continue
+        col = frame["date"].astype(str).str.slice(0, 10)
+        # 先按 trade_date 截断再取尾：反过来的话,调用方传进越过 trade_date 的
+        # frame 会让日历被过滤空,静默退回自然日,周一就会把 1 个交易日算成 3 天。
+        days.update(col[col <= end].tail(_CALENDAR_TAIL_BARS))
+    days.discard("")
+    return sorted(days)
+
+
+def elapsed_trade_days(calendar: list[str], signal_date: str, trade_date: str) -> int:
+    """信号日之后、trade_date 之前(含)经过了几个交易日。
+
+    停牌不影响计数：日历取自全市场,个股缺 bar 只该让它不可判定,不该让它不老化。
+    """
+    start, end = str(signal_date)[:10], str(trade_date)[:10]
+    if not start or not end or end <= start:
+        return 0
+    if calendar:
+        # 日历非空但窗口内没有交易日 → trade_date 不是交易日,不该老化。
+        return sum(1 for day in calendar if start < day <= end)
+    # 日历为空(df_map 为空)时退回自然日,至少保证 TTL 能到期而不是挂死。
+    try:
+        delta = (datetime.fromisoformat(end).date() - datetime.fromisoformat(start).date()).days
+    except ValueError:
+        return 0
+    return max(delta, 0)
+
+
 def run_confirmation_cycle(
     pending_signals: list[dict],
     df_map: dict[str, pd.DataFrame],
@@ -439,18 +509,33 @@ def run_confirmation_cycle(
     """对一批 pending 信号执行确认/过期判定，返回 (updates, confirmed_symbols)。"""
     updates: list[dict] = []
     confirmed_symbols: list[dict] = []
+    calendar = market_trade_calendar(df_map, trade_date)
 
     for sig in pending_signals:
-        # 信号日当天不做确认检查：当天 K 线 == 信号快照，无法验证"次日回踩"
-        if str(sig.get("signal_date", ""))[:10] == str(trade_date)[:10]:
+        # days_elapsed 按全市场交易日重算,不按调用次数自增：同一个 trade_date
+        # 跑第二轮时结果不变,信号日当天算出 0 天,天然跳过(当天 K 线 == 快照)。
+        days = elapsed_trade_days(calendar, sig.get("signal_date", ""), trade_date)
+        if days <= 0:
             continue
 
         code_str = _pending_code_key(sig["code"])
         df = df_map.get(code_str)
-        if df is None or df.empty:
+        if not has_bar_on(df, trade_date):
+            # 停牌/缺数据：今天判不了确认,但 TTL 照走,不能挂在池子里永不终结。
+            ttl = SIGNAL_TTL_DAYS.get(sig["signal_type"], 3)
+            if days < ttl:
+                continue
+            updates.append(
+                {
+                    "id": sig["id"],
+                    "status": "expired",
+                    "days_elapsed": days,
+                    "confirm_reason": f"TTL {ttl}天已到，期间无可用K线（停牌或缺数据）",
+                    "expire_date": trade_date,
+                }
+            )
             continue
 
-        days = sig.get("days_elapsed", 0) + 1
         today = build_today_ohlcv(df)
         snap = {k: sig[k] for k in sig if k.startswith("snap_")}
         new_status, reason = check_confirmation(sig["signal_type"], snap, today, days)

--- a/tests/core/test_signal_confirmation.py
+++ b/tests/core/test_signal_confirmation.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pandas as pd
 
-from core.signal_confirmation import check_confirmation, run_confirmation_cycle
+from core.signal_confirmation import (
+    check_confirmation,
+    elapsed_trade_days,
+    market_trade_calendar,
+    run_confirmation_cycle,
+)
 
 
 def test_sos_confirmation_requires_reclaiming_signal_close():
@@ -128,3 +133,130 @@ def test_confirmation_cycle_marks_confirmed_source_for_step3():
     assert confirmed[0]["source_type"] == "signal_pending"
     assert confirmed[0]["confirm_date"] == "2026-06-12"
     assert confirmed[0]["confirm_reason"]
+
+
+def _bars(dates: list[str], close: float = 10.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {"date": d, "open": close, "high": close + 0.5, "low": close - 0.4, "close": close, "volume": 900}
+            for d in dates
+        ]
+    )
+
+
+def _sos_signal(signal_date: str = "2026-06-11") -> dict:
+    """一个不会被确认谓词提前打死、只会走到 TTL 的 sos 信号(ttl=2)。"""
+    return {
+        "id": 1,
+        "code": 1,
+        "name": "平安银行",
+        "signal_type": "sos",
+        "signal_date": signal_date,
+        "signal_score": 1.2,
+        "days_elapsed": 0,
+        "snap_low": 9.2,
+        "snap_close": 10.6,
+        "snap_volume": 1_000_000,
+    }
+
+
+def test_same_trade_date_rerun_does_not_burn_ttl():
+    """同一个 trade_date 跑两轮,days_elapsed 不能翻倍。
+
+    线上 08-24/08-27/08-30 各跑了两轮,53 个信号因此提前一个交易日 expired。
+    """
+    df = _bars(["2026-06-11", "2026-06-12"])
+
+    first, _ = run_confirmation_cycle([_sos_signal()], {"000001": df}, "2026-06-12")
+    # 第二轮拿到的是第一轮写回后的 days_elapsed
+    sig = _sos_signal()
+    sig["days_elapsed"] = first[0]["days_elapsed"]
+    second, _ = run_confirmation_cycle([sig], {"000001": df}, "2026-06-12")
+
+    assert first[0]["days_elapsed"] == 1
+    assert second[0]["days_elapsed"] == 1, "重跑同一天不应把 days_elapsed 推到 2"
+    assert second[0]["status"] != "expired", "sos 的 ttl=2,第一个交易日就不该到期"
+
+
+def test_days_elapsed_counts_trade_days_not_calls():
+    """跳过一轮跑批后,days_elapsed 要按真实经过的交易日跳,不是按调用次数 +1。"""
+    df = _bars(["2026-06-11", "2026-06-12", "2026-06-15", "2026-06-16"])
+
+    updates, _ = run_confirmation_cycle([_sos_signal()], {"000001": df}, "2026-06-16")
+
+    assert updates[0]["days_elapsed"] == 3
+    assert updates[0]["status"] == "expired"
+
+
+def test_suspended_stock_still_expires_on_ttl():
+    """停牌股拿不到当日 bar,但 TTL 照走,不能永远挂在 pending 池里。"""
+    stale = _bars(["2026-06-11", "2026-06-12"])  # 12 日之后停牌
+    calendar_peer = _bars(["2026-06-11", "2026-06-12", "2026-06-15", "2026-06-16"])
+
+    updates, confirmed = run_confirmation_cycle(
+        [_sos_signal()],
+        {"000001": stale, "000002": calendar_peer},
+        "2026-06-16",
+    )
+
+    assert not confirmed
+    assert len(updates) == 1
+    assert updates[0]["status"] == "expired"
+    assert updates[0]["days_elapsed"] == 3
+    assert "无可用K线" in updates[0]["confirm_reason"]
+
+
+def test_stale_bar_is_not_treated_as_today():
+    """停牌股的旧 bar 不能当"今天"用来判确认——否则用过期价格决定信号生死。"""
+    # 这根旧 bar 单看是满足 sos 确认的(收在信号日收盘之上 + 缩量)
+    stale = pd.DataFrame(
+        [
+            {"date": "2026-06-11", "open": 10.0, "high": 10.8, "low": 9.4, "close": 10.6, "volume": 1_000_000},
+            {"date": "2026-06-12", "open": 10.6, "high": 11.0, "low": 10.4, "close": 10.9, "volume": 600_000},
+        ]
+    )
+    peer = _bars(["2026-06-11", "2026-06-12", "2026-06-15"])
+
+    _, confirmed = run_confirmation_cycle(
+        [_sos_signal()],
+        {"000001": stale, "000002": peer},
+        "2026-06-15",
+    )
+
+    assert not confirmed, "06-15 停牌,不该用 06-12 那根 bar 判出 confirmed"
+
+
+def test_non_trading_date_does_not_age_signals():
+    """trade_date 不在全市场日历上时不该老化(周末/节假日误触发)。"""
+    df = _bars(["2026-06-11", "2026-06-12"])
+
+    updates, _ = run_confirmation_cycle([_sos_signal()], {"000001": df}, "2026-06-13")
+
+    assert updates == []
+
+
+def test_calendar_truncates_before_taking_tail():
+    """frame 越过 trade_date 时,日历不能被过滤空后退回自然日。
+
+    先取尾再截断的话日历会空,elapsed 退回自然日：06-12→06-15(周一) 算成 3 天,
+    sos(ttl=2) 凭空到期。
+    """
+    df = _bars([f"2026-06-{d:02d}" for d in (11, 12, 15, 16, 17, 18, 19, 22, 23, 24, 25, 26, 29, 30)])
+
+    calendar = market_trade_calendar({"000001": df}, "2026-06-15")
+
+    assert calendar == ["2026-06-11", "2026-06-12", "2026-06-15"]
+    assert elapsed_trade_days(calendar, "2026-06-12", "2026-06-15") == 1
+
+
+def test_future_bar_is_not_treated_as_today():
+    """frame 末尾越过 trade_date 时不能拿未来那根当"今天"判确认。"""
+    df = _bars(["2026-06-11", "2026-06-12", "2026-06-15", "2026-06-16"])
+
+    _, confirmed = run_confirmation_cycle(
+        [_sos_signal(signal_date="2026-06-12")],
+        {"000001": df},
+        "2026-06-15",
+    )
+
+    assert not confirmed


### PR DESCRIPTION
## 问题

TTL 全程以「交易日」写在文档和 `SIGNAL_TTL_DAYS` 里（`sos: 2`、"TTL 2天"），但实现是 `days = sig.get("days_elapsed", 0) + 1` —— 按 `run_confirmation_cycle` **被调用的次数**自增。一个根因，三个症状。

### 1. 同日双跑（主症，已量到）

同一个 `trade_date` 跑两轮时，每个 pending 信号对着没变的 K 线多老化一天。

线上 `signal_pending` 642 行，600 行已终结，其中 **59 行（9.8%）提前一个交易日 expired**。53 行正好落在有两个 `updated_at` 的三天（08-24 / 08-27 / 08-30），另外 6 行是 08-30 结转到 08-31 的。

**59 行全是 `expired`，`confirmed` 0 行** —— 这个 bug 只会杀信号，不可能凭空造出一个确认。

（先前我用 `signal_date` 当日历算出 181/600，那是错的：确认循环实际在 24 个 `trade_date` 上跑过，有 6 天没产生新信号，在 `signal_date` 集合里看不见。用完整日历重算是 541 对齐 / 59 不对齐。）

### 2. 旧 bar 当今天（仅实盘）

`_funnel_asof_cut_enabled()` 不设 `END_CALENDAR_DAY` 就返回 False，实盘不裁切。停牌股留着停牌前那根 bar，`build_today_ohlcv` 取 `df_s.iloc[-1]` 且不校验日期，等于**用过期价格决定信号生死**。`assert_funnel_data_freshness` 只管总体 `min_coverage`，拦不住单只票。

### 3. 挂死（仅回放）

裁切开启时 `cut_ohlcv_to_as_of` 要求最后一根 bar 恰好等于 as_of（`core/asof_cut.py:33-34`），停牌股直接返回 `None`、从 `df_map` 消失，`continue` 命中，`days_elapsed` 永不前进。`load_pending_signals` 没有兜底清理，会被无限重新载入。

目前线上 42 行未终结，`days_elapsed` 都在 0/1/2，最早 09-04，还没攒起来。

## 改法

让一次 tick **天然幂等**：`days_elapsed` 从 `df_map` 自己汇出的全市场交易日历重算，而不是自增。同一个 `trade_date` 跑几轮都得到同一个数，第二轮是 no-op；信号日当天算出 0 天，天然跳过（当天 K 线 == 快照）。

- **`market_trade_calendar()`** —— 先按 `trade_date` 截断**再**取 `tail(12)`。反过来的话，调用方传进越过 `trade_date` 的 frame 会让日历被过滤空、静默退回自然日，周一就把 1 个交易日算成 3 天，正是在修的这一类 bug。
- **`elapsed_trade_days()`** —— 日历非空但窗口内无交易日 → 不老化（`trade_date` 不是交易日）；仅 `df_map` 为空时退回自然日，保证 TTL 能到期而不是挂死。
- **`has_bar_on()`** —— 拒绝把旧 bar 或未来 bar 当今天。停牌期间判不了确认，但 TTL 照走，到期以「期间无可用K线（停牌或缺数据）」终结，不留在池子里。

日历取自 `df_map` 而不是 `cached_trade_dates()`，因为本模块第 1 行声明「纯业务，不依赖 DB」。`df_map` 是全市场池（`workflows/funnel_data.py:178-203`），个股缺 bar 只意味着停牌或抓取失败，不意味着它离开了漏斗，所以停牌不该让信号免于老化。

停牌规模：2 年面板上 784/5609 只（14.0%）至少停过一天，323 只（5.8%）停过 5 天以上，但只占 **0.211% 股票日**。对 2~3 天的 TTL 窗不足 1% 信号，比双跑小一个数量级。

## 顺带：两条被实测推翻的注释

两条都被引作实盘谓词的依据，**只改注释文字，谓词行为一个字没动** —— MA20 那条要求本身不依赖被推翻的数字。

`_confirm_sos` 原写「点火类胜率仅 10-20%，回踩/LPS 44-47%」。用 T+1 复权开盘买入、第 h 日复权收盘卖出、扣双边 0.15% 复算（05-25~09-08），这个 2~4 倍差距不存在，点火在短持有期反而略高：

| h | sos | trend_pullback | lps |
|---|---|---|---|
| 1 | 44.9% (n=661) | 40.1% (n=374) | 37.8% (n=394) |
| 5 | 38.9% (n=620) | 36.1% (n=338) | 35.8% (n=360) |

原数字出自 `signal_outcomes.return_pct`，那一列从信号日收盘起算——点火当天大涨、次日跳空，收盘价买不到，这个偏差对点火类系统性更重，两族不可比。

`_confirm_evr` 原写「EVR(二次确认) 胜率仅 9.7%，比未确认样本更差」。两点都复现不了：量级上同口径是 h=1 46.8 / h=3 40.3 / h=5 47.4 / h=10 36.4（n=154），没有一个 horizon 接近 9.7；「二次确认」这个子集也不存在，`signal_pending` 642 行里 `evr` 是 **0 行**，EVR 从未进过确认池。

## 验证

- 7 个新用例，**5 个在改前代码上确实失败**（stash 后用 sed 打桩隔离出行为断言，不是 ImportError）
- `test_calendar_truncates_before_taking_tail` 钉住过滤/取尾的顺序
- `test_future_bar_is_not_treated_as_today` 在改前也过，按 guard 明确标注（一个在旧码上不失败的用例不是回归测试）
- 全量 **4819 passed / 22 skipped**；`ruff check` + `ruff format --check` 干净；`quality_gate.py --ci` → OK: No new violations