### PR TITLE
fix(backtest): 水温漏传资金流,CRASH 九天只剩一天

### DIFF
--- a/core/backtest_config.py
+++ b/core/backtest_config.py
@@ -12,7 +12,13 @@ from core.a_share_entry_research import AShareEntryResearchPolicy
 from core.ai_candidate_allocation import AiCandidateAllocationConfig
 from core.backtest_execution import ExitSimulationConfig, IntradayPriceFetcher
 from core.backtest_performance import BacktestPerformanceConfig
-from core.backtest_replay import BacktestReplayConfig, MarketBreadthCalculator, MarketRegimeAnalyzer
+from core.backtest_replay import (
+    AmountDistributionCalculator,
+    BacktestReplayConfig,
+    MarketBreadthCalculator,
+    MarketMoneyFlowCalculator,
+    MarketRegimeAnalyzer,
+)
 from core.candidate_policy import CandidatePolicyConfig
 from core.cash_portfolio import CashPortfolioConfig, expand_portfolio_styles
 from core.mainline_engine import MainlineEngineConfig
@@ -55,6 +61,10 @@ class BacktestRunInput:
     funnel_config_overrides: dict[str, object] = field(default_factory=dict)
     market_breadth_calculator: MarketBreadthCalculator | None = None
     market_regime_analyzer: MarketRegimeAnalyzer | None = None
+    # 资金流 / 成交额分布；缺失时 CRASH 拿不到确认判据而降级成 RISK_OFF，
+    # 见 core/backtest_replay._analyze_market_regime。
+    market_money_flow_calculator: MarketMoneyFlowCalculator | None = None
+    amount_distribution_calculator: AmountDistributionCalculator | None = None
     # 小盘基准；缺失时防守档判据退化，见 core/backtest_replay._analyze_market_regime。
     smallcap_bench_df: pd.DataFrame | None = None
     candidate_policy: CandidatePolicyConfig = field(default_factory=CandidatePolicyConfig)
