### PR TITLE
fix(backtest): 「未启用」把按设计不接归因报告读成读取失败

### DIFF
--- a/.github/workflows/backtest_grid.yml
+++ b/.github/workflows/backtest_grid.yml
@@ -88,8 +88,17 @@ env:
   BT_MIN_COMMISSION: "5"
   BT_STAMP_DUTY_RATE: "0.0005"
   BT_TRANSFER_FEE_RATE: "0.00001"
-  # off=静态策略；shadow=应用归因调权做回测验证；on=仅正式批准后进入正式调权。
-  FUNNEL_DYNAMIC_POLICY: ${{ vars.FUNNEL_DYNAMIC_POLICY || secrets.FUNNEL_DYNAMIC_POLICY || 'shadow' }}
+  # 回测这条链固定 off,不跟 vars/secrets 走,也不跟实盘漏斗同源——这里是刻意的分叉:
+  #
+  # 1) load_attribution_policy_snapshot 不收 as_of,拿的永远是**当前最新**那份归因报告。
+  #    用它跑 bull_2020 就是拿今天的结论去指导六年前的选股,是前视。
+  # 2) strategy_attribution_reports 最早只有 2026-06-16,历史窗口根本没有同日期的报告,
+  #    按回测日期回溯这件事不是不方便,是做不到。
+  # 3) 这个 workflow 也没有注入任何 Supabase 变量,读取本来就会失败被 except 吞掉。
+  #    留 shadow 只会让报表写「未启用」并挂一个谁都消不掉的待查。
+  #
+  # 想量归因调权的增量,得先给快照加 as_of 并攒够按日期可回溯的报告,那是另一件事。
+  FUNNEL_DYNAMIC_POLICY: "off"
   FUNNEL_DYNAMIC_POLICY_HORIZON: "5"
   STRATEGY_ATTRIBUTION_MAX_AGE_DAYS: "7"
 
@@ -283,9 +292,10 @@ jobs:
       # 能不能买由 _live_buy_block_regimes 决定，买多少由 _limit_probe_only_selection 决定。
       STEP4_BUY_PROBE_REGIMES: ${{ vars.STEP4_BUY_PROBE_REGIMES || '' }}
       STEP4_BLOCK_BUY_SIGNAL_TYPES: ${{ vars.STEP4_BLOCK_BUY_SIGNAL_TYPES || '' }}
-      # 必须与 wyckoff_funnel.yml 同源:少 secrets 兜底时,job 级 env 覆盖 workflow 级,
-      # 于是实盘读 Secret 里的值、回测读字面量 'shadow',量的不是同一条策略通道。
-      FUNNEL_DYNAMIC_POLICY: ${{ vars.FUNNEL_DYNAMIC_POLICY || secrets.FUNNEL_DYNAMIC_POLICY || 'shadow' }}
+      # 与 workflow 级同为 off,理由见文件头 FUNNEL_DYNAMIC_POLICY 那段注释。
+      # env 按 key 合并(step > job > workflow),删掉这一行会继承上面的 off,不会回退到
+      # vars/secrets;写在这里是为了在 job 内直接看见档位,别在两处写成不同的值。
+      FUNNEL_DYNAMIC_POLICY: "off"
       FUNNEL_DYNAMIC_POLICY_HORIZON: "5"
       FUNNEL_DEFENSIVE_FORCE_QUOTA: "1"
       FUNNEL_MAX_STRUCTURE_STOP_PCT: "12.0"
@@ -443,6 +453,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: fetch
     env:
+      # 同上:整条回测链都不接归因报告,理由见文件头 FUNNEL_DYNAMIC_POLICY 那段注释。
       FUNNEL_DYNAMIC_POLICY: "off"
     strategy:
       fail-fast: false

