### PR TITLE
feat(review): 补复盘捕获表的 T+h 前瞻收益评估

### DIFF
--- a/integrations/supabase_review_capture.py
+++ b/integrations/supabase_review_capture.py
@@ -27,6 +27,40 @@ CHUNK = 200
 _CONFLICT_KEY = "trade_date,ts_code"
 
 
+def load_capture_rows(since: str = "", until: str = "", *, page: int = 1000) -> list[dict[str, Any]]:
+    """读回捕获行做前瞻收益评估。
+
+    用 ``create_admin_client`` 而不是 ``create_read_client``：后者只在 server job
+    里才返回 service-role，CLI 下走 anon/RLS，而被 RLS 挡住的读**返回 count=0
+    且不报错**，与「表是空的」完全同形（见 memory anon-rls-read-returns-count-zero,
+    已咬过两张表）。评估脚本在本地跑，必须显式要 admin。
+
+    分页取：一年复盘约两万行，超过 PostgREST 默认上限。排序键带 ts_code 兜底，
+    只按 trade_date 排在跨页时会重复或漏行——同一天有几十行，页边界落在中间时
+    未定序的那部分可能两页都出现或都不出现。
+    """
+    client = create_admin_client()
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        query = client.table(TABLE_REVIEW_CAPTURE_DAILY).select("*")
+        if since:
+            query = query.gte("trade_date", since)
+        if until:
+            query = query.lte("trade_date", until)
+        resp = (
+            query.order("trade_date", desc=False)
+            .order("ts_code", desc=False)
+            .range(offset, offset + page - 1)
+            .execute()
+        )
+        batch = list(resp.data or [])
+        rows.extend(batch)
+        if len(batch) < page:
+            return rows
+        offset += page
+
+
 def build_capture_rows(
     rows: list[dict[str, Any]],
     *,

--- a/scripts/evaluate_review_capture_forward.py
+++ b/scripts/evaluate_review_capture_forward.py
@@ -1,0 +1,114 @@
+"""算「复盘漏掉的票在 T+h 上赚不赚钱」，出 JSON + Markdown。
+
+用法::
+
+    python scripts/evaluate_review_capture_forward.py \
+        --out docs/evidence/review_capture_forward
+
+读 ``review_capture_daily``，按 stage 档位分桶，两种入场口径（T 日开盘 / T+1 开盘）
+各出 h∈{1,2,3,5,10} 的绝对收益与同动量对照。为什么要两档、为什么 T 日开盘那档的
+对照必须拒绝，见 ``workflows/review_capture_forward`` 的模块 docstring。
+
+行情面板从 tushare 现取（本地没有 hist_full 快照）。取数范围要在复盘日两头各留出
+余量：前面 ~25 个交易日给 mom20 的 shift(20) 预热，后面 ~11 天给 T+1+10 的卖出价。
+预热不够会让最早那几天没有动量、直接从配对样本里掉出去，而这**不报错**——只是
+可评估日静默少几天（见 memory start-is-not-the-eval-window）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from core.funnel_effect_panels import DEFAULT_MIN_AMOUNT_WAN, build_panels, normalize_market_frame
+from integrations.supabase_review_capture import load_capture_rows
+from integrations.tushare_client import get_pro, has_tushare_token
+from workflows.review_capture_forward import (
+    FORWARD_HORIZONS,
+    capture_forward_summary,
+    forward_verdict_lines,
+)
+
+logger = logging.getLogger(__name__)
+
+# mom20 要 shift(20)，再留几天缓冲；尾部要够 T+1+max(h) 的卖出价。
+WARMUP_TRADING_DAYS = 30
+TAIL_TRADING_DAYS = max(FORWARD_HORIZONS) + 3
+# 自然日 ≈ 交易日 * 1.45（周末与节假日）。宁可多取。
+CALENDAR_FACTOR = 1.5
+
+
+def _fetch_market(codes: set[str], start: str, end: str) -> pd.DataFrame:
+    """按交易日批量取，而不是按股票循环——后者是几千次调用，跑不动也超限。"""
+    pro = get_pro()
+    cal = pro.trade_cal(exchange="SSE", start_date=start, end_date=end, is_open="1")
+    dates = sorted(str(d) for d in cal["cal_date"])
+    frames: list[pd.DataFrame] = []
+    for trade_date in dates:
+        daily = pro.daily(trade_date=trade_date)
+        if daily is None or daily.empty:
+            continue
+        frames.append(daily[["ts_code", "trade_date", "open", "close", "amount"]])
+    if not frames:
+        raise SystemExit("tushare 未返回任何行情，无法构建面板")
+    frame = pd.concat(frames, ignore_index=True)
+    frame["code6"] = frame.ts_code.astype(str).str.extract(r"(\d+)")[0].str.zfill(6)
+    # 只留复盘涉及的票 + 对照池需要的全市场票：对照要在全市场里找同动量，故不能只留复盘票。
+    logger.info("行情 %d 行，覆盖 %d 个交易日，复盘票 %d 只", len(frame), len(dates), len(codes))
+    return frame.drop(columns=["code6"])
+
+
+def _range(dates: list[str]) -> tuple[str, str]:
+    """复盘日区间两头各扩出预热与卖出窗口，返回 tushare 的 YYYYMMDD。"""
+    first = pd.Timestamp(dates[0]) - pd.Timedelta(days=int(WARMUP_TRADING_DAYS * CALENDAR_FACTOR))
+    last = pd.Timestamp(dates[-1]) + pd.Timedelta(days=int(TAIL_TRADING_DAYS * CALENDAR_FACTOR))
+    return first.strftime("%Y%m%d"), last.strftime("%Y%m%d")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="复盘捕获表的 T+h 前瞻收益评估")
+    parser.add_argument("--since", default="", help="起始复盘日 YYYY-MM-DD")
+    parser.add_argument("--until", default="", help="结束复盘日 YYYY-MM-DD")
+    parser.add_argument("--out", default="", help="输出前缀，生成 .json 与 .md")
+    parser.add_argument("--min-amount-wan", type=float, default=DEFAULT_MIN_AMOUNT_WAN)
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    rows = load_capture_rows(args.since, args.until)
+    logger.info("捕获表读回 %d 行", len(rows))
+    if not rows:
+        # 空与「被 RLS 挡住」同形，故把排查方向写进输出而不是只报空。
+        logger.warning("捕获表无数据；若确信有数据，先确认用的是 service key 再重读")
+
+    dates = sorted({str(r.get("trade_date") or "")[:10] for r in rows if r.get("trade_date")})
+    panels = None
+    if dates and has_tushare_token():
+        start, end = _range(dates)
+        codes = {str(r.get("ts_code") or "") for r in rows}
+        panels = build_panels(
+            normalize_market_frame(_fetch_market(codes, start, end)),
+            min_amount_wan=args.min_amount_wan,
+        )
+    elif dates:
+        logger.warning("无 tushare token，无法构建面板")
+
+    summary = capture_forward_summary(rows, panels)
+    lines = forward_verdict_lines(summary)
+    text = "\n".join(lines)
+    print(text)
+
+    if args.out:
+        base = Path(args.out)
+        base.parent.mkdir(parents=True, exist_ok=True)
+        base.with_suffix(".json").write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+        base.with_suffix(".md").write_text(text + "\n", encoding="utf-8")
+        logger.info("已写出 %s.json / %s.md", base, base)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/workflows/test_review_capture_forward.py
+++ b/tests/workflows/test_review_capture_forward.py
@@ -1,0 +1,212 @@
+"""捕获表前瞻收益评估的检验。
+
+重点不是「函数跑通」，而是四件会静默把结论读反的事：
+
+1. **入场档锚的日期字段不能错。** ``signal_day`` 必须锚 ``previous_trade_date``
+   （漏斗 T-1 决策 → T 日开盘进），``post_gap`` 锚 ``trade_date``。锚错了整个窗口
+   平移一天，收益仍然算得出来，只是答的不是原来那个问题。
+2. **对照池要排除整个复盘池，不只是被测桶。** 其它档位的票同样是当日 >7% 的异动股，
+   留在对照池里会把「异动 vs 异动」读成「漏掉的 vs 同侪」。
+3. **``signal_day`` 档必须显式拒绝对照。** 该档持有窗口含选样日，对照是循环的；
+   缺这一节必须写明「拒绝」，否则会被读成「对照过了」。
+4. **fixture 要有分辨力。** 有边缘与无边缘两种输入必须得到不同 verdict——否则这套
+   对照接没接上都验不出来（memory control-row-must-measure-itself）。
+"""
+
+from __future__ import annotations
+
+import random
+
+import pandas as pd
+
+from core.funnel_effect_eval import MIN_DAYS
+from core.funnel_effect_panels import build_panels
+from core.funnel_taxonomy import (
+    REVIEW_STAGE_CANDIDATE_HIT,
+    REVIEW_STAGE_STRENGTH_MISS,
+    REVIEW_STAGE_THEME_MISS,
+)
+from workflows.review_capture_forward import (
+    ENTRY_POST_GAP,
+    ENTRY_SIGNAL_DAY,
+    MERGED_CAPTURED,
+    MERGED_MISSED,
+    capture_day_map,
+    capture_forward_summary,
+    evaluate_bucket,
+    forward_verdict_lines,
+)
+
+# 预热 20 天 + 尾部 T+1+10 的窗口都吃日子，要让 h=10 也过 MIN_DAYS+10 得留够总天数。
+DAYS = 95
+POOL_SIZE = 40
+# 日收益噪声(%)。没有噪声，过去 20 日涨幅就是未来收益的完美代理，配对会把边缘
+# 一并杀掉、超额恒为 0，fixture 就只能验 null 那一侧。
+NOISE_PCT = 1.5
+
+
+def _append_series(rows: list[dict[str, object]], code: str, dates: pd.Index, edge_pct: float) -> None:
+    rng = random.Random(f"{code}-capture-fixture")
+    price = 10.0
+    for ds in dates:
+        daily = rng.gauss(0.0, NOISE_PCT) + edge_pct
+        open_price = price * (1.0 + daily / 200.0)
+        price *= 1.0 + daily / 100.0
+        rows.append(
+            {"code": code, "ds": ds, "open": round(open_price, 4), "close": round(price, 4), "amt_wan": 50000.0}
+        )
+
+
+def _market_frame(*, edge_pct: float, edge_codes: list[str], flat_codes: list[str]) -> pd.DataFrame:
+    dates = pd.bdate_range("2026-01-05", periods=DAYS).strftime("%Y-%m-%d")
+    rows: list[dict[str, object]] = []
+    for idx in range(POOL_SIZE):
+        _append_series(rows, f"{idx:06d}", dates, 0.0)
+    for code in edge_codes:
+        _append_series(rows, code, dates, edge_pct)
+    for code in flat_codes:
+        _append_series(rows, code, dates, 0.0)
+    return pd.DataFrame(rows).sort_values(["code", "ds"]).reset_index(drop=True)
+
+
+def _row(prev_ds: str, ds: str, code: str, stage: str, *, candidate: bool = False) -> dict[str, object]:
+    return {
+        "trade_date": ds,
+        "previous_trade_date": prev_ds,
+        "ts_code": code,
+        "stage": stage,
+        "is_candidate": candidate,
+    }
+
+
+def _fixture(*, edge_pct: float) -> tuple[object, list[dict[str, object]]]:
+    """漏掉的票带 edge_pct，另一档位的票不带——用于验证分辨力。"""
+    edge_codes = [f"9{idx:05d}" for idx in range(5)]
+    flat_codes = [f"8{idx:05d}" for idx in range(4)]
+    panels = build_panels(_market_frame(edge_pct=edge_pct, edge_codes=edge_codes, flat_codes=flat_codes))
+    # 前 21 天没 mom20；尾部给 post_gap 档的 T+1+10 留够。
+    usable = panels.dates[21:-12]
+    rows: list[dict[str, object]] = []
+    for prev_ds, ds in zip(usable, usable[1:], strict=False):
+        rows += [_row(prev_ds, ds, c, REVIEW_STAGE_THEME_MISS) for c in edge_codes]
+        rows += [_row(prev_ds, ds, c, REVIEW_STAGE_STRENGTH_MISS) for c in flat_codes]
+    return panels, rows
+
+
+def test_day_map_anchors_previous_trade_date_for_signal_day_entry() -> None:
+    """signal_day 锚 previous_trade_date：漏斗 T-1 决策，买在 T 日开盘。"""
+    rows = [_row("2026-01-05", "2026-01-06", "000001", REVIEW_STAGE_THEME_MISS)]
+
+    assert capture_day_map(rows, REVIEW_STAGE_THEME_MISS, ENTRY_SIGNAL_DAY) == {
+        "2026-01-05": {"formal_l4": ["000001"], "all": ["000001"]}
+    }
+    assert capture_day_map(rows, REVIEW_STAGE_THEME_MISS, ENTRY_POST_GAP) == {
+        "2026-01-06": {"formal_l4": ["000001"], "all": ["000001"]}
+    }
+
+
+def test_day_map_pool_holds_whole_replay_not_just_bucket() -> None:
+    """``all`` 必须是整个复盘池：其它档位的票也是当日异动股，不能留在对照池里。"""
+    rows = [
+        _row("2026-01-05", "2026-01-06", "000001", REVIEW_STAGE_THEME_MISS),
+        _row("2026-01-05", "2026-01-06", "000002", REVIEW_STAGE_STRENGTH_MISS),
+        _row("2026-01-05", "2026-01-06", "000003", REVIEW_STAGE_CANDIDATE_HIT, candidate=True),
+    ]
+
+    day = capture_day_map(rows, REVIEW_STAGE_THEME_MISS, ENTRY_POST_GAP)["2026-01-06"]
+
+    assert day["formal_l4"] == ["000001"]
+    assert day["all"] == ["000001", "000002", "000003"]
+
+
+def test_merged_buckets_split_by_candidate_flag() -> None:
+    rows = [
+        _row("2026-01-05", "2026-01-06", "000001", REVIEW_STAGE_THEME_MISS),
+        _row("2026-01-05", "2026-01-06", "000003", REVIEW_STAGE_CANDIDATE_HIT, candidate=True),
+    ]
+
+    missed = capture_day_map(rows, MERGED_MISSED, ENTRY_POST_GAP)["2026-01-06"]
+    captured = capture_day_map(rows, MERGED_CAPTURED, ENTRY_POST_GAP)["2026-01-06"]
+
+    assert missed["formal_l4"] == ["000001"]
+    assert captured["formal_l4"] == ["000003"]
+
+
+def test_null_candidate_flag_is_not_treated_as_captured_or_missed_wrongly() -> None:
+    """is_candidate=None 是「不知道」。它不该被当成已捕获。"""
+    rows = [{"trade_date": "2026-01-06", "previous_trade_date": "2026-01-05", "ts_code": "000001", "stage": "x"}]
+
+    assert capture_day_map(rows, MERGED_CAPTURED, ENTRY_POST_GAP) == {}
+    assert capture_day_map(rows, MERGED_MISSED, ENTRY_POST_GAP)["2026-01-06"]["formal_l4"] == ["000001"]
+
+
+def test_signal_day_entry_refuses_control_but_still_reports_absolute() -> None:
+    """含选样日那档：对照必须写明「拒绝」，绝对收益照出。"""
+    panels, rows = _fixture(edge_pct=0.0)
+
+    block = evaluate_bucket(rows, panels, REVIEW_STAGE_THEME_MISS, entry=ENTRY_SIGNAL_DAY, horizons=(3,))
+    cell = block["horizons"]["3"]
+
+    assert block["control_valid"] is False
+    assert "拒绝" in block["control_refusal"]
+    assert "matched" not in cell
+    assert "control_gap" not in cell
+    assert cell["absolute"]["net_pct"] is not None
+
+
+def test_insufficient_days_says_not_yet_knowable_not_failed() -> None:
+    """样本不足是「尚未可知」，不是「未通过」。"""
+    panels, rows = _fixture(edge_pct=0.0)
+    trimmed = [r for r in rows if r["trade_date"] in set(panels.dates[22:27])]
+
+    cell = evaluate_bucket(trimmed, panels, REVIEW_STAGE_THEME_MISS, horizons=(3,))["horizons"]["3"]
+
+    assert "尚未可知" in cell["verdict"]
+    assert "matched" not in cell
+
+
+def test_min_days_threshold_scales_with_horizon() -> None:
+    """h=10 要多十个交易日才够同样多的可评估日，门槛必须逐档递增。"""
+    panels, rows = _fixture(edge_pct=0.0)
+
+    block = evaluate_bucket(rows, panels, REVIEW_STAGE_THEME_MISS, horizons=(1, 10))
+
+    assert block["horizons"]["1"]["min_days"] == MIN_DAYS + 1
+    assert block["horizons"]["10"]["min_days"] == MIN_DAYS + 10
+
+
+def test_control_discriminates_edge_from_flat() -> None:
+    """有边缘与无边缘必须得到不同结论——否则这套对照接没接上都验不出来。
+
+    两侧用同一个桶（题材共振不足）、同一批日期，唯一差别是那批票有没有独立于动量
+    的日边缘。有边缘那侧配对超额应为正且跑赢随机负控制；无边缘那侧不应如此。
+    """
+    edge_panels, edge_rows = _fixture(edge_pct=0.6)
+    flat_panels, flat_rows = _fixture(edge_pct=0.0)
+
+    edge = evaluate_bucket(edge_rows, edge_panels, REVIEW_STAGE_THEME_MISS, horizons=(3,))["horizons"]["3"]
+    flat = evaluate_bucket(flat_rows, flat_panels, REVIEW_STAGE_THEME_MISS, horizons=(3,))["horizons"]["3"]
+
+    assert edge["matched"]["excess_pct"] > flat["matched"]["excess_pct"]
+    assert edge["absolute"]["net_pct"] > flat["absolute"]["net_pct"]
+    # 分辨力的硬要求：两侧 verdict 不能相同。
+    assert edge["control_gap"]["verdict"] != flat["control_gap"]["verdict"]
+
+
+def test_summary_reports_unavailable_without_panels() -> None:
+    """缺面板要显式说没出——不能让「没这一节」被读成「过了」。"""
+    summary = capture_forward_summary([_row("2026-01-05", "2026-01-06", "000001", "x")], None)
+
+    assert summary["available"] is False
+    assert "无行情面板" in summary["reason"]
+    assert "未出" in "\n".join(forward_verdict_lines(summary))
+
+
+def test_verdict_lines_cover_both_entries_and_carry_refusal() -> None:
+    panels, rows = _fixture(edge_pct=0.3)
+
+    text = "\n".join(forward_verdict_lines(capture_forward_summary(rows, panels, horizons=(3,))))
+
+    assert "T 日开盘入场" in text
+    assert "T+1 开盘入场" in text
+    assert "股级胜率" in text

--- a/workflows/review_capture_forward.py
+++ b/workflows/review_capture_forward.py
@@ -1,0 +1,290 @@
+"""复盘漏掉的票在 T+h 上到底赚不赚钱：捕获表的前瞻收益评估。
+
+``review_capture_daily`` 只存信号日状态（哪只票卡在哪道闸），不存前瞻收益——收益在
+评估时用行情 join 出来，与 ``review_shadow_lane_daily`` 同一套做法。原因有两条：复盘
+当天算不出 T+10（还差十个交易日），以及表里已经有一个 ``gain_pct``，再加一列「收益」
+必然被混用（见 memory control-row-must-measure-itself 与
+one-field-two-meanings-corrupts-column）。所以这里不加列、不发 DDL。
+
+入场日有两种，必须分开报
+------------------------
+漏斗在 T-1 收盘后跑，给的是 T 日的买入建议。所以「这只票该不该抓」的真实入场价是
+**T 日开盘**：``window(previous_trade_date, h)`` 正好买在那里。
+
+但复盘池是按「T 日涨幅 >7%」挑出来的，T 日落在持有窗口里就意味着这批票按结果选样：
+任何按 T-1 信息配对的对照必然输给它们，而输的原因正是它们被选中的原因。所以
+``signal_day`` 这一档只出**绝对收益**，配对与随机负控制被显式**拒绝**——不是省略，
+是拒绝，否则「没有对照一节」会被读成「对照过了」。
+
+``post_gap`` 档从 **T+1 开盘**进，把选样日排除在窗口之外，四栏才都成立：问的是「这批
+票跳完之后还继续走吗」。两档一起读：``signal_day`` 答「抓了能拿到多少」，``post_gap``
+答「这点优势是不是只来自动量选位」。
+
+持有期是网格
+------------
+拿票 2~10 天不固定，所以每档按 h∈{1,2,3,5,10} 出整行，不出 T+5 单一头条（memory
+holding-period-is-a-grid-not-t5）。可评估日 = 面板覆盖到 T+1+h 的天数，门槛按
+``MIN_DAYS + h`` 逐档算；不够就报「尚未可知」而不是「未通过」（memory
+insufficient-sample-is-not-failed-control）。
+
+统计一律复用 ``core.funnel_effect_eval``，这里只做形状适配，不新写一套口径。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from core.funnel_effect_eval import (
+    CONTROL_SEEDS,
+    MIN_DAYS,
+    MIN_HITS_PER_DAY,
+    control_gap,
+    evaluate_daily,
+    summarize_absolute,
+    summarize_group,
+    win_control_gap,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - 仅类型标注
+    from core.funnel_effect_eval import Panels
+
+# 持有期网格。拿票 2~10 天不固定，故不设单一头条窗口。
+FORWARD_HORIZONS: tuple[int, ...] = (1, 2, 3, 5, 10)
+
+# 入场档。键是行里用哪个日期当「信号日」，即 window() 的锚点。
+#   signal_day：锚 previous_trade_date -> T 日开盘进。含选样日，对照循环。
+#   post_gap  ：锚 trade_date          -> T+1 开盘进。排除选样日，对照成立。
+ENTRY_SIGNAL_DAY = "signal_day"
+ENTRY_POST_GAP = "post_gap"
+ENTRY_DATE_FIELD: dict[str, str] = {
+    ENTRY_SIGNAL_DAY: "previous_trade_date",
+    ENTRY_POST_GAP: "trade_date",
+}
+# 对照只在 post_gap 档成立。signal_day 档的配对/随机对照是循环的，必须拒绝而非省略。
+ENTRY_CONTROL_VALID: dict[str, bool] = {ENTRY_SIGNAL_DAY: False, ENTRY_POST_GAP: True}
+CIRCULAR_REFUSAL = (
+    "拒绝出对照：复盘池按「T 日涨幅 >7%」选样，本档持有窗口含 T 日，"
+    "按 T-1 信息配对的对照必然落后，落后的原因就是这批票被选中的原因。"
+    "本档只看绝对收益；对照口径见 post_gap 档。"
+)
+
+# 合并视图：单档位样本太薄（每天 1~19 只），故同时出两个累计口径。
+# missed = 全部没进候选池的票（放开任一闸能多捞到的全集）；captured = 已进候选池的票。
+MERGED_MISSED = "__missed_all__"
+MERGED_CAPTURED = "__captured__"
+MERGED_LABELS: dict[str, str] = {
+    MERGED_MISSED: "合计·未捕获",
+    MERGED_CAPTURED: "合计·已捕获",
+}
+
+
+def _code(value: Any) -> str:
+    """统一成 6 位数字，与 ``build_panels`` 的 code 口径一致。"""
+    digits = re.sub(r"\D", "", str(value or ""))
+    return digits.zfill(6)[:6] if digits else ""
+
+
+def capture_day_map(rows: list[dict[str, Any]], bucket: str, entry: str) -> dict[str, dict[str, Any]]:
+    """把捕获行按信号日分组，塞进 ``resolve_layer`` 认的形状。
+
+    ``formal_l4`` 填被测桶的票，``all`` 填**整个复盘池**——对照池是
+    ``universe - all``，所以复盘池里其它档位的票必须一并排除：它们同样是当日
+    >7% 的异动股，留在池里当对照会把「异动股 vs 异动股」读成「漏掉的 vs 同侪」。
+
+    ``entry`` 决定锚哪个日期当信号日，即买在 T 还是 T+1 开盘。
+    """
+    date_field = ENTRY_DATE_FIELD[entry]
+    hits: dict[str, set[str]] = {}
+    pool: dict[str, set[str]] = {}
+    for row in rows:
+        ds = str(row.get(date_field) or "")[:10]
+        code = _code(row.get("ts_code"))
+        if not ds or not code:
+            continue
+        pool.setdefault(ds, set()).add(code)
+        if _in_bucket(row, bucket):
+            hits.setdefault(ds, set()).add(code)
+    return {
+        ds: {"formal_l4": sorted(hits.get(ds, set())), "all": sorted(codes)}
+        for ds, codes in pool.items()
+        if hits.get(ds)
+    }
+
+
+def _in_bucket(row: dict[str, Any], bucket: str) -> bool:
+    """行属于被测桶吗。合并桶按 is_candidate 分，其余按 stage 精确匹配。
+
+    ``is_candidate`` 用 ``is True`` 而非真值判断：这一列 not null default false，
+    但读回来可能是 None（选列缺失），None 当 False 会把「不知道」写成「确定没捕获」。
+    """
+    captured = row.get("is_candidate") is True
+    if bucket == MERGED_CAPTURED:
+        return captured
+    if bucket == MERGED_MISSED:
+        return not captured
+    return str(row.get("stage") or "") == bucket
+
+
+def evaluate_bucket(
+    rows: list[dict[str, Any]],
+    panels: Panels,
+    bucket: str,
+    *,
+    entry: str = ENTRY_POST_GAP,
+    horizons: tuple[int, ...] = FORWARD_HORIZONS,
+) -> dict[str, Any]:
+    """单个档位在一种入场口径下的逐 h 结果。
+
+    门槛按 ``MIN_DAYS + horizon`` 逐档算：h=10 要多十个交易日才够同样多的可评估日，
+    用同一个门槛会让长窗口看着「达标」而其实只有几天（memory
+    eval-days-are-trace-days-minus-horizon）。
+    """
+    cands = capture_day_map(rows, bucket, entry)
+    control_ok = ENTRY_CONTROL_VALID[entry]
+    out: dict[str, Any] = {
+        "bucket": bucket,
+        "label": MERGED_LABELS.get(bucket, bucket),
+        "entry": entry,
+        "signal_days": len(cands),
+        "control_valid": control_ok,
+        "horizons": {},
+    }
+    if not control_ok:
+        out["control_refusal"] = CIRCULAR_REFUSAL
+    for horizon in horizons:
+        rows_h = evaluate_daily(cands, panels, horizon, status="formal_l4")
+        absolute = summarize_absolute(rows_h["absolute"])
+        # 可评估日 = 面板能覆盖到 T+1+h 的天数，不是 len(cands)。
+        usable = len(rows_h["absolute"])
+        threshold = MIN_DAYS + horizon
+        cell: dict[str, Any] = {
+            "usable_days": usable,
+            "min_days": threshold,
+            "absolute": absolute.as_dict(),
+        }
+        if usable < threshold:
+            cell["verdict"] = f"可评估日 {usable} 天，不足 {threshold} 天，尚未可知"
+            out["horizons"][str(horizon)] = cell
+            continue
+        if not control_ok:
+            cell["verdict"] = "样本已达标；本档只出绝对收益，对照被拒绝（见 control_refusal）"
+            out["horizons"][str(horizon)] = cell
+            continue
+        matched = summarize_group("matched", rows_h["matched"])
+        controls = [summarize_group(f"control_{seed}", rows_h[f"control_{seed}"]) for seed in CONTROL_SEEDS]
+        cell["matched"] = matched.as_dict()
+        cell["controls"] = [c.as_dict() for c in controls]
+        cell["control_gap"] = control_gap(matched, controls)
+        # 胜率必须自己过一遍控制：收益与胜率两栏实测会分家。
+        cell["win_control_gap"] = win_control_gap(matched, controls)
+        out["horizons"][str(horizon)] = cell
+    return out
+
+
+def bucket_names(rows: list[dict[str, Any]], *, min_rows: int = MIN_HITS_PER_DAY) -> list[str]:
+    """出现足够多次的 stage 档位 + 两个合并桶。
+
+    单日只有 1~2 行的档位连一天都凑不满 ``MIN_HITS_PER_DAY``，列出来只会得到一串
+    「尚未可知」，故按总行数先滤一遍。
+    """
+    counts: dict[str, int] = {}
+    for row in rows:
+        stage = str(row.get("stage") or "")
+        if stage:
+            counts[stage] = counts.get(stage, 0) + 1
+    stages = sorted((s for s, n in counts.items() if n >= min_rows), key=lambda s: -counts[s])
+    return [MERGED_MISSED, MERGED_CAPTURED, *stages]
+
+
+def capture_forward_summary(
+    rows: list[dict[str, Any]],
+    panels: Panels | None,
+    *,
+    horizons: tuple[int, ...] = FORWARD_HORIZONS,
+) -> dict[str, Any]:
+    """两种入场口径 × 各档位的完整结果。缺面板时显式降级。"""
+    if panels is None:
+        return {
+            "available": False,
+            "reason": "无行情面板，无法算前瞻收益；本次不出任何收益判定",
+        }
+    if not rows:
+        return {"available": False, "reason": "捕获表无数据"}
+    buckets = bucket_names(rows)
+    dates = sorted({str(r.get("trade_date") or "")[:10] for r in rows if r.get("trade_date")})
+    return {
+        "available": True,
+        "row_count": len(rows),
+        "replay_days": len(dates),
+        "date_range": [dates[0], dates[-1]] if dates else [],
+        "horizons": list(horizons),
+        "note": (
+            f"入场两档：signal_day=T 日开盘（漏斗 T-1 决策的真实入场价，含选样日，"
+            f"只出绝对收益）；post_gap=T+1 开盘（排除选样日，四栏成立）。"
+            f"成本双边同扣，每日最少 {MIN_HITS_PER_DAY} 只，门槛 {MIN_DAYS}+h 天。"
+            f"持有期重叠，所有 t 值都被高估。"
+        ),
+        "entries": {
+            entry: {bucket: evaluate_bucket(rows, panels, bucket, entry=entry, horizons=horizons) for bucket in buckets}
+            for entry in (ENTRY_SIGNAL_DAY, ENTRY_POST_GAP)
+        },
+    }
+
+
+ENTRY_TITLES: dict[str, str] = {
+    ENTRY_SIGNAL_DAY: "T 日开盘入场（漏斗真实入场价，只出绝对收益）",
+    ENTRY_POST_GAP: "T+1 开盘入场（排除选样日，四栏成立）",
+}
+
+
+def forward_verdict_lines(summary: dict[str, Any]) -> list[str]:
+    """报告小节。捕获率那张表旁边必须有这几行，否则「该不该抓」在数据上无法回答。"""
+    if not summary.get("available"):
+        return ["## 漏掉的票在 T+h 上赚不赚钱", "", f"未出：{summary.get('reason') or '未知原因'}", ""]
+    lines = [
+        "## 漏掉的票在 T+h 上赚不赚钱",
+        "",
+        f"复盘 {summary.get('replay_days')} 天、{summary.get('row_count')} 行"
+        f"（{' ~ '.join(summary.get('date_range') or ['—', '—'])}）。",
+        "",
+        summary.get("note") or "",
+        "",
+    ]
+    for entry, blocks in (summary.get("entries") or {}).items():
+        lines += [f"### {ENTRY_TITLES.get(entry, entry)}", ""]
+        for block in blocks.values():
+            lines.append(f"- **{block.get('label')}**（{block.get('signal_days')} 个信号日）")
+            for horizon, cell in (block.get("horizons") or {}).items():
+                lines.append(f"  - T+{horizon} {_forward_cell_line(cell)}")
+        lines.append("")
+    return lines
+
+
+def _forward_cell_line(cell: dict[str, Any]) -> str:
+    """绝对、股级胜率、两条超额同时出：任何一栏单看都会得出相反结论。
+
+    ``positive_day_pct`` 是**日级**的，不是胜率；回答「漏掉的票赚不赚钱」的是
+    ``stock_win_pct``（股级，且门槛已扣往返成本）。
+    """
+    absolute = cell.get("absolute") or {}
+    head = (
+        f"绝对 {_num(absolute.get('net_pct'))}%"
+        f"（股级胜率 {_num(absolute.get('stock_win_pct'))}%，"
+        f"日均 {_num(absolute.get('avg_size'))} 只，{absolute.get('verdict') or '—'}）"
+    )
+    if "matched" not in cell:
+        return f"{head}；{cell.get('verdict') or '—'}"
+    matched = cell.get("matched") or {}
+    gap = cell.get("control_gap") or {}
+    win_gap = cell.get("win_control_gap") or {}
+    return (
+        f"{head}；配对超额 {_num(matched.get('excess_pct'))}pct"
+        f"（t={_num(matched.get('excess_t'))}）→ {gap.get('verdict') or '样本不足'}"
+        f"；胜率超额 {_num(matched.get('stock_win_excess_pct'))}pct"
+        f"（t={_num(matched.get('stock_win_excess_t'))}）→ {win_gap.get('verdict') or '样本不足'}"
+    )
+
+
+def _num(value: Any) -> str:
+    return "—" if value is None else f"{float(value):+.2f}"


### PR DESCRIPTION
## 问题

`review_capture_daily` 里有 `gain_pct`,但那是**选样条件**(T 日涨幅 >7%),不是前瞻收益。拿它当收益是循环论证。结果就是「漏掉的票该不该抓」这个问题在数据上根本无法回答。

这是补基础设施,**不动任何生产判定**。

## 做了什么

前瞻收益评估,horizon 网格 `h∈{1,2,3,5,10}`。不是单个 T+5——用户持仓 2~10 天不固定,钉死一个 horizon 的结论没有意义。

**没加列,也没有 DDL 要执行。** 对照用的动量是 `build_panels` 从价格现算的 `mom20`,不是 L1 闸门那套依赖全域的 `rps_*`。`core/funnel_effect_panels.py` 的注释写明动量定义必须只有一处——同一把尺子量两组是配对对照的前提,两套独立算法会产生不同的邻域,而偏差是静默的。

### 两个入场档

诚实的绝对收益和非循环的对照,拿不到同一个窗口:

| 档 | 锚点 | 买入 | 对照 |
|---|---|---|---|
| `signal_day` | `previous_trade_date` | T 开盘(漏斗真实入场价) | **拒绝** |
| `post_gap` | `trade_date` | T+1 开盘 | 四栏成立 |

`signal_day` 的持有窗含选样日。按 T-1 信息配对的对照必然落后,而且落后的原因**就是**这批票被选中的原因。此档存一条 `CIRCULAR_REFUSAL` 明确拒绝出对照,而不是静默省略——静默省略会让下游以为这里本来就没有对照口径。

### 四栏一起出

绝对收益、逐只胜率、配对超额、胜率超额。胜率必须过**自己**那道对照:风格择时那轮就出现过收益侧置换 p=0.025 过关、而胜率侧 p=0.284 落在随机带内。只看收益侧会把一个胜率没有增量的东西当成有增量。

门槛按 `MIN_DAYS + horizon` 缩放。h=10 需要多十个交易日才够同样的可评估天数,一个平坦门槛会让长窗口在少数几天上看着达标。样本不足输出「尚未可知」,不是「未通过」。

## 两个静默失效点

- 读取走 `create_admin_client`。`create_read_client` 只在 server job 里返回 service-role,CLI 下走 anon/RLS,而**被 RLS 挡住的读返回 count=0 且不报错**,与「表是空的」完全同形。这个坑已经咬过两张表。
- 分页排序键带 `ts_code` 兜底。只按 `trade_date` 排(一天几十行)会让分页边界落在某一天中间,未定的行在两页里重复出现或者两页都没有。

## 验证

- 10 个新用例 / 20 个含既有捕获测试,全绿
- ruff clean,`quality_gate.py --check-no-sql` OK
- 对着线上表读通:53 行 / 1 个复盘日,`signal_day` 锚到 09-08、`post_gap` 锚到 09-09,missed=51 pool=53 与 2 只已捕获一致

夹具带 1.5% 噪声。动量配对天然抹掉纯粹是过去 20 日收益函数的那部分收益差,不带噪声时配对对照组和命中组恒等、超额恒为 0,只能验零假设那一侧。判别性用例实测:edge=0.6 → 配对超额 +2.264 (t=+7.96) 判「含独立选股信息」;edge=0 → +0.068 (t=+0.28) 判「证据不足」。

## 现在还不能下判定

线上只有 1 个复盘日,所有格子都会读「尚未可知」。要 ~20 个交易日才够第一轮判定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
