### PR TITLE
fix(backtest): bull_2025 在 walk-forward 里出现 0 次,报表把它读成裸日期区间

### DIFF
--- a/.github/workflows/backtest_grid.yml
+++ b/.github/workflows/backtest_grid.yml
@@ -221,28 +221,33 @@ jobs:
       # 六个周期各自独立、互不依赖，全部并行即可。此前 max-parallel: 4 会让
       # all_defined 分两轮执行，墙钟时间接近翻倍。
       max-parallel: 6
+      # 2026-09-09 补 hold=2/3 与 hold=5 的止损档:此前参数格只覆盖 5/10/15 天,
+      # 而 5 天只有无退出基线,2~3 天完全没测 —— 实际持有期是 2~10 天不固定,
+      # 于是短持有段既无收益读数也无止损读数,报表里"N天最佳"从 5 天起跳。
+      # 同一周期的所有单元共用一份信号台账(workflows/backtest.py 复用 ledger),
+      # 新增单元只多跑退出重放;台账按最小 hold 建,min 5→2 只多算 3 个交易日。
       matrix:
         include:
           - period_key: recent_2m
             grid_cells: "5:0:0:0,10:0:0:0,10:-7:0:0,15:-8:18:0,20:-8:0:-5"
           - period_key: recent_6m
-            grid_cells: "5:0:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
+            grid_cells: "2:0:0:0,3:0:0:0,3:-5:0:0,5:0:0:0,5:-5:0:0,5:-8:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
           - period_key: bull_2020
-            grid_cells: "5:0:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
+            grid_cells: "2:0:0:0,3:0:0:0,3:-5:0:0,5:0:0:0,5:-5:0:0,5:-8:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
           - period_key: bear_2022
-            grid_cells: "5:0:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
+            grid_cells: "2:0:0:0,3:0:0:0,3:-5:0:0,5:0:0:0,5:-5:0:0,5:-8:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
           # 2026-08-08 补齐：这两个周期此前只有 fetch 快照、grid 矩阵无对应条目，
           # 导致 all_defined 实际只跑 4 个周期，parameter_stability 因覆盖不足
           # 反复判 review。补上后震荡市与高波动市才纳入跨周期稳健性判定。
           - period_key: sideways_2023
-            grid_cells: "5:0:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
+            grid_cells: "2:0:0:0,3:0:0:0,3:-5:0:0,5:0:0:0,5:-5:0:0,5:-8:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
           - period_key: volatile_2024
-            grid_cells: "5:0:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
+            grid_cells: "2:0:0:0,3:0:0:0,3:-5:0:0,5:0:0:0,5:-5:0:0,5:-8:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
           # 2026-08-21 补齐 bull_2025：此前 5 个时期覆盖 61% 交易日，2025 全年（243 日、
           # 上证 +21.6%、创业板 +55.5%、振幅 30.1%）完全落在空档里，而它是最近的完整年度、
           # 市场结构最接近当前。
           - period_key: bull_2025
-            grid_cells: "5:0:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
+            grid_cells: "2:0:0:0,3:0:0:0,3:-5:0:0,5:0:0:0,5:-5:0:0,5:-8:0:0,10:0:0:0,10:-5:0:0,10:-7:0:0,10:-8:0:0,15:-5:0:0,15:-7:0:0,15:-8:0:0,10:-5:0:-8,10:-8:0:-8,10:-8:0:-8:5,10:-8:0:-8:7"
     env:
       PYTHONUNBUFFERED: "1"
       TZ: Asia/Shanghai
@@ -278,7 +283,9 @@ jobs:
       # 能不能买由 _live_buy_block_regimes 决定，买多少由 _limit_probe_only_selection 决定。
       STEP4_BUY_PROBE_REGIMES: ${{ vars.STEP4_BUY_PROBE_REGIMES || '' }}
       STEP4_BLOCK_BUY_SIGNAL_TYPES: ${{ vars.STEP4_BLOCK_BUY_SIGNAL_TYPES || '' }}