--- a/core/backtest_config.py
+++ b/core/backtest_config.py
@@ -76,6 +76,9 @@ class BacktestRunInput:
     mainline_config: MainlineEngineConfig | None = None
     signal_weight_map: dict[str, float] = field(default_factory=dict)
     signal_weight_meta: dict[str, object] = field(default_factory=dict)
+    # 归因调权在本轮的档位（off/shadow/on）。空权重表有两种成因——按设计不接、
+    # 或该接却读失败——单看 signal_weight_map 分不出来，报表就只能含糊说「未启用」。
+    signal_weight_mode: str = ""
 
 
 @dataclass(frozen=True)
@@ -320,6 +323,7 @@ def _replay_config(
         mainline_config=params.mainline_config,
         signal_weight_map=dict(params.signal_weight_map),
         signal_weight_meta=dict(params.signal_weight_meta),
+        signal_weight_mode=params.signal_weight_mode,
         a_share_entry_research=params.a_share_entry_research,
     )
 

--- a/core/backtest_replay.py
+++ b/core/backtest_replay.py
@@ -99,6 +99,7 @@ class BacktestReplayConfig:
     mainline_config: MainlineEngineConfig | None = None
     signal_weight_map: dict[str, float] = field(default_factory=dict)
     signal_weight_meta: dict[str, object] = field(default_factory=dict)
+    signal_weight_mode: str = ""
     # 对跨日确认信号补跑损失护栏，与实盘 apply_loss_guard 对齐。
     #
     # 暂时默认关闭（2026-08-08）：机制已就位且语义已修正（只施加风险类护栏、

--- a/core/backtest_report.py
+++ b/core/backtest_report.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from core.backtest_metrics import fmt_metric
 from core.cash_portfolio import STYLE_LABELS
-from core.strategy_policy_display import format_policy_meta_text, format_policy_weight_text
+from core.strategy_policy_display import (
+    POLICY_OFF_BY_DESIGN,
+    format_policy_meta_text,
+    format_policy_weight_text,
+)
 
 
 def build_summary_md(summary: dict) -> str:
@@ -90,9 +94,27 @@ def _crash_probe_lines(summary: dict) -> list[str]:
 
 
 def _signal_weight_line(summary: dict) -> str:
+    """策略治理调权那一行。
+
+    空权重表分两种成因,报表必须说清是哪一种:
+
+    - ``mode == "off"``：回测按设计不接归因报告。快照加载取的是**当前最新**一份
+      报告,不按回测日期回溯,拿它去跑 bull_2020 就是用今天的结论指导六年前的选股;
+      归因报告表本身也只有 2026-06 起的数据,历史窗口没有对应日期的报告可用。
+      这一档是正常状态,不该挂待查。
+    - ``mode in {"shadow", "on"}`` 而权重仍空：该接却没接上,要查。读取失败会被
+      load_attribution_policy_snapshot 的 except 吞成空快照,与「报告确实没有可执行
+      权重」同形,两者都会走到这里。
+
+    这行会被 backtest_market_report_artifacts 解析回 GridCell.strategy_policy,
+    再被确认块做前缀匹配,所以措辞是契约的一部分,改动要三处同步。
+    """
     weights = summary.get("signal_weight_map") or {}
     meta_text = format_policy_meta_text(summary.get("signal_weight_meta"))
     if not weights:
+        mode = str(summary.get("signal_weight_mode") or "").strip().lower()
+        if mode == "off":
+            return f"- 策略治理调权: {POLICY_OFF_BY_DESIGN}{meta_text}"
         return f"- 策略治理调权: 未启用{meta_text}"
     weight_text = format_policy_weight_text(weights, limit=12, delimiter="；")
     return f"- 策略治理调权: {weight_text}{meta_text}"