@@ -297,6 +307,8 @@ def _replay_config(
         intraday_entry_price_fetcher=params.intraday_entry_price_fetcher,
         market_breadth_calculator=params.market_breadth_calculator,
         market_regime_analyzer=params.market_regime_analyzer,
+        market_money_flow_calculator=params.market_money_flow_calculator,
+        amount_distribution_calculator=params.amount_distribution_calculator,
         smallcap_bench_df=getattr(params, "smallcap_bench_df", None),
         exit=params.exit_config,
         candidate_policy=params.candidate_policy,

--- a/core/backtest_replay.py
+++ b/core/backtest_replay.py
@@ -51,6 +51,8 @@ logger = logging.getLogger(__name__)
 ProgressReporter = Callable[[str, str, float], None]
 MarketBreadthCalculator = Callable[[dict[str, pd.DataFrame]], dict]
 MarketRegimeAnalyzer = Callable[..., dict]
+MarketMoneyFlowCalculator = Callable[..., dict]
+AmountDistributionCalculator = Callable[..., dict]
 HistoryEndPositions = dict[str, NDArray[np.intp]]
 
 
@@ -109,6 +111,10 @@ class BacktestReplayConfig:
     enforce_confirmed_loss_guard: bool = False
     market_breadth_calculator: MarketBreadthCalculator | None = None
     market_regime_analyzer: MarketRegimeAnalyzer | None = None
+    # 资金流 / 成交额分布。缺它则 CRASH 拿不到确认判据而降级成 RISK_OFF——
+    # 见 _analyze_market_regime 的说明。
+    market_money_flow_calculator: MarketMoneyFlowCalculator | None = None
+    amount_distribution_calculator: AmountDistributionCalculator | None = None
     # 小盘基准（默认创业板指）。缺它则 CRASH/PANIC_REPAIR 少一条判据，
     # 防守档会塌成 NEUTRAL——见 _analyze_market_regime 的说明。
     smallcap_bench_df: pd.DataFrame | None = None
@@ -483,7 +489,14 @@ def _build_day_context(
         smallcap_slice = None
     day_cfg = replace(base_cfg)
     breadth = _calculate_market_breadth(day_df_map, config)
-    bench_context = _analyze_market_regime(bench_slice, day_cfg, breadth, config, smallcap_slice)
+    bench_context = _analyze_market_regime(
+        bench_slice,
+        day_cfg,
+        breadth,
+        config,
+        smallcap_slice,
+        **_liquidity_context(day_df_map, breadth, day_cfg, config),
+    )
     result = run_funnel(
         all_symbols=list(day_df_map.keys()),
         df_map=day_df_map,
@@ -518,12 +531,50 @@ def _calculate_market_breadth(day_df_map: dict[str, pd.DataFrame], config: Backt
     return calculator(day_df_map)
 
 
+def _liquidity_context(
+    day_df_map: dict[str, pd.DataFrame],
+    breadth: dict,
+    day_cfg: FunnelConfig,
+    config: BacktestReplayConfig,
+) -> dict[str, dict | None]:
+    """CRASH 确认判据的两个入参,见 _analyze_market_regime 的说明。"""
+    return {
+        "money_flow": _calculate_market_money_flow(day_df_map, breadth, config),
+        "amount_distribution": _calculate_amount_distribution(day_df_map, day_cfg, config),
+    }
+
+
+def _calculate_market_money_flow(
+    day_df_map: dict[str, pd.DataFrame],
+    breadth: dict,
+    config: BacktestReplayConfig,
+) -> dict | None:
+    calculator = config.market_money_flow_calculator
+    if calculator is None:
+        return None
+    return calculator(day_df_map, breadth)
+
+
+def _calculate_amount_distribution(
+    day_df_map: dict[str, pd.DataFrame],
+    day_cfg: FunnelConfig,
+    config: BacktestReplayConfig,
+) -> dict | None:
+    calculator = config.amount_distribution_calculator
+    if calculator is None:
+        return None
+    return calculator(day_df_map, day_cfg.min_avg_amount_wan, day_cfg.amount_avg_window)
+
+
 def _analyze_market_regime(
     bench_slice: pd.DataFrame,
     day_cfg: FunnelConfig,
     breadth: dict,
     config: BacktestReplayConfig,
     smallcap_slice: pd.DataFrame | None = None,
+    *,
+    money_flow: dict | None = None,
+    amount_distribution: dict | None = None,
 ) -> dict:
     """按日判定水温。
 
@@ -533,9 +584,24 @@ def _analyze_market_regime(
     在回测里全部塌成 NEUTRAL 或 CAUTION，24 个重叠日仅 14 天判定一致（58%）。
     后果是任何按水温分档的回测结论都不可信——例如防守档流动性门槛改动，
     因该档在回测中从不出现而完全测不出差别。
+
+    money_flow / amount_distribution 是同一处的第二层：此前也只传 breadth，
+    另两个入参留空。tools/market_regime.py 不会报错，而是拿一个空的行情字典兜底
+    重算，于是 money_flow.sample_size=0、分数退化成跟 breadth 涨跌幅同值、
+    成交额分布是「样本不足」。CRASH 要求价格判据 + 一条确认判据（广度断崖或
+    资金撤退），确认永远拿不到，CRASH 就掉到 RISK_OFF——实测 9 天 CRASH 只剩 1 天
+    （2026-08-19 广度 delta=-30.98 自己够到断崖阈值）。两档的下游不同：
+    step4 仓位系数 0.70 vs 0.85、执行优先级 2 vs 3，且 _tune_risk_off_cfg 只认 RISK_OFF。
     """
     analyzer = config.market_regime_analyzer or analyze_benchmark_and_tune_cfg
-    return analyzer(bench_slice, smallcap_slice, day_cfg, breadth=breadth)
+    return analyzer(
+        bench_slice,
+        smallcap_slice,
+        day_cfg,
+        breadth=breadth,
+        money_flow=money_flow,
+        amount_distribution=amount_distribution,
+    )
 
 
 def _day_df_map(

--- a/tests/core/test_backtest_regime_money_flow.py
+++ b/tests/core/test_backtest_regime_money_flow.py
@@ -1,0 +1,341 @@
+"""Tests for money_flow / amount_distribution plumbing in backtest replay.
+
+回测此前只把 breadth 传给 analyzer，money_flow 和 amount_distribution 留空
+（core/backtest_replay._analyze_market_regime）。tools/market_regime.py 不报错，
+而是拿一个空的行情字典兜底重算：
+
+    money_flow_context = money_flow or calc_market_money_flow({}, breadth)
+    amount_distribution_context = amount_distribution or calc_amount_distribution_health({}, ...)
+
+于是 money_flow.sample_size=0、分数退化成跟 breadth 涨跌幅同值、成交额分布是「样本不足」。
+
+CRASH 要求价格判据 + 一条确认判据（广度断崖 breadth_delta<=-20 或资金撤退），
+确认永远拿不到，CRASH 就掉到 RISK_OFF。实测生产库 9 天 CRASH 在回测里只剩 1 天
+（2026-08-19 广度 delta=-30.98 自己够到断崖阈值，不依赖资金流）。
+
+两档下游不同，所以不是化妆问题：
+- workflows/step4_order_engine.py 仓位系数 CRASH 0.70 vs RISK_OFF 0.85
+- core/market_trade_mode.py 执行优先级 CRASH 2 vs RISK_OFF 3
+- _tune_risk_off_cfg 只认 RISK_OFF，没有 CRASH 分支
+
+注意 RISK_OFF 兜底那条路径返回的 panic_reasons 是空的（_regime_from_panic 返回
+regime, [], []），所以空 panic_reasons 不能读成「价格判据没触发」。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from core.backtest_execution import ExitSimulationConfig
+from core.backtest_replay import (
+    BacktestReplayConfig,
+    _analyze_market_regime,
+    _calculate_amount_distribution,
+    _calculate_market_money_flow,
+)
+from core.wyckoff_engine import FunnelConfig
+from tools.market_regime import analyze_benchmark_and_tune_cfg
+
+# 2026-07-17 的真实形态：主板 -3.046%、小盘 -7.145%，两条价格判据都过
+# （阈值 -1.3% / -2.5%），而广度 delta -8 够不到断崖阈值 -20。
+# 这正是生产判 CRASH、回测判 RISK_OFF 的那一类日子。
+CRASH_MAIN_PCT = -3.05
+CRASH_SMALL_PCT = -7.15
+# 键名必须是 ratio_pct / delta_pct：analyzer 读的是这两个，写成 ratio / delta
+# 不会报错,只是被当成缺值忽略,广度判据静默失效。
+BREADTH_NO_CLIFF = {"ratio_pct": 28.0, "prev_ratio_pct": 36.0, "delta_pct": -8.0, "sample_size": 4000}
+BREADTH_CLIFF = {"ratio_pct": 8.0, "prev_ratio_pct": 38.98, "delta_pct": -30.98, "sample_size": 4000}
+MONEY_FLOW_RETREAT = {"trend": "retreat", "score": -25.0, "up_down_amount_ratio": 0.40, "sample_size": 4000}
+AMOUNT_DISTRIBUTION_THIN = {"state": "thin", "sample_size": 4000}
+
+
+def _index_frame(last_pct: float, rows: int = 260, base: float = 100.0) -> pd.DataFrame:
+    """构造指数历史。
+
+    rows 必须 >= 200：MA200 缺失时算出来的是 NaN，而 _structural_regime 用
+    `value is None` 判空，NaN 会穿过去，BEAR 永不成立、全部塌成 NEUTRAL。
+    """
+    closes = [base] * (rows - 1) + [base * (1 + last_pct / 100.0)]
+    return pd.DataFrame(
+        {
+            "date": pd.date_range("2025-01-01", periods=rows, freq="B").date,
+            "close": closes,
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "pct_chg": [0.0] * (rows - 1) + [last_pct],
+            "volume": [1e6] * rows,
+        }
+    )
+
+
+def _day_df_map() -> dict[str, pd.DataFrame]:
+    rows = 30
+    return {
+        "000001": pd.DataFrame(
+            {
+                "date": pd.date_range("2026-06-01", periods=rows, freq="B").date,
+                "close": [10.0] * rows,
+                "open": [10.0] * rows,
+                "high": [10.2] * rows,
+                "low": [9.8] * rows,
+                "pct_chg": [0.0] * rows,
+                "volume": [1e6] * rows,
+                "amount": [1e8] * rows,
+            }
+        )
+    }
+
+
+def _config(**overrides) -> BacktestReplayConfig:
+    """BacktestReplayConfig 有 18 个必填字段，这里给出与本用例无关的最小占位。"""
+
+    base = dict(
+        trading_days=250,
+        hold_days=5,
+        board="all",
+        top_n=5,
+        selection_mode="tradeable_l4",
+        full_formal_l4_max=50,
+        regime_filter=False,
+        execution_regime_gate="live",
+        pending_mode="only",
+        pending_merge_order="confirmed_first",
+        abc_filter=False,
+        entry_price_mode="open",
+        entry_price_time="",
+        entry_price_fallback="close",
+        buy_friction_pct=0.026,
+        sell_friction_pct=0.176,
+        max_atr_hold_days=0,
+        exit=ExitSimulationConfig(
+            exit_mode="close_only",
+            stop_loss_pct=0.0,
+            take_profit_pct=0.0,
+            trailing_stop_pct=0.0,
+            trailing_activate_pct=0.0,
+            sltp_priority="stop_first",
+            atr_period=14,
+            atr_multiplier=2.0,
+            atr_hard_stop_pct=0.0,
+        ),
+    )
+    base.update(overrides)
+    return BacktestReplayConfig(**base)
+
+
+class TestCrashSurvivesWithMoneyFlow:
+    """行为回归：跑真 analyzer,不是 spy。"""
+
+    def test_crash_day_reproduces_as_crash(self):
+        """给了资金撤退这条确认判据,CRASH 就是 CRASH。"""
+        out = _analyze_market_regime(
+            _index_frame(CRASH_MAIN_PCT),
+            FunnelConfig(),
+            BREADTH_NO_CLIFF,
+            _config(market_regime_analyzer=analyze_benchmark_and_tune_cfg),
+            _index_frame(CRASH_SMALL_PCT),
+            money_flow=MONEY_FLOW_RETREAT,
+            amount_distribution=AMOUNT_DISTRIBUTION_THIN,
+        )
+
+        assert out["regime"] == "CRASH"
+
+    def test_same_day_degrades_to_risk_off_without_money_flow(self):
+        """对照:这就是修复前回测里发生的事——同一天掉到 RISK_OFF。
+
+        断言 RISK_OFF 而非 CRASH,是为了让这个用例在 bug 回归时变红。
+        """
+        out = _analyze_market_regime(
+            _index_frame(CRASH_MAIN_PCT),
+            FunnelConfig(),
+            BREADTH_NO_CLIFF,
+            _config(market_regime_analyzer=analyze_benchmark_and_tune_cfg),
+            _index_frame(CRASH_SMALL_PCT),
+        )
+
+        assert out["regime"] == "RISK_OFF"
+
+    def test_crash_reasons_include_price_and_confirmation(self):
+        """CRASH 的 panic_reasons 必须同时含价格判据和确认判据。"""
+        out = _analyze_market_regime(
+            _index_frame(CRASH_MAIN_PCT),
+            FunnelConfig(),
+            BREADTH_NO_CLIFF,
+            _config(market_regime_analyzer=analyze_benchmark_and_tune_cfg),
+            _index_frame(CRASH_SMALL_PCT),
+            money_flow=MONEY_FLOW_RETREAT,
+            amount_distribution=AMOUNT_DISTRIBUTION_THIN,
+        )
+        reasons = out.get("panic_reasons") or []
+
+        assert any(reason.startswith("main_day_drop") for reason in reasons)
+        assert any(reason.startswith("money_flow_retreat") for reason in reasons)
+
+    def test_risk_off_fallthrough_reports_no_reasons(self):
+        """记录这个坑:降级那条路返回空 panic_reasons,不代表价格判据没触发。"""
+        out = _analyze_market_regime(
+            _index_frame(CRASH_MAIN_PCT),
+            FunnelConfig(),
+            BREADTH_NO_CLIFF,
+            _config(market_regime_analyzer=analyze_benchmark_and_tune_cfg),
+            _index_frame(CRASH_SMALL_PCT),
+        )
+
+        assert out["regime"] == "RISK_OFF"
+        assert not (out.get("panic_reasons") or [])
+
+    def test_breadth_cliff_alone_still_confirms(self):
+        """广度自己够到断崖阈值时,不依赖资金流也应判 CRASH。
+
+        对应实测中唯一能复现的那天(2026-08-19,delta=-30.98)。
+        """
+        out = _analyze_market_regime(
+            _index_frame(CRASH_MAIN_PCT),
+            FunnelConfig(),
+            BREADTH_CLIFF,
+            _config(market_regime_analyzer=analyze_benchmark_and_tune_cfg),
+            _index_frame(CRASH_SMALL_PCT),
+        )
+
+        assert out["regime"] == "CRASH"
+
+
+class TestAnalyzerReceivesLiquidityContext:
+    def test_money_flow_is_forwarded(self):
+        seen: dict[str, object] = {}
+
+        def spy(bench, smallcap, cfg, **kwargs):
+            seen["money_flow"] = kwargs.get("money_flow")
+            return {"regime": "NEUTRAL"}
+
+        _analyze_market_regime(
+            _index_frame(-1.5),
+            FunnelConfig(),
+            {},
+            _config(market_regime_analyzer=spy),
+            None,
+            money_flow=MONEY_FLOW_RETREAT,
+        )
+
+        assert seen["money_flow"] == MONEY_FLOW_RETREAT
+
+    def test_amount_distribution_is_forwarded(self):
+        seen: dict[str, object] = {}
+
+        def spy(bench, smallcap, cfg, **kwargs):
+            seen["amount_distribution"] = kwargs.get("amount_distribution")
+            return {"regime": "NEUTRAL"}
+
+        _analyze_market_regime(
+            _index_frame(-1.5),
+            FunnelConfig(),
+            {},
+            _config(market_regime_analyzer=spy),
+            None,
+            amount_distribution=AMOUNT_DISTRIBUTION_THIN,
+        )
+
+        assert seen["amount_distribution"] == AMOUNT_DISTRIBUTION_THIN
+
+    def test_breadth_and_smallcap_still_passed(self):
+        """新增两个入参不得挤掉原有的两个。"""
+        seen: dict[str, object] = {}
+
+        def spy(bench, smallcap, cfg, **kwargs):
+            seen["breadth"] = kwargs.get("breadth")
+            seen["smallcap"] = smallcap
+            return {"regime": "NEUTRAL"}
+
+        _analyze_market_regime(
+            _index_frame(0.0),
+            FunnelConfig(),
+            {"ratio_pct": 12.0},
+            _config(market_regime_analyzer=spy),
+            _index_frame(-3.0),
+            money_flow=MONEY_FLOW_RETREAT,
+            amount_distribution=AMOUNT_DISTRIBUTION_THIN,
+        )
+
+        assert seen["breadth"] == {"ratio_pct": 12.0}
+        assert seen["smallcap"] is not None
+
+    def test_defaults_to_none_when_omitted(self):
+        """省略参数时保持向后兼容,走 market_regime 里的空字典兜底。"""
+        seen: dict[str, object] = {}
+
+        def spy(bench, smallcap, cfg, **kwargs):
+            seen["money_flow"] = kwargs.get("money_flow")
+            seen["amount_distribution"] = kwargs.get("amount_distribution")
+            return {"regime": "NEUTRAL"}
+
+        _analyze_market_regime(_index_frame(0.0), FunnelConfig(), {}, _config(market_regime_analyzer=spy))
+
+        assert seen["money_flow"] is None
+        assert seen["amount_distribution"] is None
+
+
+class TestCalculatorInjection:
+    def test_money_flow_calculator_receives_day_data_and_breadth(self):
+        seen: dict[str, object] = {}
+
+        def spy(df_map, breadth):
+            seen["codes"] = list(df_map.keys())
+            seen["breadth"] = breadth
+            return MONEY_FLOW_RETREAT
+
+        out = _calculate_market_money_flow(
+            _day_df_map(),
+            BREADTH_NO_CLIFF,
+            _config(market_money_flow_calculator=spy),
+        )
+
+        assert seen["codes"] == ["000001"]
+        assert seen["breadth"] == BREADTH_NO_CLIFF
+        assert out == MONEY_FLOW_RETREAT
+
+    def test_amount_distribution_calculator_receives_cfg_thresholds(self):
+        """成交额分布要读当日 cfg 的门槛和窗口,不能用默认值。"""
+        seen: dict[str, object] = {}
+
+        def spy(df_map, min_avg_amount_wan, lookback):
+            seen["codes"] = list(df_map.keys())
+            seen["min_avg_amount_wan"] = min_avg_amount_wan
+            seen["lookback"] = lookback
+            return AMOUNT_DISTRIBUTION_THIN
+
+        cfg = FunnelConfig()
+        out = _calculate_amount_distribution(
+            _day_df_map(),
+            cfg,
+            _config(amount_distribution_calculator=spy),
+        )
+
+        assert seen["codes"] == ["000001"]
+        assert seen["min_avg_amount_wan"] == cfg.min_avg_amount_wan
+        assert seen["lookback"] == cfg.amount_avg_window
+        assert out == AMOUNT_DISTRIBUTION_THIN
+
+    def test_missing_calculators_return_none(self):
+        """没注入就返回 None,让 analyzer 走自己的兜底,保持旧行为。"""
+        config = _config()
+
+        assert _calculate_market_money_flow(_day_df_map(), BREADTH_NO_CLIFF, config) is None
+        assert _calculate_amount_distribution(_day_df_map(), FunnelConfig(), config) is None
+
+
+class TestConfigFields:
+    def test_replay_config_carries_calculators(self):
+        config = _config(
+            market_money_flow_calculator=lambda *_a, **_k: {},
+            amount_distribution_calculator=lambda *_a, **_k: {},
+        )
+
+        assert config.market_money_flow_calculator is not None
+        assert config.amount_distribution_calculator is not None
+
+    def test_replay_config_defaults_are_none(self):
+        config = _config()
+
+        assert config.market_money_flow_calculator is None
+        assert config.amount_distribution_calculator is None

--- a/tests/workflows/test_backtest_service.py
+++ b/tests/workflows/test_backtest_service.py
@@ -81,6 +81,14 @@ def test_run_backtest_workflow_builds_context_without_network(monkeypatch) -> No
     assert captured["config"].performance.cash_portfolio is True
     analyzer = captured["config"].replay.market_regime_analyzer
     assert analyzer.keywords["regime_config"].smallcap_bench_code == "399905"
+    # 资金流/成交额分布必须注入,否则 analyzer 拿空行情字典兜底,
+    # CRASH 拿不到确认判据而降级成 RISK_OFF——见 tests/core/test_backtest_regime_money_flow.py
+    money_flow = captured["config"].replay.market_money_flow_calculator
+    assert money_flow is not None
+    assert money_flow.keywords["config"].lookback == 20
+    amount_distribution = captured["config"].replay.amount_distribution_calculator
+    assert amount_distribution is not None
+    assert amount_distribution.keywords["config"].lookback == 20
 
 
 def test_backtest_signal_weight_map_matches_funnel_policy_gate(monkeypatch) -> None:

--- a/workflows/backtest.py
+++ b/workflows/backtest.py
@@ -23,6 +23,7 @@ from core.dynamic_policy import dynamic_policy_mode
 from core.market_breadth import calc_market_breadth
 from core.theme_activity import build_theme_member_index
 from tools.mainline_config import load_mainline_engine_config
+from tools.market_liquidity import calc_amount_distribution_health, calc_market_money_flow
 from tools.market_regime import analyze_benchmark_and_tune_cfg
 from workflows.ai_candidate_allocation_config import ai_candidate_allocation_config_from_env
 from workflows.backtest_data import (
@@ -74,6 +75,10 @@ from workflows.backtest_strategy_variants import (
 from workflows.candidate_policy_config import candidate_policy_config_from_env
 from workflows.dynamic_policy_config import dynamic_policy_config_from_env
 from workflows.funnel_config_overrides import funnel_cfg_overrides_from_env
+from workflows.market_liquidity_config import (
+    amount_distribution_config_from_env,
+    market_money_flow_config_from_env,
+)
 from workflows.market_regime_config import market_regime_config_from_env
 from workflows.strategy_attribution_policy import attribution_weights_for_funnel, load_attribution_policy_snapshot
 
@@ -246,6 +251,8 @@ def _build_run_config(request: BacktestWorkflowRequest) -> BacktestRunConfig:
             funnel_config_overrides=funnel_overrides,
             market_breadth_calculator=calc_market_breadth,
             market_regime_analyzer=_market_regime_analyzer_from_env(),
+            market_money_flow_calculator=_market_money_flow_calculator_from_env(),
+            amount_distribution_calculator=_amount_distribution_calculator_from_env(),
             candidate_policy=candidate_policy_config_from_env(),
             ai_allocation=ai_candidate_allocation_config_from_env(),
             mainline_config=load_mainline_engine_config(),
@@ -257,6 +264,14 @@ def _build_run_config(request: BacktestWorkflowRequest) -> BacktestRunConfig:
 
 def _market_regime_analyzer_from_env():
     return partial(analyze_benchmark_and_tune_cfg, regime_config=market_regime_config_from_env())
+
+
+def _market_money_flow_calculator_from_env():
+    return partial(calc_market_money_flow, config=market_money_flow_config_from_env())
+
+
+def _amount_distribution_calculator_from_env():
+    return partial(calc_amount_distribution_health, config=amount_distribution_config_from_env())
 
 
 def _signal_weight_map_from_env() -> dict[str, float]:


### PR DESCRIPTION
## 问题

回测按日判定水温时，只给 `analyze_benchmark_and_tune_cfg` 传了 `breadth`，`money_flow` 和 `amount_distribution` 留空。

`tools/market_regime.py:940-941` 不会报错，而是拿一个**空的行情字典**兜底重算。退化是精确的，不是「精度差一点」：

| 量 | 空兜底下的值 |
|---|---|
| `money_flow.sample_size` | 0 |
| `direction` / `expansion` | 0 / 0 |
| `money_flow.score` | **恰好等于广度涨跌幅** |
| `retreat` 翻转点 | **-20**，与 `crash_breadth_delta_pct` 同值 |
| `up_down_amount_ratio` | 恒 `None`（`_safe_ratio(0,0)`） |
| `amount_distribution.state` | `"unknown"` |

`_money_flow_score` 里 `breadth_part = breadth_delta / 20.0`，再乘 20，`direction` 和 `expansion` 都是 0，所以 `score == breadth_delta` 逐位相同。实测：delta −5.0→score −5.0，−19.9→−19.9（都是 neutral），−20.0→−20.0（retreat），−30.98→−31.0。

## 后果

CRASH 要求**价格判据 + 一条确认判据**（广度断崖 **或** 资金撤退）。两条确认判据于是塌成同一个信号数两遍——广度没到 −20 时，资金流也一定到不了。

9 天 CRASH 只复现 1 天：2026-08-19，广度 `delta=-30.98` 自己够到断崖阈值。其余 8 天走 `if panic_reasons: regime = "RISK_OFF"` 掉档。

两档下游行为不同，所以这不是换个标签：

- `workflows/step4_order_engine.py:79` 仓位系数 CRASH 0.70 vs RISK_OFF 0.85
- `core/market_trade_mode.py:46` `MARKET_EXECUTION_PRIORITY` CRASH 2 vs RISK_OFF 3
- `_tune_risk_off_cfg` 只认 RISK_OFF，没有 `elif regime == "CRASH"` 分支

**第二处影响：** `money_flow` 还喂 `_resolve_holiday_grace_dynamic`，它会真的改写 `cfg.exit_holiday_grace_days`（默认开启，1 → 2），且在 `run_funnel` 拿到 `day_cfg` 之前执行。所以空兜底连节后宽限期也一起算歪了，不只是水温标签。

## 改动

沿用上一处 `smallcap_bench_df` 的注入形式：`core/` 收可选 `Callable`，`workflows/` 层填真实实现（读 env 配置的 `partial`）。

- `core/backtest_replay.py`：2 个类型别名、2 个 dataclass 字段、`_liquidity_context` 等 3 个 helper、`_analyze_market_regime` 加 `money_flow=` / `amount_distribution=` 两个 kwarg
- `core/backtest_config.py`：`BacktestRunInput` 2 个字段并转接
- `workflows/backtest.py`：2 个 `partial` 工厂，复用生产同一套 `market_liquidity_config`

## 验证边界（重要）

单元测试用的是**真实 analyzer**，不是 spy：同一天同一组价格，带 `money_flow=retreat` 判 CRASH，不带则判 RISK_OFF——这条是有判别性的对照，填错了会退回旧行为。

**没有验证的是**：那 8 个生产日的真实资金流够不够到撤退线。生产只在 `source_jobs.daily_job` 里记了 `breadth`，没有资金流快照，重建每天约 5000 只票的面板没做。本改动只保证入参正确，具体哪天翻转取决于真实数据。

## 测试

- `tests/core/test_backtest_regime_money_flow.py` 新增 14 个
- `tests/workflows/test_backtest_service.py` 补接线断言
- `tests/core tests/workflows` 2265 passed
- `scripts/quality_gate.py --check-functions` OK

用例里记了两个踩过的坑：广度字典的键名必须是 `ratio_pct` / `delta_pct`（写成 `ratio` / `delta` 不报错，被当缺值静默忽略）；指数样本必须 ≥200 行（MA200 缺失时是 NaN，而 `_structural_regime` 用 `value is None` 判空，NaN 会穿过去，BEAR 永不成立、全部塌成 NEUTRAL）。