### PR TITLE
feat(backtest): trades_*.csv 记信号前动量,给触发器收益配同动量对照

### DIFF
--- a/core/backtest_execution.py
+++ b/core/backtest_execution.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 
+from core.funnel_effect_panels import MOM_LOOKBACK_BARS, momentum_pct
 from core.limit_move import limit_pct
 
 CN_ZONE = ZoneInfo("Asia/Shanghai")
@@ -48,6 +49,10 @@ class TradeRecord:
     mae_pct: float | None = None
     signal_confirmed: bool = False
     entry_weight_multiplier: float = 1.0
+    # 信号日已知的 20 日涨幅（%）。没有它就没法给「某触发器收益高」配同动量对照——
+    # 高动量票本身就跑得快，不把动量固定住，量到的是选股增量还是追涨分不开。
+    # None 表示历史不足 20 根（样本头几天/新股），不是 0.0：0.0 是横盘这个真实档位。
+    prior_mom20_pct: float | None = None
 
 
 @dataclass(frozen=True)
@@ -88,6 +93,34 @@ def calc_trade_excursion_pct(
         max_high = max(max_high, float(high))
         min_low = min(min_low, float(low))
     return (max_high / entry_price - 1.0) * 100.0, (min_low / entry_price - 1.0) * 100.0
+
+
+def calc_prior_momentum_pct(
+    sorted_dates: list[date],
+    day_ohlc: dict[date, tuple[float, float, float, float]],
+    signal_date: date,
+    lookback: int = MOM_LOOKBACK_BARS,
+) -> float | None:
+    """信号日已知的 20 日涨幅，口径与效果检验面板同源（见 ``momentum_pct``）。
+
+    ``sorted_dates`` 必须是**这只票自己的**交易日升序序列，不是全市场的：按全市场日历
+    回看 20 格，停牌过的票会把停牌日算作有行情的日子，实际回看窗口被拉长，动量就偏小。
+    这条偏差只在停牌票上出现，均值上看不出来，只会让配对时挑错邻居。
+
+    含信号日当天的收盘（``close[T] / close[T-20]``），T 日收盘可知，无前视。
+    历史不足 20 根返回 ``None``——回测的预热是 ``trading_days * 3`` 个自然日，样本头几天
+    与新股本来就不够长，填 0.0 会被当成横盘。
+    """
+    if lookback <= 0:
+        return None
+    pos = bisect.bisect_left(sorted_dates, signal_date)
+    if pos >= len(sorted_dates) or sorted_dates[pos] != signal_date or pos < lookback:
+        return None
+    now = day_ohlc.get(sorted_dates[pos])
+    past = day_ohlc.get(sorted_dates[pos - lookback])
+    if now is None or past is None:
+        return None
+    return momentum_pct(now[3], past[3])
 
 
 def close_on_or_after(df: pd.DataFrame, day: date) -> tuple[float | None, date | None]:

--- a/core/backtest_replay.py
+++ b/core/backtest_replay.py
@@ -27,6 +27,7 @@ from core.backtest_execution import (
     IntradayPriceFetcher,
     TradeRecord,
     build_daily_ohlc_lookup,
+    calc_prior_momentum_pct,
     calc_trade_excursion_pct,
     entry_on_or_after,
     market_of_board,
@@ -1013,6 +1014,9 @@ def _make_trade_record(
     actual_exit_idx = _trade_date_index(trade_dates, exit_date, plan.actual_exit_idx)
     window = trade_dates[plan.actual_entry_idx + 1 : actual_exit_idx + 1]
     mfe_pct, mae_pct = calc_trade_excursion_pct(day_ohlc, window, plan.entry_close)
+    # 显式 sorted 而不是复用 day_ohlc 的插入顺序：下游是 bisect，序错了不报错，只会
+    # 静默回看到别的日子。已排序输入上 sorted() 是线性的，这个保险不要钱。
+    prior_mom20_pct = calc_prior_momentum_pct(sorted(day_ohlc), day_ohlc, ctx.signal_date)
     entry_exec = plan.entry_close * (1.0 + config.buy_friction_pct / 100.0)
     exit_exec = exit_close * (1.0 - config.sell_friction_pct / 100.0)
     _, trigger_name = selected.trigger_name_map.get(code, (0.0, "Layer3_Backup"))
@@ -1042,6 +1046,7 @@ def _make_trade_record(
             selected.signal_type_map.get(code),
             ctx.regime,
         ),
+        prior_mom20_pct=prior_mom20_pct,
     )
 
 

--- a/core/funnel_effect_panels.py
+++ b/core/funnel_effect_panels.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import pandas as pd
@@ -23,6 +24,31 @@ from core.funnel_effect_eval import Panels
 # 20 日均额下限（万元）。低于此的票进不了对照池——流动性差的票的收益噪声与
 # 候选不可比，把它们放进邻域只会放大控制组的方差。
 DEFAULT_MIN_AMOUNT_WAN = 8000.0
+
+# 动量回看的**交易日**根数。面板侧向量化算（``shift``）、回测侧按单只标量算，两条
+# 路径都读这个常量：这是「同一把尺子」里唯一可能被改歪的数字。
+MOM_LOOKBACK_BARS = 20
+
+
+def momentum_pct(now_close: float | None, past_close: float | None) -> float | None:
+    """20 日涨幅的标量口径，与 ``build_panels`` 的向量化算法同源。
+
+    回测的 ``trades_*.csv`` 要给每笔交易记信号前动量，好给「某触发器收益高」配同动量
+    对照；它手里是单只票的日线字典，不是面板那张长表，没法直接套 ``shift``。所以口径
+    在这里各写一次形态、但**回看根数与公式共用**：改 ``MOM_LOOKBACK_BARS`` 两边一起动。
+
+    取不到值时返回 ``None`` 而不是 ``0.0``。0.0 是一个合法的动量值（横盘），拿它填缺失
+    会把新股与停牌票混进「零动量」那一档，配对时按零动量去找邻居，控制组就选错了人，
+    而这种偏差不报错（见 memory nan-passes-every-truthy-guard、
+    blank-risk-signal-means-never-evaluated）。
+    """
+    if now_close is None or past_close is None:
+        return None
+    now = float(now_close)
+    past = float(past_close)
+    if not math.isfinite(now) or not math.isfinite(past) or past <= 0.0:
+        return None
+    return 100.0 * (now / past - 1.0)
 
 
 def normalize_market_frame(frame: pd.DataFrame) -> pd.DataFrame:
@@ -84,7 +110,7 @@ def build_panels(
     grouped = frame.groupby("code", sort=False)
     frame["avg20"] = grouped.amt_wan.transform(lambda s: s.rolling(20, min_periods=10).mean().shift(1))
     # 20 日涨幅按 T 日收盘算（含 T 日），配对时对候选和对照同口径，无前视。
-    frame["mom20"] = grouped.close.transform(lambda s: 100.0 * (s / s.shift(20) - 1.0))
+    frame["mom20"] = grouped.close.transform(lambda s: 100.0 * (s / s.shift(MOM_LOOKBACK_BARS) - 1.0))
     liquid = frame[frame.avg20 >= min_amount_wan]
     bench_open, bench_close = load_benchmark_prices(benchmark)
     return Panels(

--- a/tests/core/test_backtest_execution.py
+++ b/tests/core/test_backtest_execution.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 import pandas as pd
 import pytest
@@ -10,6 +10,7 @@ from core.backtest_execution import (
     TradeRecord,
     build_daily_nav,
     calc_portfolio_metrics,
+    calc_prior_momentum_pct,
     resolve_trade_exit,
 )
 
@@ -246,3 +247,132 @@ def _daily_ohlc_frame(rows: list[tuple[date, float, float, float, float]]):
             "close": [row[4] for row in rows],
         }
     )
+
+
+def _ohlc_from_closes(days: list[date], closes: dict[date, float]) -> dict:
+    return {d: (closes[d], closes[d], closes[d], closes[d]) for d in days}
+
+
+def test_prior_momentum_matches_panel_definition_day_by_day() -> None:
+    """回测标量口径与效果检验面板的向量化口径必须逐日相等。
+
+    这条是整列的意义所在：同动量对照要求两组「用同一把尺子量」。两边各算一遍 20 日
+    涨幅（含不含 T 日、shift 几格）而结果不同的话，不会报错，只会让对照组挑错邻居。
+    """
+    import pandas as pd_
+
+    from core.funnel_effect_panels import MOM_LOOKBACK_BARS, build_panels, normalize_market_frame
+
+    stamps = pd_.bdate_range("2026-01-01", periods=40)
+    closes = [10.0 + i * 0.3 for i in range(40)]
+    panels = build_panels(
+        normalize_market_frame(
+            pd_.DataFrame(
+                {
+                    "ts_code": ["000001.SZ"] * 40,
+                    "trade_date": [d.strftime("%Y%m%d") for d in stamps],
+                    "open": closes,
+                    "close": closes,
+                    "amount": [1e9] * 40,
+                }
+            )
+        ),
+        min_amount_wan=0.0,
+    )
+    days = [d.date() for d in stamps]
+    day_ohlc = _ohlc_from_closes(days, dict(zip(days, closes, strict=True)))
+
+    compared = 0
+    for i in range(MOM_LOOKBACK_BARS, len(days)):
+        panel_value = panels.mom20[stamps[i].strftime("%Y-%m-%d")]["000001"]
+        assert calc_prior_momentum_pct(days, day_ohlc, days[i]) == pytest.approx(panel_value)
+        compared += 1
+    assert compared == len(days) - MOM_LOOKBACK_BARS
+
+
+def test_prior_momentum_is_none_when_history_shorter_than_lookback() -> None:
+    """历史不足 20 根返回 None，不能填 0.0。
+
+    0.0 是「横盘」这个真实档位。用它填缺失会把样本头几天与新股混进零动量那一档，
+    配对时按零动量找邻居，控制组就选错了人，而这种偏差不报错。
+    """
+    days = [d.date() for d in pd.bdate_range("2026-01-01", periods=25)]
+    day_ohlc = _ohlc_from_closes(days, {d: 10.0 + i for i, d in enumerate(days)})
+
+    assert calc_prior_momentum_pct(days, day_ohlc, days[19]) is None
+    assert calc_prior_momentum_pct(days, day_ohlc, days[20]) is not None
+
+
+def test_prior_momentum_counts_the_stocks_own_bars_not_the_market_calendar() -> None:
+    """停牌票要按自己的交易日回看 20 根，不能按全市场日历数 20 格。
+
+    按全市场日历数，停牌日会被算作有行情的日子，实际回看窗口被拉长、动量偏小。
+    这里把停牌区放进回看窗口内，两种做法相差 5.9pct——只在停牌票上出现，均值上看不出来。
+    """
+    market_days = [d.date() for d in pd.bdate_range("2026-01-01", periods=45)]
+    halted = set(market_days[30:35])
+    own_days = [d for d in market_days if d not in halted]
+
+    closes, price = {}, 10.0
+    for day in own_days:
+        closes[day] = price
+        price *= 1.01
+    day_ohlc = _ohlc_from_closes(own_days, closes)
+    target = own_days[-1]
+
+    actual = calc_prior_momentum_pct(own_days, day_ohlc, target)
+    own_ref = own_days[own_days.index(target) - 20]
+    market_ref = market_days[market_days.index(target) - 20]
+
+    assert own_ref != market_ref, "构造无效：停牌区没落在回看窗口内，两种做法本来就同解"
+    assert actual == pytest.approx(100.0 * (closes[target] / closes[own_ref] - 1.0))
+    assert actual != pytest.approx(100.0 * (closes[target] / closes[market_ref] - 1.0))
+
+
+def test_prior_momentum_rejects_dates_outside_the_series() -> None:
+    """信号日不在这只票的行情里就返回 None——不能顺移到最近的一天。
+
+    顺移会让动量的基准日与信号日错开，且错开多少取决于停牌长度，静默不可查。
+    """
+    days = [d.date() for d in pd.bdate_range("2026-01-01", periods=30)]
+    day_ohlc = _ohlc_from_closes(days, {d: 10.0 + i for i, d in enumerate(days)})
+    # 序列里的空档（周六）：必须落在 20 根之后，否则「不足回看」会先命中，用例就废了
+    gap = next(d + timedelta(days=1) for d in days[22:] if (d + timedelta(days=1)) not in day_ohlc)
+
+    assert gap not in day_ohlc and days[0] < gap < days[-1]
+    assert calc_prior_momentum_pct(days, day_ohlc, gap) is None
+    assert calc_prior_momentum_pct(days, day_ohlc, date(2030, 1, 1)) is None
+
+
+def test_prior_momentum_guards_non_positive_and_non_finite_base() -> None:
+    """基准价 <=0 或非有限值返回 None,不能算出 inf 混进配对。"""
+    from core.funnel_effect_panels import momentum_pct
+
+    assert momentum_pct(10.0, 0.0) is None
+    assert momentum_pct(10.0, -1.0) is None
+    assert momentum_pct(None, 5.0) is None
+    assert momentum_pct(10.0, None) is None
+    assert momentum_pct(float("nan"), 5.0) is None
+    assert momentum_pct(11.0, 10.0) == pytest.approx(10.0)
+
+
+def test_trade_record_carries_prior_momentum_into_csv_columns() -> None:
+    """列要落进 trades_*.csv;缺值写空串而不是 0。"""
+    record = TradeRecord(
+        signal_date=date(2026, 3, 2),
+        entry_date=date(2026, 3, 3),
+        exit_date=date(2026, 3, 10),
+        code="000001",
+        name="平安银行",
+        trigger="sos",
+        score=1.0,
+        entry_close=10.0,
+        exit_close=11.0,
+        ret_pct=10.0,
+        prior_mom20_pct=12.5,
+    )
+    frame = pd.DataFrame([record.__dict__, TradeRecord(**{**record.__dict__, "prior_mom20_pct": None}).__dict__])
+
+    assert "prior_mom20_pct" in frame.columns
+    assert frame["prior_mom20_pct"].tolist()[0] == pytest.approx(12.5)
+    assert frame.to_csv(index=False).splitlines()[2].split(",")[-1] == ""


### PR DESCRIPTION
## 问题

sos 触发器在 h=2/3 上量到 +19.5 / +23.8 的收益,但这个数**排除不掉动量混淆**——高动量票本身就跑得快。要判断这是选股增量还是追涨,得给候选配同动量对照;而 `trades_*.csv` 里没有信号前动量这一列,配对时无从下手。

这个 PR 只加数据列,不改任何选股或下单行为。

## 口径单一来源

回看根数与公式住在 `core/funnel_effect_panels.py`(同动量对照的定义本来就在那儿),新增 `MOM_LOOKBACK_BARS = 20` 和标量 `momentum_pct()`。面板侧向量化路径改读同一个常量,回测侧 `calc_prior_momentum_pct()` 导入这两个。

面板手里是长表能直接 `shift`,回测手里是单只票的日线字典,所以形态各写一次——但**会被改歪的那两个数字(窗口长度、公式)共用**。

## 三处刻意的选择

**按这只票自己的交易日回看,不按全市场日历。** 停牌票会把停牌日算成有行情的日子,回看窗口被拉长、动量偏小。构造了一个窗口内停牌的用例实测:

| 回看方式 | 20 日涨幅 | 基准日 |
|---|---|---|
| 这只票自己的交易日 | 22.019 | — |
| 全市场日历 | 16.0969 | 晚 7 个自然日 |

差 5.92pct。这条偏差只在停牌票上出现,均值上看不出来,只会让配对时挑错邻居。

**取不到值返回 `None`,不是 `0.0`。** 0.0 是横盘这个合法档位,拿它填缺失会把新股和历史不足的票混进「零动量」档。

**`day_ohlc` 显式 `sorted()` 再交给 `bisect`。** 不复用字典插入顺序:序错了 `bisect` 不报错,只会静默回看到别的日子。已排序输入上 `sorted()` 是线性的。

## 无前视

含信号日当天收盘(`close[T] / close[T-20]`),T 日收盘在 T 日已知。

## 验证

- 与 `build_panels` 的向量化结果**逐日**比对:20 个可比日全部相等,偏差 0
- 判别性:缺值填 `0.0` 挂 1 个用例(正是该挂的那个),回看漂到 21 挂 3 个
- 停牌那条用例自带 `assert own_ref != market_ref`,防止以后构造退化成「两种做法本来同解」还显示通过
- `read_trades` 走 `csv.DictReader`,新增列对历史产物向后兼容
- 全量 4996 passed / 22 skipped,ruff clean,无 .sql 文件

## 不在这个 PR 里

拿到这一列之后才能做的事:给 sos 的 h=2/3 收益配同动量对照,看 +19.5/+23.8 还剩多少。那是下一步。