--- a/core/backtest_run.py
+++ b/core/backtest_run.py
@@ -239,6 +239,7 @@ def _base_summary(
         "signal_weight_count": len(config.replay.signal_weight_map),
         "signal_weight_map": dict(config.replay.signal_weight_map),
         "signal_weight_meta": dict(config.replay.signal_weight_meta),
+        "signal_weight_mode": config.replay.signal_weight_mode,
         "eval_days": replay.eval_days,
         "signal_days": replay.signal_days,
         "trades": len(trades_df),

--- a/core/strategy_policy_display.py
+++ b/core/strategy_policy_display.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import math
 from typing import Any
 
+# 回测里归因调权按设计不接报告时的措辞。
+#
+# 只有一处定义:这条串要被 core/backtest_report 渲染进 markdown、被
+# workflows/backtest_market_report_artifacts 解析回 GridCell、再被
+# workflows/backtest_market_report_builder 的确认块前缀匹配。三处各抄一份字面量,
+# 改一处就会让确认块把「按设计关闭」重新读成「该开却没开」并挂上没人能消的待查。
+POLICY_OFF_BY_DESIGN = "不接归因报告（回测避免前视）"
+
 
 def policy_weight_rows(weights: dict[str, Any] | None) -> list[dict[str, Any]]:
     rows = []

--- a/tests/core/test_ai_candidate_allocation.py
+++ b/tests/core/test_ai_candidate_allocation.py
@@ -112,6 +112,15 @@ class TestAllocateAiCandidates:
     def test_production_workflows_stay_aligned_with_core_policy_defaults(self):
         default_allocation = AiCandidateAllocationConfig()
         default_policy = CandidatePolicyConfig()
+        # 归因调权是这两条链**唯一**故意不同源的一档,期望值写在这里而不是各自 assert 里:
+        # 让改任一边的人必须同时看见另一边的值。实盘要 shadow(读报告、只做对照),回测必须
+        # off——``load_attribution_policy_snapshot`` 不收 ``as_of``,永远拿当前最新那份报告,
+        # 拿它跑 bull_2020 就是用今天的结论指导六年前的选股;何况报告最早只有 2026-06-16,
+        # 历史窗口没有同日期的报告可回溯。两边写成一样才是 bug,且在回测侧表现为静默前视。
+        expected_dynamic_policy = {
+            ".github/workflows/wyckoff_funnel.yml": "shadow",
+            ".github/workflows/backtest_grid.yml": "off",
+        }
         for path, job_name in (
             (".github/workflows/wyckoff_funnel.yml", "run"),
             (".github/workflows/backtest_grid.yml", "grid"),
@@ -125,9 +134,14 @@ class TestAllocateAiCandidates:
                 assert int(env[f"FUNNEL_AI_{family}_ACCUM"]) == accum_quota
             assert float(env["FUNNEL_LOSS_GUARD_RISK_ON_PRE5_RET"]) == default_policy.risk_on_pre5_ret
             assert "tradeable_l4" in str(env["FUNNEL_AI_SELECTION_MODE"])
-            assert "shadow" in str(env["FUNNEL_DYNAMIC_POLICY"])
             assert int(env["FUNNEL_DYNAMIC_POLICY_HORIZON"]) == 5
             assert int(env["STRATEGY_ATTRIBUTION_MAX_AGE_DAYS"]) == 7
+
+            wanted = expected_dynamic_policy[path]
+            assert wanted in str(env["FUNNEL_DYNAMIC_POLICY"])
+            # 反向也钉一下:回测侧只要出现 shadow 就是把前视放回来了。
+            for other in set(expected_dynamic_policy.values()) - {wanted}:
+                assert other not in str(env["FUNNEL_DYNAMIC_POLICY"])
 
     def test_evr_and_compression_only_hits_enter_quota_tracks(self):
         result = FunnelResult(

--- a/tests/core/test_backtest_report.py
+++ b/tests/core/test_backtest_report.py
@@ -153,3 +153,48 @@ def test_build_summary_md_renders_inactive_policy_meta() -> None:
         "- 策略治理调权: 未启用（远端, 报告=2026-07-04, 周期=h5, 策略=shadow 对照(shadow), 范围=尾盘+漏斗shadow, 正式dynamic=未进正式漏斗(未启用自动晋级)）"
         in md
     )
+
+
+def _policy_line(md: str) -> str:
+    """摘出策略治理调权那一行。
+
+    不能直接对整篇 md 断言「未启用」不出现:绩效引擎那行写的是「legacy（wbt 未启用）」,
+    整篇匹配会永远命中,断言等于没写。
+    """
+    lines = [line for line in md.splitlines() if line.startswith("- 策略治理调权:")]
+    assert len(lines) == 1, lines
+    return lines[0]
+
+
+def test_build_summary_md_says_off_by_design_when_mode_is_off() -> None:
+    """mode=off 要说「按设计不接」,不能跟读取失败共用「未启用」。
+
+    两种成因在 signal_weight_map 上完全同形(都是空表),但一种是正常状态、
+    一种必须查。报表混成一句,查的人就得每次重新翻一遍代码才能分清。
+    """
+    md = build_summary_md({"signal_weight_map": {}, "signal_weight_mode": "off"})
+
+    assert _policy_line(md) == "- 策略治理调权: 不接归因报告（回测避免前视）"
+
+
+def test_build_summary_md_keeps_unset_wording_when_mode_wants_weights() -> None:
+    """shadow/on 而权重为空 = 该接却没接上,仍要报「未启用」。"""
+    for mode in ("shadow", "on"):
+        md = build_summary_md({"signal_weight_map": {}, "signal_weight_mode": mode})
+
+        assert _policy_line(md) == "- 策略治理调权: 未启用", mode
+
+
+def test_build_summary_md_ignores_mode_when_weights_exist() -> None:
+    """有权重就渲染权重,档位不参与——否则 off 会盖掉真实生效的调权。"""
+    md = build_summary_md(
+        {
+            "signal_weight_map": {"lps[regime=RISK_ON]": 0.5},
+            "signal_weight_mode": "off",
+        }
+    )
+
+    line = _policy_line(md)
+    assert "lps[regime=RISK_ON]" in line
+    assert "不接归因报告" not in line
+    assert "未启用" not in line

--- a/tests/scripts/test_update_backtest_market_report.py
+++ b/tests/scripts/test_update_backtest_market_report.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+_DEFAULT_POLICY = (
+    "lps[regime=RISK_ON]×0.50↓（远端, 报告=2026-07-04, 周期=h5, "
+    "策略=shadow 对照(shadow), 范围=尾盘+漏斗shadow）"
+)
 
-def _write_grid_cell(tmp_path, period, start, end, hold, stop, cash_return):
+
+def _write_grid_cell(tmp_path, period, start, end, hold, stop, cash_return, policy=_DEFAULT_POLICY):
     artifact = tmp_path / f"backtest-grid-{period}-h{hold}-sl-{stop}-tp0-tr0-37"
     artifact.mkdir()
     (artifact / f"summary_{period}_h{hold}.md").write_text(
@@ -12,7 +17,7 @@ def _write_grid_cell(tmp_path, period, start, end, hold, stop, cash_return):
                 "- 股票池: main_chinext (sample=0)",
                 "- 绩效引擎: legacy",
                 "- 入场价格模式: open",
-                "- 策略治理调权: lps[regime=RISK_ON]×0.50↓（远端, 报告=2026-07-04, 周期=h5, 策略=shadow 对照(shadow), 范围=尾盘+漏斗shadow）",
+                f"- 策略治理调权: {policy}",
                 "- 成交样本: 10",
                 "- 胜率: 40.0%",
                 "- 平均收益: 1.0%",
@@ -221,6 +226,50 @@ def test_backtest_confirmation_passes_only_cross_period_positive(tmp_path):
     assert confirmation["strategy_policy"].startswith("lps[regime=RISK_ON]×0.50↓")
     assert confirmation["entry_price_ready"] is True
     assert confirmation["entry_price_mode"] == "open"
+
+
+def _confirmation_with_policy(tmp_path, policy):
+    from scripts.update_backtest_market_report import build_confirmation, load_grid_cells
+
+    for period, start, end, cash_return in [
+        ("recent_6m", "2025-12-01", "2026-05-31", 6.0),
+        ("bull_2020", "2020-07-01", "2021-02-18", 4.0),
+        ("bear_2022", "2021-12-13", "2022-10-31", 3.0),
+    ]:
+        _write_grid_cell(tmp_path, period, start, end, 15, 8, cash_return, policy=policy)
+
+    return build_confirmation(
+        load_grid_cells(tmp_path),
+        run_url="https://github.com/example/actions/runs/1",
+        generated_at="2026-07-04 00:00:00 Asia/Shanghai",
+    )
+
+
+def test_backtest_confirmation_accepts_policy_off_by_design(tmp_path):
+    """按设计不接归因报告要算口径齐备,不能把 pass 降级成 review。
+
+    回测永远拿不到可回溯的归因报告(快照不收 as_of,报告表也只有 2026-06 起的数据),
+    所以这道闸判它未生效就是天天挂一个谁都消不掉的待查——而天天挂着的待查等于
+    没有待查,真正该查的那次就被埋进噪声里。
+    """
+    from core.strategy_policy_display import POLICY_OFF_BY_DESIGN
+
+    confirmation = _confirmation_with_policy(tmp_path, POLICY_OFF_BY_DESIGN)
+
+    assert confirmation["strategy_policy_ready"] is True
+    assert confirmation["strategy_policy_reason"] == ""
+    assert confirmation["status"] == "pass"
+
+
+def test_backtest_confirmation_still_flags_unset_policy(tmp_path):
+    """「未启用」= 开关开着而权重为空,该查,不能跟着上面一起放行。"""
+    confirmation = _confirmation_with_policy(
+        tmp_path, "未启用（远端, 报告=2026-07-04, 周期=h5）"
+    )
+
+    assert confirmation["strategy_policy_ready"] is False
+    assert confirmation["strategy_policy_reason"] == "策略治理调权未实际生效"
+    assert confirmation["status"] == "review"
 
 
 def test_backtest_confirmation_requires_next_open_entry_price(tmp_path):

--- a/tests/scripts/test_update_backtest_market_report.py
+++ b/tests/scripts/test_update_backtest_market_report.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 _DEFAULT_POLICY = (
-    "lps[regime=RISK_ON]×0.50↓（远端, 报告=2026-07-04, 周期=h5, "
-    "策略=shadow 对照(shadow), 范围=尾盘+漏斗shadow）"
+    "lps[regime=RISK_ON]×0.50↓（远端, 报告=2026-07-04, 周期=h5, 策略=shadow 对照(shadow), 范围=尾盘+漏斗shadow）"
 )
 
 
@@ -263,9 +262,7 @@ def test_backtest_confirmation_accepts_policy_off_by_design(tmp_path):
 
 def test_backtest_confirmation_still_flags_unset_policy(tmp_path):
     """「未启用」= 开关开着而权重为空,该查,不能跟着上面一起放行。"""
-    confirmation = _confirmation_with_policy(
-        tmp_path, "未启用（远端, 报告=2026-07-04, 周期=h5）"
-    )
+    confirmation = _confirmation_with_policy(tmp_path, "未启用（远端, 报告=2026-07-04, 周期=h5）")
 
     assert confirmation["strategy_policy_ready"] is False
     assert confirmation["strategy_policy_reason"] == "策略治理调权未实际生效"

--- a/tests/workflows/test_backtest_service.py
+++ b/tests/workflows/test_backtest_service.py
@@ -109,7 +109,10 @@ def test_backtest_signal_weight_map_matches_funnel_policy_gate(monkeypatch) -> N
         ),
     )
 
-    shadow_weights, shadow_meta = backtest._signal_policy_from_env()
+    shadow_weights, shadow_meta, shadow_mode = backtest._signal_policy_from_env()
+    # mode 要跟着断言,不能用 ``_`` 丢掉:报表靠它区分「按设计没调权(off)」和
+    # 「本该调权却拿到空权重(shadow/on 读失败)」,两者在旧版里都显示成「未启用」。
+    assert shadow_mode == "shadow"
     assert shadow_weights == {"lps": 0.5}
     assert shadow_meta["source"] == "远端"
     assert shadow_meta["active_scope"] == "漏斗shadow"
@@ -128,7 +131,10 @@ def test_backtest_signal_weight_map_matches_funnel_policy_gate(monkeypatch) -> N
         ),
     )
 