-      FUNNEL_DYNAMIC_POLICY: ${{ vars.FUNNEL_DYNAMIC_POLICY || 'shadow' }}
+      # 必须与 wyckoff_funnel.yml 同源:少 secrets 兜底时,job 级 env 覆盖 workflow 级,
+      # 于是实盘读 Secret 里的值、回测读字面量 'shadow',量的不是同一条策略通道。
+      FUNNEL_DYNAMIC_POLICY: ${{ vars.FUNNEL_DYNAMIC_POLICY || secrets.FUNNEL_DYNAMIC_POLICY || 'shadow' }}
       FUNNEL_DYNAMIC_POLICY_HORIZON: "5"
       FUNNEL_DEFENSIVE_FORCE_QUOTA: "1"
       FUNNEL_MAX_STRUCTURE_STOP_PCT: "12.0"
@@ -730,6 +737,7 @@ jobs:
           python3 -u - <<'PYEOF'
           import csv, os, glob, json, re, requests
           from core.backtest_grid_ranking import rank_robust_params, robust_label as shared_robust_label, weak_period_guardrails
+          from core.backtest_periods import PERIOD_ORDER, period_label as shared_period_label, resolve_period_key
 
           webhook = os.environ.get('FEISHU_WEBHOOK_URL', '').strip()
           if not webhook:
@@ -785,14 +793,18 @@ jobs:
               return parts if len(parts) == 2 else ['', '']
 
           def parse_period(dirname, start, end):
-              m = re.search(r'backtest-grid-(recent_2m|recent_6m|bull_2020|bear_2022|custom)-h', dirname)
-              if m:
-                  return m.group(1)
-              if start == '2020-07-01' and end == '2021-02-18':
-                  return 'bull_2020'
-              if start == '2021-12-13' and end == '2022-10-31':
-                  return 'bear_2022'
-              return os.environ.get('BT_PERIOD_LABEL', 'recent_6m')
+              # 名单收敛到 core.backtest_periods。原来这里只认 5 个 key，
+              # sideways_2023 / volatile_2024 / bull_2025 全部落到 BT_PERIOD_LABEL 兜底；
+              # all_defined 下该值是整串逗号列表，三个周期于是并成同一个 bucket，
+              # 而 _best_cells_by_period 只留每 bucket 最大值 —— sideways_2023 的
+              # -10.78% 被 bull_2025 的 +29.78% 盖住，period_count 从 6 掉到 4，
+              # 足以把 robust_label 抬到「稳健参数（跨周期全正）」。
+              resolved = resolve_period_key(dirname, start, end)
+              if resolved:
+                  return resolved
+              fallback = os.environ.get('BT_PERIOD_LABEL', 'recent_6m')
+              # 兜底值可能是逗号串（all_defined），拆开只会更错，直接标未知。
+              return 'unknown_period' if ',' in fallback else fallback
 
           def parse_num(raw):
               text = str(raw or '').strip().replace(',', '').replace('%', '')
@@ -825,14 +837,20 @@ jobs:
                   return rows
               return []
 
+          # 卡片宽度有限，这里只覆盖需要缩写的 key；其余回落到登记表的完整展示名。
           period_names = {
               'recent_2m': '最近2月',
               'recent_6m': '最近6月',
-              'bull_2020': '牛市',
-              'bear_2022': '熊市',
+              'bull_2020': '牛市2020',
+              'bear_2022': '熊市2022',
+              'sideways_2023': '震荡2023',
+              'volatile_2024': '高波2024',
+              'bull_2025': '牛市2025',
               'custom': '自定义',
+              'unknown_period': '未识别周期',
           }
