### PR TITLE
fix(regime): 每个周一都被判成节后,离场宽限期白放宽一天

### DIFF
--- a/core/wyckoff_engine.py
+++ b/core/wyckoff_engine.py
@@ -2622,13 +2622,17 @@ def _detect_upthrust_after_distribution(df: pd.DataFrame, cfg: FunnelConfig) -> 
     }
 
 
-def _skipped_weekdays(prev: pd.Timestamp, curr: pd.Timestamp) -> int:
+def skipped_weekdays(prev: pd.Timestamp, curr: pd.Timestamp) -> int:
     """两个相邻交易日之间被跳过的工作日数。0 = 连续交易日，**普通周末也算连续**。
 
     判据是「中间有没有整个工作日没开盘」，不是「跨了几个自然日」。跨天数会两头出错：
 
     - 周五 → 周一跨 3 自然日，中间只有周六周日，**是普通周末不是假日**；
     - 周二 → 周四只跨 2 自然日，中间的周三是工作日却没开盘,**这才是假日**。
+
+    公开给 tools/market_regime.py 复用:节后判据原先在两处各抄了一份跨自然日的写法,
+    #401 只修了本文件这处,另一处直到 2026-09-09 才发现同样把每个周一当节后。
+    同一个问题按定义只应有一个实现。
     """
     gap = (curr - prev).days
     if gap <= 1:
@@ -2646,7 +2650,7 @@ def _is_holiday_grace(df_s: pd.DataFrame, grace_days: int) -> bool:
     34.9——那批本该吃 −35 分的票,周一一分不扣。
 
     同一个阈值还漏掉周中单日假(周二→周四跨 2 天,判 False)。改成数「被跳过的