-    blocked_weights, blocked_meta = backtest._signal_policy_from_env()
+    blocked_weights, blocked_meta, blocked_mode = backtest._signal_policy_from_env()
+    # 这一格正是要区分的那种:mode=on(要求调权)但权重为空(被 next_action 挡住)。
+    # 报表必须说「读到了但被挡」,而不是跟 off 一样说「未启用」。
+    assert blocked_mode == "on"
     assert blocked_weights == {}
     assert blocked_meta["formal_dynamic_allowed"] is False
     assert blocked_meta["formal_dynamic_block_reason"] == "next_action=keep_static_policy"
@@ -148,12 +154,39 @@ def test_backtest_signal_weight_map_matches_funnel_policy_gate(monkeypatch) -> N
         ),
     )
 
-    weights, meta = backtest._signal_policy_from_env()
+    weights, meta, mode = backtest._signal_policy_from_env()
+    assert mode == "on"
     assert weights == {"sos": 1.15}
     assert meta["source"] == "远端"
     assert meta["report_date"] == "2026-07-04"
     assert meta["active_scope"] == "正式漏斗"
     assert backtest._signal_weight_map_from_env() == {"sos": 1.15}
+
+
+def test_backtest_off_mode_returns_empty_without_reading_the_report(monkeypatch) -> None:
+    """off 档不能去读归因报告——生产的 backtest_grid.yml 就钉在这一档。
+
+    ``load_attribution_policy_snapshot`` 不收 ``as_of``,拿的永远是当前最新那份报告,
+    在回测里读它就是前视。所以这里不只断言权重为空,还断言**根本没调用**那个读取函数:
+    只看空权重表分不清「没读」和「读了但报告为空」,而后者是真前视。
+    """
+    import workflows.backtest as backtest
+
+    monkeypatch.setenv("FUNNEL_DYNAMIC_POLICY", "off")
+    calls: list[dict] = []
+
+    def _explode(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("off 档不该读归因报告")
+
+    monkeypatch.setattr(backtest, "load_attribution_policy_snapshot", _explode)
+
+    weights, meta, mode = backtest._signal_policy_from_env()
+    assert mode == "off"
+    assert weights == {}
+    assert meta == {}
+    assert calls == []
+    assert backtest._signal_weight_map_from_env() == {}
 
 
 def test_shared_request_key_ignores_atr_params_for_signal_reuse() -> None:

--- a/workflows/backtest.py
+++ b/workflows/backtest.py
@@ -208,7 +208,7 @@ def _shared_request_key(request: BacktestWorkflowRequest) -> tuple:
 
 
 def _build_run_config(request: BacktestWorkflowRequest) -> BacktestRunConfig:
-    signal_weight_map, signal_weight_meta = _signal_policy_from_env()
+    signal_weight_map, signal_weight_meta, signal_weight_mode = _signal_policy_from_env()
     strategy_variant = normalize_strategy_variant(request.strategy_variant)
     funnel_overrides = {
         **funnel_cfg_overrides_from_env(),
@@ -258,6 +258,7 @@ def _build_run_config(request: BacktestWorkflowRequest) -> BacktestRunConfig:
             mainline_config=load_mainline_engine_config(),
             signal_weight_map=signal_weight_map,
             signal_weight_meta=signal_weight_meta,
+            signal_weight_mode=signal_weight_mode,
         )
     )
 
