### PR TITLE
report(backtest): 稳健性表补上胜率两列,排序键不动

### DIFF
--- a/core/backtest_grid_ranking.py
+++ b/core/backtest_grid_ranking.py
@@ -41,6 +41,25 @@ def rank_robust_params(
     recent_period: str | None = None,
     period_rank_fn: Callable[[str], tuple[int, str]] | None = None,
 ) -> list[RobustParamScore[T]]:
+    """按跨周期稳健性给参数组排序。
+
+    ``value_fn`` 虽然是注入的,但这个模块只对「现金收益(百分点,可正可负)」成立,两处写死了:
+    ``RobustParamScore`` 的字段叫 ``*_cash_return``,``robust_label()`` 每个分支的文案也都在
+    说现金收益。换个量纲进来,排序还能跑,读出来的话是错的。
+
+    换成胜率会退化成常数项,不是"另一种排法"。三处判据都把「> 0」当好(:func:`_robust_score`
+    的 ``positive_periods``、:func:`robust_label` 的 ``min_cash_return > 0``、
+    :func:`weak_period_guardrails` 的 ``max(values) <= 0``),而胜率没有负数。实测 09-09 那批
+    网格:传胜率进来,60 组参数的 ``positive_periods`` 全是 6,权重最大的
+    ``positive_periods * 4.0`` 变成人人加 24 的常数;``robust_label`` 把头五名全标成
+    「稳健参数（跨周期全正）」,而这五名里头名现金收益 +0.52%、第二名 -5.71%——那句标签说的
+    是「六个周期都赚钱」,实际只是「胜率都没到 0 以下」。另外 ``representative_fn`` 在两个
+    生产调用方那里都按现金收益挑代表格子,与胜率排序错位(今天两个调用方两处都传现金收益,
+    所以还没错位,换量纲才会)。
+
+    要出胜率口径的对照,用 :func:`workflows.backtest_market_report_artifacts.win_rate_span`
+    在展示层汇总,别改这里的排序键——改它会一次性改掉所有历史格子的排名。
+    """
     groups: dict[Hashable, list[T]] = defaultdict(list)
     for cell in cells:
         groups[key_fn(cell)].append(cell)

--- a/tests/scripts/test_update_backtest_market_report.py
+++ b/tests/scripts/test_update_backtest_market_report.py
@@ -5,7 +5,7 @@ _DEFAULT_POLICY = (
 )
 
 