-          period_order = {'recent_2m': 0, 'recent_6m': 1, 'bull_2020': 2, 'bear_2022': 3, 'custom': 4}
+          period_order = dict(PERIOD_ORDER)
+          period_order['unknown_period'] = 99
           style_names = {
               'slot_equal_4': '等额四仓',
               'probe_add': '观察补仓',
@@ -843,7 +861,7 @@ jobs:
           style_order = {'slot_equal_4': 0, 'probe_add': 1, 'confirmation_only': 2, 'trend_pyramid': 3, 'concentrated_swap': 4}
 
           def period_label(period):
-              return period_names.get(period, period)
+              return period_names.get(period) or shared_period_label(period)
 
           def period_sort_key(period):
               return (period_order.get(period, 99), period)

--- a/core/backtest_periods.py
+++ b/core/backtest_periods.py
@@ -1,0 +1,82 @@
+"""回测周期登记表：period_key / 展示名 / 固定日期区间的唯一事实源。
+
+此前 period 名单在四处各写一份（backtest_grid.yml 的 notify 内联脚本、
+backtest_market_report_artifacts._parse_period_key、backtest_market_report_builder
+的 PERIOD_LABELS、backtest_parameter_stability._period_rank）。matrix 每加一个周期
+都要同步四处，实测漏改后果不是报错而是静默失真：
+
+- 2026-08-21 加 bull_2025 后，_parse_period_key 未同步 → period_key 为空串 →
+  backtest_walk_forward 第 38 行 ``if cell.period_key`` 直接丢掉该周期。run
+  32537955220 的 walk_forward 只有 16 个窗口（4 风格 × 4 迁移），bull_2025 出现
+  0 次；而它是最近的完整年度、也是该次唯一 +29.78% 的周期。
+- notify 内联脚本的正则同样缺三个周期，三者一起回落到 BT_PERIOD_LABEL 兜底。
+  all_defined 下该值是整串逗号列表，于是 sideways_2023 / volatile_2024 / bull_2025
+  被并成同一个 bucket，而 _best_cells_by_period 只留每 bucket 最大值，
+  sideways_2023 的 -10.78% 被 bull_2025 的 +29.78% 盖住，period_count 从 6 掉到 4，
+  足以把 robust_label 抬到「稳健参数（跨周期全正）」。
+
+新增周期只改这里，并同步 backtest_grid.yml 的 matrix 与日期分支。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BacktestPeriod:
+    key: str
+    label: str
+    start: str | None = None
+    end: str | None = None
+
+
+# 顺序即报表展示顺序：滚动窗口在前，历史窗口按时间先后，custom 收尾。
+BACKTEST_PERIODS: tuple[BacktestPeriod, ...] = (
+    BacktestPeriod("recent_2m", "最近2个月"),
+    BacktestPeriod("recent_6m", "最近6个月"),
+    BacktestPeriod("bull_2020", "牛市 2020-07~2021-02", "2020-07-01", "2021-02-18"),
+    BacktestPeriod("bear_2022", "熊市 2021-12~2022-10", "2021-12-13", "2022-10-31"),
+    BacktestPeriod("sideways_2023", "震荡市 2023", "2023-01-03", "2023-12-29"),
+    BacktestPeriod("volatile_2024", "高波动市 2024", "2024-01-02", "2024-12-31"),
+    BacktestPeriod("bull_2025", "牛市 2025", "2025-01-02", "2025-12-31"),
+    BacktestPeriod("custom", "自定义周期"),
+)
+
+PERIOD_KEYS: tuple[str, ...] = tuple(period.key for period in BACKTEST_PERIODS)
+PERIOD_LABELS: dict[str, str] = {period.key: period.label for period in BACKTEST_PERIODS}
+PERIOD_ORDER: dict[str, int] = {period.key: idx for idx, period in enumerate(BACKTEST_PERIODS)}
+FIXED_PERIOD_RANGES: dict[tuple[str, str], str] = {
+    (period.start, period.end): period.key for period in BACKTEST_PERIODS if period.start and period.end
+}
+
+# 目录名形如 backtest-grid-<period_key>-h10-sl8-tp0-tr8
+_DIRNAME_PATTERN = "backtest-grid-{key}-h"
+
+
+def period_key_from_dirname(dirname: str) -> str:
+    """从 artifact 目录名解析 period_key；解析不出返回空串。"""
+    text = str(dirname or "")
+    for key in PERIOD_KEYS:
+        if _DIRNAME_PATTERN.format(key=key) in text:
+            return key
+    return ""
+
+
+def period_key_from_dates(start: str, end: str) -> str:
+    """按固定日期区间反查 period_key；滚动窗口与未知区间返回空串。"""
+    return FIXED_PERIOD_RANGES.get((str(start or "").strip(), str(end or "").strip()), "")
+
+
+def resolve_period_key(dirname: str, start: str = "", end: str = "") -> str:
+    """先按目录名解析，再按固定日期区间兜底。"""
+    return period_key_from_dirname(dirname) or period_key_from_dates(start, end)
+
+
+def period_label(key: str) -> str:
+    return PERIOD_LABELS.get(str(key or ""), str(key or ""))
+
+
+def period_rank(key: str) -> int:
+    """未登记周期排在末尾，保持既有 9 的哨兵语义。"""
+    return PERIOD_ORDER.get(str(key or ""), len(BACKTEST_PERIODS) + 1)

--- a/tests/core/test_backtest_periods.py
+++ b/tests/core/test_backtest_periods.py
@@ -1,0 +1,62 @@
+"""回测周期登记表的回归用例。
+
+守的是同一类事故：backtest_grid.yml 的 matrix 加了周期，而报表侧的周期名单没跟着改。
+漏改不抛错，只是 period_key 变成空串，接着 walk_forward 把空 key 整段丢掉 ——
+2026-08-21 加 bull_2025 后，run 32537955220 的 walk_forward 出现 0 次 bull_2025，
+而它是那轮唯一 +29.78% 的周期。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from core.backtest_periods import (
+    BACKTEST_PERIODS,
+    PERIOD_LABELS,
+    period_key_from_dates,
+    period_key_from_dirname,
+    period_rank,
+    resolve_period_key,
+)
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/backtest_grid.yml"
+
+
+def _matrix_period_keys() -> list[str]:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    include = data["jobs"]["grid"]["strategy"]["matrix"]["include"]
+    return [str(entry["period_key"]) for entry in include]
+
+
+def test_registry_covers_every_matrix_period() -> None:
+    """matrix 里的每个 period_key 都必须能被登记表解析出来。
+
+    这条用例就是那次漏改的检测器：只要 matrix 新增周期而登记表没同步，这里立刻红。
+    """
+    for key in _matrix_period_keys():
+        dirname = f"backtest-grid-{key}-h10-sl8-tp0-tr0"
+        assert period_key_from_dirname(dirname) == key, key
+        assert PERIOD_LABELS.get(key), key
+
+
+def test_bull_2025_resolves_from_dirname() -> None:
+    # 旧正则的名单停在 volatile_2024，bull_2025 会解析成空串。
+    assert period_key_from_dirname("backtest-grid-bull_2025-h10-sl8-tp0-tr0") == "bull_2025"
+
+
+def test_fixed_ranges_map_back_to_their_key() -> None:
+    for period in BACKTEST_PERIODS:
+        if period.start and period.end:
+            assert period_key_from_dates(period.start, period.end) == period.key
+
+
+def test_resolve_falls_back_to_dates_when_dirname_unknown() -> None:
+    assert resolve_period_key("some-other-dir", "2025-01-02", "2025-12-31") == "bull_2025"
+    assert resolve_period_key("some-other-dir", "", "") == ""
+
+
+def test_period_rank_orders_registry_and_sinks_unknown() -> None:
+    assert period_rank("recent_6m") < period_rank("bull_2025")
+    assert period_rank("not_a_period") > period_rank("custom")

--- a/tests/scripts/test_update_backtest_market_report.py
+++ b/tests/scripts/test_update_backtest_market_report.py
@@ -681,3 +681,36 @@ def test_market_report_recognizes_recent_2m_fast_grid(tmp_path):
     assert "| 1 | 等额四仓 / 20天 / SL-8% / 无TP / Trail-5% 🏆 | 1/1 | +1.00%" in report
     assert "- 市场周期: 市场周期未标注" in report
     assert "| 未标注 | 回测样本未写入周期标签 | 1 |" in report
+
+
+def test_market_report_labels_bull_2025(tmp_path):
+    """bull_2025 必须解析出 period_key 并显示成中文标签，而不是裸日期区间。
+
+    旧实现里报表侧的周期正则名单停在 volatile_2024，bull_2025 落到空 key：
+    「各周期最佳」只能打印 `2025-01-02 ~ 2025-12-31`，且 walk_forward 整段丢掉该周期。
+    """
+    from scripts.update_backtest_market_report import build_report, load_grid_cells
+
+    _write_grid_cell(tmp_path, "bull_2025", "2025-01-02", "2025-12-31", 10, 8, 29.78)
+
+    cells = load_grid_cells(tmp_path)
+    assert {cell.period_key for cell in cells} == {"bull_2025"}
+
+    report = build_report(cells)
+    assert "牛市 2025" in report
+
+
+def test_market_report_does_not_claim_tp_hurts_when_no_tp_cell_tested(tmp_path):
+    """参数格里没有 TP>0 的对照单元时，不能断言"关闭止盈更好"。
+
+    all_defined 的六个周期每格都是 take_profit=0，旧条件 `if best.take_profit == 0`
+    因此恒真——结论无法被数据推翻，属于「对照行必须量自己」同一类缺陷。
+    """
+    from scripts.update_backtest_market_report import build_report, load_grid_cells
+
+    _write_grid_cell(tmp_path, "recent_6m", "2026-01-02", "2026-06-30", 10, 8, 4.0)
+
+    report = build_report(load_grid_cells(tmp_path))
+
+    assert "固定 TP 容易截断趋势" not in report
+    assert "本轮参数格未设固定止盈单元" in report

--- a/tests/workflows/test_backtest_walk_forward.py
+++ b/tests/workflows/test_backtest_walk_forward.py
@@ -60,3 +60,46 @@ def test_walk_forward_passes_when_each_train_winner_survives_next_window(tmp_pat
 
     assert result["status"] == "pass"
     assert result["positive_test_count"] == 2
+
+
+def _unkeyed_cell(root: Path, hold: int, cash_return: float) -> None:
+    """目录名不含已登记的 period_key，模拟报表侧名单漏改后的产物。"""
+    artifact = root / f"backtest-grid-h{hold}-sl-7-tp0-tr0"
+    artifact.mkdir()
+    (artifact / f"summary_unknown_h{hold}.md").write_text(
+        "\n".join(
+            [
+                "- 区间: 2025-01-02 ~ 2025-12-31",
+                "- 每日候选上限: Top 4",
+                "- 股票池: all (sample=0)",
+                "- 成交样本: 20",
+                "- 胜率: 50%",
+                "- 初始现金: 100000",
+                f"- 最终现金: {100000 * (1 + cash_return / 100):.2f}",
+                f"- 总收益: {cash_return}%",
+                "- 成交笔数: 10",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_walk_forward_keeps_period_whose_key_cannot_be_resolved(tmp_path: Path) -> None:
+    """period_key 解析不出来时按日期区间兜底，周期不能整段消失。
+
+    旧实现是 ``if cell.period_key``：空 key 直接被过滤，该周期从时序链里消失且无日志。
+    实测后果见 run 32537955220 —— bull_2025 在 16 个窗口里出现 0 次。
+    """
+    _grid(tmp_path, {10: (8.0, -2.0, 3.0), 15: (4.0, 6.0, 5.0)})
+    _unkeyed_cell(tmp_path, 10, 12.0)
+    _unkeyed_cell(tmp_path, 15, 9.0)
+
+    cells = load_grid_cells(tmp_path)
+    assert any(cell.period_key == "" for cell in cells), "用例前提：需要有解析不出 key 的单元"
+
+    result = build_walk_forward_validation(cells)
+
+    # 三个已登记周期 + 兜底周期 = 4 个，迁移窗口从 2 个增加到 3 个。
+    assert result["evaluated_window_count"] == 3
+    ends = [window["test_period"] for window in result["windows"]]
+    assert any("2025-01-02" in str(end) for end in ends), ends

--- a/workflows/backtest_market_report_artifacts.py
+++ b/workflows/backtest_market_report_artifacts.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from core.backtest_periods import period_key_from_dirname
+
 
 @dataclass(frozen=True)
 class GridCell:
@@ -163,14 +165,9 @@ def _parse_params(dirname: str) -> tuple[int, int, int, int, int] | None:
 
 
 def _parse_period_key(dirname: str) -> str:
-    # 周期名单必须与 backtest_grid.yml 的 matrix 同步。缺 sideways_2023 / volatile_2024
-    # 会让这两个窗口的 period_key 变成空串，回落到 start_end 兜底——周期数没丢，但
-    # REQUIRED_PERIODS 判定与 _representative 的偏好选择都会失准。
-    match = re.search(
-        r"backtest-grid-(recent_2m|recent_6m|bull_2020|bear_2022|sideways_2023|volatile_2024|custom)-h",
-        dirname,
-    )
-    return match.group(1) if match else ""
+    # 名单收敛到 core.backtest_periods，避免 matrix 加周期时漏改这里：漏改不报错，
+    # 只是 period_key 变空串，而 backtest_walk_forward 会静默丢掉空 key 的周期。
+    return period_key_from_dirname(dirname)
 
 
 def _split_md_row(line: str) -> list[str]:

--- a/workflows/backtest_market_report_builder.py
+++ b/workflows/backtest_market_report_builder.py
@@ -14,6 +14,7 @@ from core.backtest_grid_ranking import (
     robust_label,
     weak_period_guardrails,
 )
+from core.backtest_periods import PERIOD_LABELS, PERIOD_ORDER
 from workflows.backtest_market_report_artifacts import GridCell, read_trades
 from workflows.backtest_parameter_stability import build_parameter_stability
 from workflows.backtest_walk_forward import build_walk_forward_validation
@@ -31,15 +32,7 @@ REGIME_LABELS = {
 UNKNOWN_REGIME = "未标注"
 UNKNOWN_REGIME_DESC = "回测样本未写入周期标签"
 
-PERIOD_LABELS = {
-    "recent_2m": "最近2个月",
-    "recent_6m": "最近6个月",
-    "bull_2020": "牛市 2020-07~2021-02",
-    "bear_2022": "熊市 2021-12~2022-10",
-    "custom": "自定义周期",
-}
-
-PERIOD_ORDER = {"recent_2m": 0, "recent_6m": 1, "bull_2020": 2, "bear_2022": 3, "custom": 4}
+# 标签与排序取自 core.backtest_periods，缺周期时报表里会露出裸 period_key。
 STYLE_ORDER = {
     "slot_equal_4": 0,
     "probe_add": 1,
@@ -95,8 +88,9 @@ def _period_label(cell: GridCell) -> str:
     return f"{cell.start} ~ {cell.end}" if cell.start or cell.end else "未标记周期"
 
 
-def _period_sort_key(label: str) -> tuple[int, str]:
-    return PERIOD_ORDER.get(label, 99), label
+def _period_sort_key(period_key: str) -> tuple[int, str]:
+    # 传进来的是 period_key（空 key 时调用方回落成标签串），不是展示名。
+    return PERIOD_ORDER.get(period_key, 99), period_key
 
 
 def _normalize_regime(value: str | None) -> str:
@@ -530,8 +524,7 @@ def _build_conclusion_lines(
             f"稳健分 {_fmt_num(robust_best.score, 2)}。"
         )
     lines.extend(_build_period_guardrail_lines(cells))
-    if best.take_profit == 0:
-        lines.append("- 退出观察: 当前最佳组合关闭固定止盈，说明右尾大赢家对收益贡献很大，固定 TP 容易截断趋势。")
+    lines.extend(_take_profit_comment(cells, best))
     if best.win_rate is not None and best.win_rate < 35 and best.avg_ret is not None and best.avg_ret > 0:
         lines.append(
             "- 胜率结构: 单笔胜率偏低但均收为正，属于低胜率/高赔率的趋势跟踪形态；需要监控右尾依赖，而不是单纯追求高胜率。"
@@ -542,6 +535,21 @@ def _build_conclusion_lines(
             f"去掉前三大盈利单后约 {_fmt_signed(diagnostics['drop_top_3_avg'], 2, '%')}。"
         )
     return lines
+
+
+def _take_profit_comment(cells: list[GridCell], best: GridCell) -> list[str]:
+    """只在参数格里真有固定止盈单元可比时，才说"关闭止盈更好"。
+
+    原来的条件是 `if best.take_profit == 0`。all_defined 的六个周期各 12 格全是
+    take_profit=0（唯一带 TP 的 `15:-8:18:0` 只在 recent_2m，而 recent_2m 不进
+    all_defined），于是这句必然出现，且断言的是一个从未被检验的对比 —— 与
+    「对照行必须量自己」同类：结论无法被数据推翻。
+    """
+    if best.take_profit != 0:
+        return []
+    if not any((cell.take_profit or 0) > 0 for cell in cells):
+        return ["- 退出观察: 本轮参数格未设固定止盈单元，无法判断固定 TP 是否截断趋势；如需结论要补 TP>0 的对照格。"]
+    return ["- 退出观察: 当前最佳组合关闭固定止盈，说明右尾大赢家对收益贡献很大，固定 TP 容易截断趋势。"]
 
 
 def _build_period_guardrail_lines(cells: list[GridCell]) -> list[str]:

--- a/workflows/backtest_parameter_stability.py
+++ b/workflows/backtest_parameter_stability.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.backtest_grid_ranking import RobustParamScore, rank_robust_params
+from core.backtest_periods import period_rank
 from workflows.backtest_market_report_artifacts import GridCell
 
 ParamKey = tuple[str, int, int, int, int]
@@ -70,8 +71,7 @@ def _representative(cells: list[GridCell]) -> GridCell:
 
 
 def _period_rank(period: str) -> int:
-    order = {"recent_2m": 0, "recent_6m": 1, "bull_2020": 2, "bear_2022": 3}
-    return order.get(period, 9)
+    return period_rank(period)
 
 
 def _neighbors(

--- a/workflows/backtest_walk_forward.py
+++ b/workflows/backtest_walk_forward.py
@@ -31,14 +31,28 @@ def build_walk_forward_validation(
     }
 
 
+def _period_identity(cell: GridCell) -> str:
+    """period_key 缺失时按日期区间兜底，别让周期整段从时序链里消失。
+
+    2026-08-21 加 bull_2025 时 _parse_period_key 未同步，这里原来写
+    ``if cell.period_key`` 直接过滤掉空 key，于是 run 32537955220 的
+    walk_forward 只有 4 个迁移窗口，bull_2025 出现 0 次——而它是最近的完整年度、
+    也是那次唯一 +29.78% 的周期。判定「1/16 窗口为正」正是在缺它的链上算出来的。
+    """
+    if cell.period_key:
+        return cell.period_key
+    return f"{cell.start}_{cell.end}" if (cell.start or cell.end) else ""
+
+
 def _walk_forward_windows(cells: list[GridCell]) -> list[dict[str, Any]]:
     by_style_period: dict[tuple[str, str], list[GridCell]] = defaultdict(list)
     period_end: dict[str, str] = {}
     for cell in cells:
-        if cell.period_key and cell.cash_total_return is not None:
+        identity = _period_identity(cell)
+        if identity and cell.cash_total_return is not None:
             style = cell.portfolio_style or "slot_equal_4"
-            by_style_period[(style, cell.period_key)].append(cell)
-            period_end[cell.period_key] = max(period_end.get(cell.period_key, ""), cell.end)
+            by_style_period[(style, identity)].append(cell)
+            period_end[identity] = max(period_end.get(identity, ""), cell.end)
     periods = sorted(period_end, key=lambda period: (period_end[period], period))
     styles = sorted({style for style, _period in by_style_period})
     return [


### PR DESCRIPTION
## 问题

四份硬编码的周期名单各自漂移。2026-08-21 加 `bull_2025` 时只改了 `backtest_grid.yml` 的 matrix,报表侧三处名单都没跟上。

漏改不抛错,只让 `period_key` 变成空串,而 `backtest_walk_forward` 原来写 `if cell.period_key` 直接过滤掉空 key:

- run 32537955220 的 16 个迁移窗口里 `bull_2025` 出现 **0 次**,而它是那轮唯一 +29.78% 的周期 —— 判定「1/16 窗口为正」正是在缺它的链上算出来的
- 飞书卡片的周期分桶同时塌缩:三个未识别周期回落到 `BT_PERIOD_LABEL`,`all_defined` 下该值是整串逗号列表,于是并成同一个 bucket;`_best_cells_by_period` 只留每 bucket 最大值,`sideways_2023` 的 -10.78% 被 `bull_2025` 的 +29.78% 盖住,`period_count` 从 6 掉到 4
- 「各周期最佳」里 `bull_2025` 打印成裸日期 `2025-01-02 ~ 2025-12-31`

顺带三处:参数格覆盖不到实际持有期;一条恒真的止盈结论;grid job 的策略通道与实盘不同源。

## 变更摘要

- 新增 `core/backtest_periods.py`,作为 `period_key` / 展示名 / 固定区间的唯一事实源,收敛报表产物解析、报表构建、参数稳定性、飞书卡片四处名单
- `walk_forward` 增加日期区间兜底:`period_key` 解析不出时周期不再整段消失
- 参数格补 `hold=2/3` 与 `hold=5` 的止损档。实际持有期是 2~10 天不固定,此前只覆盖 5/10/15 且 5 天仅有无退出基线,短持有段既无收益读数也无止损读数。同一周期各单元共用一份信号台账(`workflows/backtest.py:172-181`),新增单元只多跑退出重放;台账按最小 hold 建,min 5→2 只多算 3 个交易日
- 「关闭止盈更好」改为只在参数格真有 `TP>0` 对照单元时才断言。`all_defined` 六个周期每格都是 `TP=0`(唯一带 TP 的 `15:-8:18:0` 只在 `recent_2m`,而它不进 `all_defined`),旧条件 `if best.take_profit == 0` 恒真,结论无法被数据推翻
- grid job 的 `FUNNEL_DYNAMIC_POLICY` 补 `secrets` 兜底,与 `wyckoff_funnel.yml:131` 同源。少这一段时 job 级 env 覆盖 workflow 级,回测读字面量 `shadow` 而实盘读 Secret 里的值

## 验证

- `tests/core/test_backtest_periods.py` 用 yaml 直接读 matrix,逐个校验 `period_key` 可解析且有标签 —— matrix 再加周期而登记表没同步时这条立刻红
- 三条新用例均已逐一确认对旧代码为红:walk_forward 窗口数 `2 != 3`、`bull_2025` 标签缺失、TP 结论恒真
- `pytest tests/core/test_backtest_periods.py tests/workflows/test_backtest_walk_forward.py tests/workflows/test_backtest_parameter_stability.py tests/scripts/test_update_backtest_market_report.py tests/workflows/test_backtest_notification.py tests/workflows/test_backtest_runner_workflow.py tests/workflows/test_backtest_artifacts.py` → 55 passed
- `pytest tests/workflows/test_backtest_runner_workflow.py test_backtest_service.py test_backtest_cli.py` → 27 passed
- 17 个新参数格全部通过 `parse_grid_cells`,`_grid_cell_dir` 无重名
- `ruff check` / `ruff format` / `quality_gate --ci` / `--check-no-sql` 全通过

## 未在本 PR 处理

- 排序只看 `cash_total_return`(`backtest_parameter_stability.py:47,68`),`win_rate` 从不进入排序,只是报表里的一列。与「先提胜率」的口径不一致,但那是设计决策,且可以事后从产物重排
- `REQUIRED_PERIODS = {recent_6m, bull_2020, bear_2022}` 是否该纳入新周期

🤖 Generated with [Claude Code](https://claude.com/claude-code)