@@ -278,14 +279,20 @@ def _signal_weight_map_from_env() -> dict[str, float]:
     return _signal_policy_from_env()[0]
 
 
-def _signal_policy_from_env() -> tuple[dict[str, float], dict[str, object]]:
+def _signal_policy_from_env() -> tuple[dict[str, float], dict[str, object], str]:
+    """回测这一轮的归因调权权重、快照 meta、档位。
+
+    档位要跟着返回：空权重表有两种成因,「off 按设计不接」和「shadow/on 该接
+    却读失败」在 signal_weight_map 上完全同形,只看权重表报表只能含糊说「未启用」,
+    而这两种成因一种不该管、一种必须查。
+    """
     config = dynamic_policy_config_from_env()
     mode = dynamic_policy_mode(config)
     if mode == "off":
-        return {}, {}
+        return {}, {}, mode
     snapshot = load_attribution_policy_snapshot(market="cn", log_fn=lambda message: logger.info(message))
     weights = attribution_weights_for_funnel(snapshot, mode=mode, log_fn=lambda message: logger.info(message))
-    return weights, snapshot.as_dict()
+    return weights, snapshot.as_dict(), mode
 
 
 def _intraday_entry_price_fetcher(request: BacktestWorkflowRequest):

--- a/workflows/backtest_market_report_builder.py
+++ b/workflows/backtest_market_report_builder.py
@@ -15,6 +15,7 @@ from core.backtest_grid_ranking import (
     weak_period_guardrails,
 )
 from core.backtest_periods import PERIOD_LABELS, PERIOD_ORDER