-    工作日」两头都对,见 :func:`_skipped_weekdays`。
+    工作日」两头都对,见 :func:`skipped_weekdays`。
     """
     if grace_days <= 0 or "date" not in df_s.columns or len(df_s) < 2:
         return False
@@ -2656,7 +2660,7 @@ def _is_holiday_grace(df_s: pd.DataFrame, grace_days: int) -> bool:
     for i in range(1, check_pairs + 1):
         if dates.isna().iloc[-i] or dates.isna().iloc[-i - 1]:
             continue
-        if _skipped_weekdays(dates.iloc[-i - 1], dates.iloc[-i]) >= 1:
+        if skipped_weekdays(dates.iloc[-i - 1], dates.iloc[-i]) >= 1:
             return True
     return False
 

--- a/tests/core/test_wyckoff_engine.py
+++ b/tests/core/test_wyckoff_engine.py
@@ -25,7 +25,6 @@ from core.wyckoff_engine import (
     _latest_trade_date,
     _lps_creek_confirmed,
     _recent_sequence_events,
-    _skipped_weekdays,
     _sos_volume_ratio,
     _spring_support_level,
     build_candidate_entries,
@@ -36,6 +35,7 @@ from core.wyckoff_engine import (
     layer2_strength_detailed,
     layer3_sector_resonance,
     layer5_exit_signals,
+    skipped_weekdays,
     sort_by_date_if_needed,
 )
 
@@ -306,10 +306,10 @@ class TestSkippedWeekdays:
         ],
     )
     def test_counts_only_missing_weekdays(self, prev, curr, expected, label):
-        assert _skipped_weekdays(pd.Timestamp(prev), pd.Timestamp(curr)) == expected, label
+        assert skipped_weekdays(pd.Timestamp(prev), pd.Timestamp(curr)) == expected, label
 
     def test_same_day_is_zero(self):
-        assert _skipped_weekdays(pd.Timestamp("2024-01-05"), pd.Timestamp("2024-01-05")) == 0
+        assert skipped_weekdays(pd.Timestamp("2024-01-05"), pd.Timestamp("2024-01-05")) == 0
 
 
 class TestComputeStopLoss:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2199,6 +2199,61 @@ class TestMarketRegime:
         assert cfg.exit_holiday_grace_days == 2
         assert result["holiday_grace_dynamic"]["extended"] is True
 
+    def _holiday_grace_result(self, monkeypatch, last_two_dates: tuple[str, str]):
+        """跑一遍水温,把基准最后两个交易日钉成指定日期。资金流给平稳档,
+        让「是不是节后」成为唯一决定放宽与否的判据。"""
+        import tools.market_regime as market_regime
+        from core.wyckoff_engine import FunnelConfig
+
+        monkeypatch.setattr(market_regime, "_generate_pv_outlook", lambda **_kwargs: "次日推演：测试")
+        closes = list(pd.Series(range(220), dtype=float).map(lambda x: 100.0 + x * 0.2))
+        bench = _benchmark_df(closes)
+        bench.loc[len(bench) - 2, "date"] = last_two_dates[0]
+        bench.loc[len(bench) - 1, "date"] = last_two_dates[1]
+        cfg = FunnelConfig()
+        result = market_regime.analyze_benchmark_and_tune_cfg(
+            bench,
+            None,
+            cfg,
+            breadth={"ratio_pct": 70.0, "delta_pct": 5.0, "sample_size": 100},
+            money_flow={"trend": "entry", "score": 25.0},
+        )
+        return cfg, result["holiday_grace_dynamic"]
+
+    def test_holiday_grace_does_not_extend_over_a_plain_weekend(self, monkeypatch):
+        """周五→周一跨 3 自然日但没跳过任何工作日,不是节后,宽限期必须保持 1。
+
+        原判据是 gap_days < 3 才跳过,周五到周一正好 3 天,于是每个周一都被判成节后、
+        止损多躺一个交易日。#401 修过 core/wyckoff_engine 那处,这是漏掉的第二处。
+        """
+        friday, monday = pd.Timestamp("2026-09-04"), pd.Timestamp("2026-09-07")
+        assert (friday.weekday(), monday.weekday()) == (4, 0)
+
+        cfg, grace = self._holiday_grace_result(monkeypatch, (friday.strftime("%Y-%m-%d"), monday.strftime("%Y-%m-%d")))
+
+        assert grace["gap_days"] == 3, "自然日间隔仍照实上报,只是不再拿它判节后"
+        assert grace["skipped_weekdays"] == 0
+        assert grace["reason"] == "not_holiday_gap"
+        assert grace["extended"] is False
+        assert cfg.exit_holiday_grace_days == 1
+
+    def test_holiday_grace_extends_over_a_midweek_single_day_holiday(self, monkeypatch):
+        """周二→周四只跨 2 自然日,但中间的周三整日休市,这才是节后,要放宽。
+
+        旧判据 gap_days >= 3 会把这天漏掉——两头都错,不只是周一多算。
+        """
+        tuesday, thursday = pd.Timestamp("2026-09-08"), pd.Timestamp("2026-09-10")
+        assert (tuesday.weekday(), thursday.weekday()) == (1, 3)
+
+        cfg, grace = self._holiday_grace_result(
+            monkeypatch, (tuesday.strftime("%Y-%m-%d"), thursday.strftime("%Y-%m-%d"))
+        )
+
+        assert grace["gap_days"] == 2, "跨天数比周末还少,旧判据据此漏判"
+        assert grace["skipped_weekdays"] == 1
+        assert grace["extended"] is True
+        assert cfg.exit_holiday_grace_days == 2
+
     def test_market_pv_policy_shadow_structures_defensive_outlook(self):
         from core.wyckoff_engine import FunnelConfig
         from tools.market_regime import derive_market_pv_policy_shadow

--- a/tools/market_regime.py
+++ b/tools/market_regime.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 import pandas as pd
 
 from core.market_breadth import calc_market_breadth as calc_core_market_breadth
-from core.wyckoff_engine import FunnelConfig
+from core.wyckoff_engine import FunnelConfig, skipped_weekdays
 from tools.market_liquidity import calc_amount_distribution_health, calc_market_money_flow
 from utils.safe import finite_float as _safe_float
 
@@ -202,6 +202,8 @@ def calc_market_breadth(
 
 
 def _latest_trade_gap_days(df: pd.DataFrame | None) -> int:
+    """最后两个交易日跨了几个自然日。只作观测字段用,别拿它判节后——见
+    :func:`_latest_skipped_weekdays`。"""
     if df is None or df.empty or "date" not in df.columns:
         return 0
     dates = pd.to_datetime(df["date"], errors="coerce").dropna().sort_values()
@@ -210,20 +212,55 @@ def _latest_trade_gap_days(df: pd.DataFrame | None) -> int:
     return int((dates.iloc[-1].date() - dates.iloc[-2].date()).days)
 
 
+def _latest_skipped_weekdays(df: pd.DataFrame | None) -> int:
+    """最后两个交易日之间被跳过的工作日数,0 = 普通周末或连续交易日。"""
+    if df is None or df.empty or "date" not in df.columns:
+        return 0
+    dates = pd.to_datetime(df["date"], errors="coerce").dropna().sort_values()
+    if len(dates) < 2:
+        return 0
+    return skipped_weekdays(dates.iloc[-2], dates.iloc[-1])
+
+
+def _resolve_holiday_grace_from_bench(
+    cfg: FunnelConfig,
+    regime: str,
+    money_flow: dict,
+    bench_df: pd.DataFrame | None,
+) -> dict:
+    return _resolve_holiday_grace_dynamic(
+        cfg,
+        regime,
+        money_flow,
+        _latest_trade_gap_days(bench_df),
+        _latest_skipped_weekdays(bench_df),
+    )
+
+
 def _resolve_holiday_grace_dynamic(
     cfg: FunnelConfig,
     regime: str,
     money_flow: dict,
     gap_days: int,
+    skipped: int,
 ) -> dict:
+    """资金流平稳时把节后宽限期从 1 天放宽到 exit_holiday_grace_max_days。
+
+    判据是「中间有没有整个工作日没开盘」,不是「跨了几个自然日」。原先门是
+    ``gap_days < 3`` 才跳过,而周五→周一正好跨 3 自然日,于是**每个周一都被判成节后**,
+    只要资金流不是撤退就把离场宽限期从 1 放宽到 2,止损多躺一个交易日。
+    这是 #401 修过的同一个 bug 的第二处:当时只改了
+    core/wyckoff_engine.py 的 ``_is_holiday_grace``,本处漏了。
+    """
     result = {
         "enabled": bool(cfg.exit_holiday_grace_dynamic_enabled),
         "gap_days": gap_days,
+        "skipped_weekdays": skipped,
         "extended": False,
         "exit_holiday_grace_days": int(cfg.exit_holiday_grace_days),
         "reason": "",
     }
-    if not cfg.exit_holiday_grace_dynamic_enabled or gap_days < 3:
+    if not cfg.exit_holiday_grace_dynamic_enabled or skipped < 1:
         result["reason"] = "not_holiday_gap"
         return result
     score = float(money_flow.get("score") or 0.0)
@@ -333,6 +370,7 @@ def _base_holiday_grace_context(cfg: FunnelConfig) -> dict:
     return {
         "enabled": bool(cfg.exit_holiday_grace_dynamic_enabled),
         "gap_days": 0,
+        "skipped_weekdays": 0,
         "extended": False,
         "exit_holiday_grace_days": int(cfg.exit_holiday_grace_days),
         "reason": "",
@@ -964,9 +1002,7 @@ def analyze_benchmark_and_tune_cfg(
     regime, bear_rebound_reasons = _apply_bear_rebound_regime(regime, main)
     _apply_evr_policy(cfg, regime, runtime)
     _tune_cfg_for_regime(cfg, regime, main.recent3_cum, runtime)
-    holiday_grace_dynamic = _resolve_holiday_grace_dynamic(
-        cfg, regime, money_flow_context, _latest_trade_gap_days(bench_df)
-    )
+    holiday_grace_dynamic = _resolve_holiday_grace_from_bench(cfg, regime, money_flow_context, bench_df)
     breadth_context = _final_breadth_context(
         breadth_ratio,
         breadth_prev,


### PR DESCRIPTION
## 问题

这是 #401 那个 bug 的第二处。#401 修的是「节后宽限期按自然日算,把每个周一都当成节后」,当时只改了 `core/wyckoff_engine.py` 的 `_is_holiday_grace`。`tools/market_regime.py` 里还有一份同样的判据,漏了:

```python
if not cfg.exit_holiday_grace_dynamic_enabled or gap_days < 3:
    result["reason"] = "not_holiday_gap"
    return result
```

`_latest_trade_gap_days` 返回的是 `(dates[-1] - dates[-2]).days`,**周五→周一正好 3 自然日**,过门。

## 后果

过门之后,只要资金流不是撤退、分数不低于 `exit_holiday_grace_min_money_flow_score`(默认 −5.0),就执行:

```python
cfg.exit_holiday_grace_days = max(old_days, int(cfg.exit_holiday_grace_max_days))
```

默认 `exit_holiday_grace_days=1` → `2`,而 `exit_holiday_grace_dynamic_enabled` **默认就是 True**。所以每个周一,离场宽限期都白放宽一天,止损在宽限期里多躺一个交易日。

`_is_holiday_grace` 里 `check_pairs = min(grace_days, n - 1)`,`grace_days` 从 1 变 2 就多往回看一对交易日,窗口是真的宽了。

**两头都错,不只是周一多算。** 周二→周四只跨 2 自然日,中间的周三整日休市——这才是真节后,旧判据反而漏掉。

方向和 #401 那处相反(那处是跳过止损,这处是放宽窗口),症状对不上,所以一直没被联想到一起。

回测侧吃同一个 bug:`_analyze_market_regime` 在 `run_funnel` 拿到 `day_cfg` 之前跑,改写的就是那份 cfg。

## 改动

判据换成「相邻交易日之间被跳过的工作日数 ≥ 1」,直接复用 `core.wyckoff_engine.skipped_weekdays`,并把它从 `_skipped_weekdays` 提成公开名。

**没有再抄一份日期逻辑。** 同一个问题被抄成两份,正是这次漏修的根因——#401 改了一处,另一处安静地错着。

`gap_days` 作为观测字段照实保留(周末仍上报 3,名字没说谎),另加 `skipped_weekdays` 字段,省得下次再有人拿自然日去判节后。

顺带确认了第三处 `workflows/market_funnel_data.py::_max_recent_gap_days` **不是** 同一个 bug:它问的是「行情源缺没缺整段」,阈值 `BENCHMARK_MAX_GAP_DAYS = 21`,自然日是对的单位,周末 3 天永远碰不到,没动它。

## 测试

补了两个此前缺失的用例。缺的一直是**假阳性那一侧**——原有的 `test_holiday_grace_extends_when_money_flow_is_not_retreat` 用 5 天间隔,不管从周几起算都至少跳过 1 个工作日,是真节后,修完照样通过。它没钉住 bug,只是没覆盖到。

| 用例 | gap_days | skipped_weekdays | 期望 |
|---|---|---|---|
| 周五→周一 | 3 | 0 | 不放宽 |
| 周二→周四 | 2 | 1 | 放宽 |

两个都是对照式的,**拿旧判据跑会失败**——已实测回退 `skipped < 1` 为 `gap_days < 3`,两条同时 FAILED,双向都判别得出来。用例里把两个日期的 `weekday()` 也断言了,免得日期改了意图悄悄漂走。

全量 `tests/` 4982 passed / 22 skipped,`--check-functions` OK,`ruff check` / `ruff format --check` 全库干净。