-def _write_grid_cell(tmp_path, period, start, end, hold, stop, cash_return, policy=_DEFAULT_POLICY):
+def _write_grid_cell(tmp_path, period, start, end, hold, stop, cash_return, policy=_DEFAULT_POLICY, win_rate=40.0):
     artifact = tmp_path / f"backtest-grid-{period}-h{hold}-sl-{stop}-tp0-tr0-37"
     artifact.mkdir()
     (artifact / f"summary_{period}_h{hold}.md").write_text(
@@ -18,7 +18,7 @@ def _write_grid_cell(tmp_path, period, start, end, hold, stop, cash_return, poli
                 "- 入场价格模式: open",
                 f"- 策略治理调权: {policy}",
                 "- 成交样本: 10",
-                "- 胜率: 40.0%",
+                f"- 胜率: {win_rate}%",
                 "- 平均收益: 1.0%",
                 "- 中位收益: 0.5%",
                 "- 夏普比 (Sharpe Ratio): 0.3",
@@ -198,6 +198,32 @@ def test_market_report_prefers_cross_period_robust_params(tmp_path):
     assert "RISK_ON / 强主线修复" not in report
     assert "稳健参数（跨周期全正）: **等额四仓 / 15天 / SL-8% / 无TP / 无Trail**" in report
     assert "跨周期参数稳健性" in report
+
+
+def test_robust_param_table_reports_win_rate_next_to_cash_return(tmp_path):
+    """跨周期稳健表要并排给出胜率,否则「赚钱但胜率低」在表上跟真稳健同形。
+
+    代表格子按现金收益从 recent_6m 里挑,所以摘要行原本只会显示那一档的胜率。这里把
+    recent_6m 设成 62.0%、bear_2022 设成 24.0%,断言报表同时出现这两个数——只报代表格子
+    的实现会漏掉 24.00%,这就是这条用例的判别点。实测 09-09 网格上这段落差是 53.85 → 27.59。
+    """
+    from scripts.update_backtest_market_report import build_report, load_grid_cells
+
+    for period, start, end, cash_return, win_rate in [
+        ("recent_6m", "2025-12-01", "2026-05-31", 6.0, 62.0),
+        ("bull_2020", "2020-07-01", "2021-02-18", 4.0, 41.0),
+        ("bear_2022", "2021-12-13", "2022-10-31", 3.0, 24.0),
+    ]:
+        _write_grid_cell(tmp_path, period, start, end, 15, 8, cash_return, win_rate=win_rate)
+        _write_grid_cell(tmp_path, period, start, end, 10, 8, cash_return - 1, win_rate=win_rate - 2)
+
+    report = build_report(load_grid_cells(tmp_path))
+
+    assert "| 平均胜率 | 最差周期胜率 |" in report
+    assert "平均胜率 42.33%" in report
+    assert "最差周期胜率 24.00%" in report
+    # 现金收益那几列必须没被挤掉。
+    assert "最差周期 +3.00%" in report
 
 
 def test_backtest_confirmation_passes_only_cross_period_positive(tmp_path):

--- a/tests/workflows/test_backtest_market_report_artifacts.py
+++ b/tests/workflows/test_backtest_market_report_artifacts.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from workflows.backtest_market_report_artifacts import win_rate_span
+
+
+@dataclass(frozen=True)
+class _Cell:
+    """只带 win_rate 的替身:win_rate_span 只读这一个字段,不必造完整 GridCell。"""
+
+    win_rate: float | None
+
+
+def test_win_rate_span_returns_average_and_worst():
+    avg, worst = win_rate_span([_Cell(60.0), _Cell(40.0), _Cell(30.0)])
+
+    assert worst == 30.0
+    assert avg == (60.0 + 40.0 + 30.0) / 3
+
+
+def test_win_rate_span_keeps_zero_as_a_real_reading():
+    """胜率 0.0 是「一笔没赢」这个真实取值,不能跟缺值一样被丢掉。
+
+    丢了它,最差周期会读成剩下那些里最小的那个,把一段完全没赢的周期抹成看着还行。
+    """
+    avg, worst = win_rate_span([_Cell(0.0), _Cell(50.0)])
+
+    assert worst == 0.0
+    assert avg == 25.0
+
+
+def test_win_rate_span_skips_missing_values():
+    avg, worst = win_rate_span([_Cell(None), _Cell(40.0), _Cell(None), _Cell(20.0)])
+
+    assert worst == 20.0
+    assert avg == 30.0
+
+
+def test_win_rate_span_drops_nan_regardless_of_position():
+    """NaN 必须按位置无关地剔除。
+
+    ``min()`` 碰到 NaN 的结果取决于它在序列里的位置:``min([1.0, nan])`` 得 1.0、
+    ``min([nan, 1.0])`` 得 nan。所以只测一种摆法测不出来——NaN 放第一位时,没过滤的实现
+    会静默把整组的最差周期改写成 NaN,而报表那一格只会显示成 ``-``,看着像"没这个数"。
+    """
+    assert math.isnan(min([float("nan"), 1.0])), "构造无效：min 已不再受 NaN 位置影响"
+
+    leading = win_rate_span([_Cell(float("nan")), _Cell(40.0), _Cell(20.0)])
+    trailing = win_rate_span([_Cell(40.0), _Cell(20.0), _Cell(float("nan"))])
+
+    assert leading == trailing == (30.0, 20.0)
+
+
+def test_win_rate_span_returns_none_when_nothing_is_measurable():
+    """全缺值时给 (None, None),让 ``_fmt_num`` 显示 ``-``,而不是 0.0 冒充胜率为零。"""
+    assert win_rate_span([_Cell(None), _Cell(float("inf"))]) == (None, None)
+    assert win_rate_span([]) == (None, None)

--- a/tests/workflows/test_backtest_parameter_stability.py
+++ b/tests/workflows/test_backtest_parameter_stability.py
@@ -6,7 +6,7 @@ from workflows.backtest_market_report_artifacts import load_grid_cells
 from workflows.backtest_parameter_stability import build_parameter_stability
 
 
-def _cell(root: Path, period: str, hold: int, stop: int, cash_return: float) -> None:
+def _cell(root: Path, period: str, hold: int, stop: int, cash_return: float, win_rate: float = 50.0) -> None:
     artifact = root / f"backtest-grid-{period}-h{hold}-sl-{stop}-tp0-tr0"
     artifact.mkdir()
     (artifact / f"summary_{period}_h{hold}.md").write_text(
@@ -16,7 +16,7 @@ def _cell(root: Path, period: str, hold: int, stop: int, cash_return: float) -> 
                 "- 每日候选上限: Top 4",
                 "- 股票池: all (sample=0)",
                 "- 成交样本: 20",
-                "- 胜率: 50%",
+                f"- 胜率: {win_rate}%",
                 "- 初始现金: 100000",
                 f"- 最终现金: {100000 * (1 + cash_return / 100):.2f}",
                 f"- 总收益: {cash_return}%",
@@ -88,6 +88,52 @@ def test_parameter_stability_reviews_when_anchor_misses_required_period(tmp_path
 
     assert result["status"] == "review"
     assert "bear_2022" in result["summary"]
+
+
+def test_score_payload_reports_win_rate_span_across_periods(tmp_path):
+    """payload 要带跨周期胜率跨度,不能只有现金收益。
+
+    实测 09-09 网格的榜首代表格子胜率 53.85%,而它最差那个周期只有 27.59%——只报代表
+    格子会把这段塌陷藏掉。这里三个周期给 60/40/30,断言 min 取到 30 而不是代表格子的值。
+    """
+    periods = ("recent_6m", "bull_2020", "bear_2022")
+    for period, cash, win in zip(periods, (6.0, 5.0, 4.0), (60.0, 40.0, 30.0), strict=True):
+        _cell(tmp_path, period, 15, 8, cash, win_rate=win)
+        _cell(tmp_path, period, 10, 8, cash - 2, win_rate=win)
+        _cell(tmp_path, period, 15, 7, cash - 3, win_rate=win)
+
+    anchor = build_parameter_stability(load_grid_cells(tmp_path))["anchor"]
+
+    assert anchor["min_win_rate_pct"] == 30.0
+    assert anchor["avg_win_rate_pct"] == round((60.0 + 40.0 + 30.0) / 3, 4)
+    # 现金收益列必须原样保留:胜率是新增对照,不是替换口径。
+    assert anchor["min_cash_return"] == 4.0
+
+
+def test_win_rate_columns_do_not_change_the_stability_verdict(tmp_path):
+    """胜率只做展示,不进判定:现金收益一样、胜率天差地别的两个网格必须同一个结论。
+
+    判定口径一改,历史上所有 pass/fail 的含义就变了一次。这条用例就是钉住「没改」。
+    """
+    high, low = tmp_path / "high", tmp_path / "low"
+    high.mkdir()
+    low.mkdir()
+    periods = ("recent_6m", "bull_2020", "bear_2022")
+    for root, win in ((high, 70.0), (low, 20.0)):
+        for period, cash in zip(periods, (6.0, 5.0, 4.0), strict=True):
+            _cell(root, period, 15, 8, cash, win_rate=win)
+            _cell(root, period, 10, 8, cash - 2, win_rate=win)
+            _cell(root, period, 15, 7, cash - 3, win_rate=win)
+
+    high_result = build_parameter_stability(load_grid_cells(high))
+    low_result = build_parameter_stability(load_grid_cells(low))
+
+    for field in ("status", "neighbor_count", "stable_neighbor_count", "stable_neighbor_ratio"):
+        assert high_result[field] == low_result[field], field
+    assert high_result["anchor"]["robust_score"] == low_result["anchor"]["robust_score"]
+    # 而胜率列本身必须跟着变,否则这条用例就退化成「两个空值相等」。
+    assert high_result["anchor"]["min_win_rate_pct"] == 70.0
+    assert low_result["anchor"]["min_win_rate_pct"] == 20.0
 
 
 def test_parse_params_keeps_trailing_activate_distinct():

--- a/workflows/backtest_market_report_artifacts.py
+++ b/workflows/backtest_market_report_artifacts.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import csv
 import glob
+import math
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -72,6 +74,24 @@ def read_trades(path: Path | None) -> list[dict[str, str]]:
         return []
     with path.open(encoding="utf-8-sig", newline="") as file:
         return list(csv.DictReader(file))
+
+
+def win_rate_span(cells: Iterable[GridCell]) -> tuple[float | None, float | None]:
+    """一组同参数格子的（平均胜率, 最差周期胜率），单位为百分点。
+
+    跨周期稳健性那张表原本整行只报现金收益,于是「赚钱但十次只对四次」和「胜率高但不赚钱」
+    在表上完全同形。这里只做展示用的汇总,不参与排序:排序键按现金收益排,换成胜率会退化——
+    ``_robust_score`` 里权重最大的 ``positive_periods * 4.0`` 判的是「> 0」,而胜率没有负数,
+    60 组参数会全部拿到满格 6/6,那一项就变成人人加同样分的常数。
+
+    非有限值一律剔除而不是当 0:胜率 0.0 是「一笔没赢」这个真实取值,拿 NaN 冒充它会把
+    读数拖低;而 ``min()`` 碰到 NaN 的结果取决于它在序列里的位置(``min([1.0, nan])`` 得
+    1.0,``min([nan, 1.0])`` 得 nan),一个脏值就能静默改写整组的最差周期。
+    """
+    values = [cell.win_rate for cell in cells if cell.win_rate is not None and math.isfinite(cell.win_rate)]
+    if not values:
+        return None, None
+    return sum(values) / len(values), min(values)
 
 
 def _to_float(raw: str | None) -> float | None:

--- a/workflows/backtest_market_report_builder.py
+++ b/workflows/backtest_market_report_builder.py
@@ -16,7 +16,7 @@ from core.backtest_grid_ranking import (
 )
 from core.backtest_periods import PERIOD_LABELS, PERIOD_ORDER
 from core.strategy_policy_display import POLICY_OFF_BY_DESIGN
-from workflows.backtest_market_report_artifacts import GridCell, read_trades
+from workflows.backtest_market_report_artifacts import GridCell, read_trades, win_rate_span
 from workflows.backtest_parameter_stability import build_parameter_stability
 from workflows.backtest_walk_forward import build_walk_forward_validation
 
@@ -261,12 +261,16 @@ def _build_robust_param_table(scores: list[RobustParamScore]) -> list[str]:
         "",
         "## 跨周期参数稳健性",
         "",
-        "| 排名 | 参数组合 | 正周期 | 最近收益 | 平均收益 | 最差收益 | 稳健分 | 覆盖周期 |",
-        "|---:|---|---:|---:|---:|---:|---:|---:|",
+        "| 排名 | 参数组合 | 正周期 | 最近收益 | 平均收益 | 最差收益 | 平均胜率 | 最差周期胜率 | 稳健分 | 覆盖周期 |",
+        "|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for idx, score in enumerate(scores[:12], 1):
         cell = score.best_cell
         marker = " 🏆" if idx == 1 else ""
+        # 胜率两列只做展示,排名仍由现金收益决定(理由见 ``win_rate_span``)。摆在收益列右边是
+        # 因为这两个口径经常打架:实测榜首现金收益 +0.56% 但最差周期胜率只有 27.59%,
+        # 只看收益列会把它读成「稳健」。
+        avg_win_rate, min_win_rate = win_rate_span(score.cells)
         lines.append(
             "| "
             + " | ".join(
@@ -277,6 +281,8 @@ def _build_robust_param_table(scores: list[RobustParamScore]) -> list[str]:
                     _fmt_signed(score.recent_cash_return, 2, "%"),
                     _fmt_signed(score.avg_cash_return, 2, "%"),
                     _fmt_signed(score.min_cash_return, 2, "%"),
+                    _fmt_num(avg_win_rate, 2, "%"),
+                    _fmt_num(min_win_rate, 2, "%"),
                     _fmt_num(score.score, 2),
                     str(score.period_count),
                 ]
@@ -518,10 +524,16 @@ def _build_conclusion_lines(
         f"- 参数观察: {_best_per_hold_comment(cells)}",
     ]
     if robust_best:
+        # 胜率要跟现金收益并排出:上面那行「代表单元」的胜率只来自代表格子(按现金收益从
+        # recent_2m/recent_6m 里挑的那一个),跨周期最差的那一档比它低得多——实测榜首代表
+        # 格子 53.85%,最差周期 27.59%。只报代表格子会把跨周期的胜率塌陷藏起来。
+        avg_win_rate, min_win_rate = win_rate_span(robust_best.cells)
         lines.append(
             f"- 跨周期稳健性: 正收益周期 {robust_best.positive_periods}/{robust_best.period_count}；"
             f"平均现金收益 {_fmt_signed(robust_best.avg_cash_return, 2, '%')}；"
             f"最差周期 {_fmt_signed(robust_best.min_cash_return, 2, '%')}；"
+            f"平均胜率 {_fmt_num(avg_win_rate, 2, '%')}；"
+            f"最差周期胜率 {_fmt_num(min_win_rate, 2, '%')}；"
             f"稳健分 {_fmt_num(robust_best.score, 2)}。"
         )
     lines.extend(_build_period_guardrail_lines(cells))

--- a/workflows/backtest_parameter_stability.py
+++ b/workflows/backtest_parameter_stability.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from core.backtest_grid_ranking import RobustParamScore, rank_robust_params
 from core.backtest_periods import period_rank
-from workflows.backtest_market_report_artifacts import GridCell
+from workflows.backtest_market_report_artifacts import GridCell, win_rate_span
 
 ParamKey = tuple[str, int, int, int, int]
 REQUIRED_PERIODS = frozenset({"recent_6m", "bull_2020", "bear_2022"})
@@ -135,6 +135,9 @@ def _summary(
 
 def _score_payload(score: RobustParamScore[GridCell]) -> dict[str, Any]:
     style, hold, stop_loss, take_profit, trailing_stop, trailing_activate = score.key
+    # 胜率随payload一起出,但 ``stable_definition`` 仍只看现金收益:判定口径不能悄悄改,
+    # 那会让历史上所有 pass/fail 的含义变一次。这两列是给人看的对照,不进 ``_verdict``。
+    avg_win_rate, min_win_rate = win_rate_span(score.cells)
     return {
         "portfolio_style": style,
         "hold_days": hold,
@@ -146,6 +149,8 @@ def _score_payload(score: RobustParamScore[GridCell]) -> dict[str, Any]:
         "positive_periods": score.positive_periods,
         "avg_cash_return": _round(score.avg_cash_return),
         "min_cash_return": _round(score.min_cash_return),
+        "avg_win_rate_pct": _round(avg_win_rate),
+        "min_win_rate_pct": _round(min_win_rate),
         "robust_score": _round(score.score),
     }
 


### PR DESCRIPTION
## 问题

跨周期参数稳健性那张表整行只报现金收益,于是「赚钱但十次只对四次」和「胜率高但不赚钱」在表上完全同形。实测 09-09 那批网格的榜首:

| | 读数 |
|---|---|
| 最近收益 | +0.56% |
| 平均现金收益 | -3.08% |
| 最差周期胜率 | **27.59%** |

结论行原本也报胜率,但取自「代表单元」——按现金收益从 `recent_2m`/`recent_6m` 里挑出的那一个格子,读数 53.85%。跨周期最差的那一档比它低 26 个百分点,只报代表格子把这个塌陷整个藏住了。

## 改了什么

只改展示层。新增 `win_rate_span()` 返回一组同参数格子的(平均胜率, 最差周期胜率),三处共用:

- 稳健性 Markdown 表:8 列 → 10 列,胜率两列摆在收益列右边
- 结论行:胜率改成跨周期汇总,不再只报代表格子
- `backtest_parameter_stability` 的 payload:新增 `avg_win_rate_pct` / `min_win_rate_pct`

刻意没动的:排序键 `_robust_score`、`_cross_period_positive`、`_verdict`、`rules.stable_definition`。历史格子的排名和每一次 pass/fail 的含义都不变。

## 为什么不把排序键换成胜率

试过,会退化成常数项,不是「另一种排法」。三处判据都把「> 0」当好(`_robust_score` 的 `positive_periods`、`robust_label` 的 `min_cash_return > 0`、`weak_period_guardrails` 的 `max(values) <= 0`),而胜率没有负数。实测:

- 60 组参数的 `positive_periods` **全是 6**,权重最大的 `positive_periods * 4.0` 变成人人加 24 的常数
- `robust_label` 把头五名全标成「稳健参数(跨周期全正)」,那句话说的是「六个周期都赚钱」,实际只是「胜率都没到 0 以下」——这五名里第二名现金收益 **-5.71%**
- 两个排法真的打架:现金榜首在胜率榜第 10,胜率榜首在现金榜第 29

另外网格里根本没有高胜率参数组,重排也找不出来:408 个格子中位数 34.78%,只有 7 个过 50%,而「每个周期胜率都 >50%」的参数组 **0/60**。理由记在 `rank_robust_params` 的 docstring 里了。

## 验证

- 全量 `pytest`:4998 passed, 22 skipped
- `uvx ruff@0.16.2 check .` / `format --check .`:与 CI 钉住的版本一致,均通过
- `quality_gate.py --check-no-sql`:通过
- 用真实 09-09 产物(102 份 summary / 408 格)渲染过报表,新列读数与手算一致
- 新增 7 个用例。四处源码变异各自被对应用例抓到:结论行退回代表格子胜率、去掉 `isfinite` 过滤、`is not None` 改真值判断、往 `_cross_period_positive` 里注入胜率闸门

胜率口径是逐笔且已扣成本(`core/cash_portfolio.py:560`,`ret_pct = pnl / cost_total`,`pnl` 已扣 `sell_friction_pct` 与 `calc_trade_cost`),所以 `> 0` 是真赢。

两处细节值得记一笔:`min()` 碰 NaN 的结果取决于它在序列里的位置(`min([1.0, nan])` 得 1.0,`min([nan, 1.0])` 得 nan),一个脏值就能静默改写整组的最差周期,所以非有限值一律剔除;而胜率 0.0 是「一笔没赢」这个真实取值,不能用真值判断滤掉,否则全亏的周期看着反而正常。