+from core.strategy_policy_display import POLICY_OFF_BY_DESIGN
 from workflows.backtest_market_report_artifacts import GridCell, read_trades
 from workflows.backtest_parameter_stability import build_parameter_stability
 from workflows.backtest_walk_forward import build_walk_forward_validation
@@ -641,12 +642,24 @@ def _confirmation_param(score: RobustParamScore | None) -> dict[str, object]:
 
 
 def _confirmation_policy_check(cells: list[GridCell]) -> dict[str, object]:
+    """归因调权这一档能不能算「口径齐备」。
+
+    ``POLICY_OFF_BY_DESIGN`` 要算齐备。回测不接归因报告是刻意的——快照只取当前
+    最新一份报告、不按回测日期回溯,历史窗口(bull_2020/bear_2022)也没有对应日期的
+    报告——把它判成未生效会给每一轮回测挂上一个谁都消不掉的待查,而天天挂着的
+    待查等于没有待查,真正该查的那次就被埋进噪声里。
+
+    ``未启用`` 仍然算不齐备:那一档是开关开着(shadow/on)而权重仍空,即读取失败
+    或报告无可执行权重,这是该查的。
+    """
     policies = sorted({cell.strategy_policy for cell in cells if cell.strategy_policy})
     if not policies:
         return {"ready": False, "reason": "缺少策略治理调权记录", "policies": []}
     if len(policies) > 1:
         return {"ready": False, "reason": "策略治理调权口径不一致", "policies": policies}
     policy = policies[0]
+    if policy.startswith(POLICY_OFF_BY_DESIGN):
+        return {"ready": True, "reason": "", "policies": policies}
     if policy.startswith("未启用") or policy == "未写入" or "×" not in policy:
         return {"ready": False, "reason": "策略治理调权未实际生效", "policies": policies}
     return {"ready": True, "reason": "", "policies": policies}


### PR DESCRIPTION
## 问题

回测报表里那行 `- 策略治理调权: 未启用（周期=h5）`,看上去像「该开的没开」,其实是**按设计不该开**。

`_signal_weight_line` 只判 `signal_weight_map` 空不空,把两种完全不同的情况压成同一句话:

| 实际情况 | 该不该报 | 旧措辞 |
|---|---|---|
| `mode == "off"` —— 按设计不接归因报告 | 不该报 | `未启用` |
| `mode in {shadow, on}` 而权重仍空 —— 读取失败 / 报告无可执行权重 | **该查** | `未启用` |

回测属于第一种,报表按第二种措辞。`core/strategy_policy_governor.py:663` 又拿 `strategy_policy_ready is not True` 把 `pass` 降级成 `review`,于是每一轮回测都挂一个永远消不掉的待查。天天挂着的待查等于没有待查,真正该查的那一次会被埋进噪声。

## 为什么不补凭据,而是改措辞

两条都是硬约束,不是取舍:

1. **补凭据会引入前视。** `load_attribution_policy_snapshot` 不收 `as_of`,拿的永远是**当前最新**那份归因报告。用它跑 `bull_2020`,就是拿今天的结论去指导六年前的选股。
2. **历史窗口没有报告可回溯。** `strategy_attribution_reports` 只有 51 行 `cn` 记录,最早 2026-06-16。`bull_2020` / `bear_2022` 根本不存在同日期的报告,按回测日期回溯不是不方便,是做不到。

想量归因调权的增量,得先给快照加 `as_of` 参数并攒够按日期可回溯的报告,那是另一件事。

## 改动

- `signal_weight_mode` 从 env 一路串到 summary(`workflows/backtest.py` → `backtest_config` → `backtest_replay` → `backtest_run`),报表这才有依据区分两种空权重
- 措辞常量 `POLICY_OFF_BY_DESIGN` 收在 `core/strategy_policy_display.py`,**只留一处定义**
- 确认块认这条串为口径齐备;`未启用` 仍判不齐备
- `backtest_grid.yml` 三处 `FUNNEL_DYNAMIC_POLICY` 钉成 `off` 并写清理由,不再跟 vars/secrets 走

### 这条串是个三处往返契约

`core/backtest_report.py` 渲染进 markdown → `backtest_market_report_artifacts.py:243` 用 `_parse_simple_field` 解析回 `GridCell.strategy_policy` → `backtest_market_report_builder.py` 的确认块前缀匹配。三处各抄一份字面量的话,改一处就会让确认块把「按设计关闭」重新读成「该开却没开」。所以常量只定义一次。

## 验证

三处往返逐档实测,字节级一致:

```
mode='off'     parsed='不接归因报告（回测避免前视）'  ready=True  reason=''
mode='shadow'  parsed='未启用'                      ready=False reason='策略治理调权未实际生效'
mode='on'      parsed='未启用'                      ready=False reason='策略治理调权未实际生效'
mode=''        parsed='未启用'                      ready=False reason='策略治理调权未实际生效'
weights+off -> 'lps[regime=RISK_ON]×0.50↓'   ready: True
```

最后一行是防回归:有真实权重时档位不参与判断,否则 `off` 会盖掉实际生效的调权。

- 两条受影响用例:**28 passed**
- 更大范围(dataclass 签名变了):`test_backtest_config` / `test_backtest_selection` / `test_funnel_render` / `test_funnel_report_payload` / `test_tools` —— **227 passed**
- ruff 全部 9 个 py 文件:`All checks passed!`
- `scripts/quality_gate.py --check-no-sql`:`OK: 无 .sql 文件`
- **判别力**:两条新行为都先把生产代码回滚回去验过会红,不是白绿

用例断言只切「策略治理调权」那一行。对整篇 md 断言 `"未启用" not in md` 会被 `- 绩效引擎: legacy（wbt 未启用）` 永远命中,那种断言等于没写——这次第一版就踩了,已修。

## 注意

这条链钉死 `off` 之后,repo Variable `FUNNEL_DYNAMIC_POLICY` 只管实盘漏斗,不再影响回测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)