### PR TITLE
fix(attribution): entry_type 一列两语义，归因分组键被打散

### DIFF
--- a/core/candidate_metadata.py
+++ b/core/candidate_metadata.py
@@ -15,6 +15,7 @@ from core.candidate_tracks import (
     candidate_entry_key,
     candidate_entry_score,
     candidate_entry_sort_key,
+    lane_slug_or,
     normalize_candidate_entry_key,
     stronger_candidate_entry,
 )
@@ -150,12 +151,21 @@ def candidate_metadata_for_signal(
     return metadata_map.get((code_s, signal_key), metadata_map.get(code_s, {}))
 
 
+def _prose_entry_type(item: Mapping[str, Any]) -> str:
+    """``entry_type`` 里那段不是车道 slug 的文字,没有就空串。"""
+    raw = _text(item.get("entry_type"))
+    return "" if not raw or lane_slug_or(raw, "") else raw
+
+
 def candidate_entry_metadata(item: dict[str, Any], mainline: dict[str, Any] | None = None) -> dict[str, Any]:
-    lane = _text(item.get("lane")) or _text(item.get("signal_key")) or _text(item.get("entry_type"))
+    lane = _text(item.get("lane")) or _text(item.get("signal_key")) or lane_slug_or(item.get("entry_type"), "")
     meta = {
         "strategy_version": STRATEGY_VERSION_CANDIDATE_LANE_V1,
         "candidate_lane": lane,
-        "entry_type": _text(item.get("entry_type")) or lane,
+        # 只收 slug 形状:主线链路的 entry_type 是中文买点理由,落进来会把这一列
+        # 变成 29 个散文键,下游按它 group by 的归因与治理器全部碎掉。理由本身在
+        # 下面的 candidate_timing 里。
+        "entry_type": lane_slug_or(item.get("entry_type"), lane),
         "signal_key": candidate_entry_key(item, fields=("signal_key", "lane", "entry_type"))
         or normalize_candidate_entry_key(lane),
         # candidate_status 是语义状态位（主线买点候选 / 过热不追 / AI复核候选…），
@@ -169,7 +179,11 @@ def candidate_entry_metadata(item: dict[str, Any], mainline: dict[str, Any] | No
         # 「主线观察」，is_confirmed_step4_candidate 会因「观察」子串一票否决，把已
         # confirmed 的 SOS/LPS 等正式信号静默踢出推荐写入与 Step4。主题/分数仍可继承。
         "candidate_status": _semantic_status(item),
-        "candidate_timing": _text(item.get("timing")) or _text((mainline or {}).get("entry_type")),
+        # 第三个兜底是上面被 slug 门槛拦下的那段文字:生产者若只在 entry_type 里放了
+        # 中文买点理由、没填 timing,拦下来不能顺手丢掉,挪到它该在的列。
+        "candidate_timing": _text(item.get("timing"))
+        or _text((mainline or {}).get("entry_type"))
+        or _prose_entry_type(item),
         "candidate_risk": _text(item.get("risk")) or _join_texts((mainline or {}).get("risk_flags")),
         "candidate_reasons": _json_object(_candidate_reason_payload(item, mainline)),
         "candidate_metrics": _json_object(item.get("metrics") or _mainline_metrics_payload(mainline or {}) or {}),
@@ -185,14 +199,14 @@ def candidate_entry_metadata(item: dict[str, Any], mainline: dict[str, Any] | No
 
 
 def mainline_metadata(item: dict[str, Any]) -> dict[str, Any]:
-    entry_type = _text(item.get("entry_type")) or "mainline"
+    timing = _text(item.get("entry_type")) or "mainline"
     meta = {
         "strategy_version": STRATEGY_VERSION_CANDIDATE_LANE_V1,
         "candidate_lane": "mainline",
-        "entry_type": entry_type,
+        "entry_type": lane_slug_or(item.get("entry_type"), "mainline"),
         "signal_key": "mainline",
         "candidate_status": _text(item.get("status")),
-        "candidate_timing": entry_type,
+        "candidate_timing": timing,
         "candidate_risk": _join_texts(item.get("risk_flags")),
         "candidate_reasons": _json_object(_candidate_reason_payload(item, item)),
         "candidate_metrics": _json_object(_mainline_metrics_payload(item)),

--- a/core/candidate_tracks.py
+++ b/core/candidate_tracks.py
@@ -82,6 +82,48 @@ def normalize_candidate_entry_key(raw: Any) -> str:
     return re.sub(r"_+", "_", key).strip("_")
 
 
+#: 车道 slug 的字面形状:ASCII 字母数字加分隔符。所有 13 个合法取值(sos/evr/lps/
+#: spring/compression/trend_pullback/mainline/…)都落在里面,而中文买点理由
+#: (「主线回踩MA5 + 主线平台再突破」)落不进来。
+_LANE_SLUG_SHAPE = re.compile(r"[A-Za-z0-9 _-]+")
+
+
+#: ``selection_source`` 在市场闸门关闭时被追加的后缀（``_tracking_source``）。它标的是
+#: 「这一行写入时市场闸门是关的」,属于来源/状态维度,不是车道身份的一部分。
+MARKET_BLOCK_SUFFIX = ":market_blocked"
+
+
+def strip_lane_status_suffix(raw: Any) -> str:
+    """把车道取值里的市场闸门后缀摘掉。
+
+    ``recommendation_payload`` 在 candidate_lane 缺失时会退到 ``selection_source``,
+    而那个字段此时已经带了 ``:market_blocked``,于是同一条车道按市场状态被劈成两个
+    标签:实测 ``signal_confirmed`` 开市侧 14 行、拦截侧 94 行,跨 13 个交易日。
+    任何按车道汇总的归因都会把它们当两条车道,而占多数的那半还是带后缀的。
+    """
+    text = str(raw or "").strip()
+    if text.endswith(MARKET_BLOCK_SUFFIX):
+        return text[: -len(MARKET_BLOCK_SUFFIX)].strip()
+    return text
+
+
+def lane_slug_or(raw: Any, fallback: str) -> str:
+    """把 ``raw`` 当车道 slug 用,形状不对就退回 ``fallback``。
+
+    ``entry_type`` 这一列的契约是车道 slug,可主线链路曾把 ``_timing_result`` 的
+    中文买点理由原样塞进来——同一列两种语义,和 ``candidate_status`` 当年一模一样。
+    危害在下游的 group by:``_signal_context_key`` 和治理器的 ``_context_scope``
+    都拿它当分组键,29 个散文键里只有 4 个够 ``MIN_CONTEXT_SAMPLES``,63 行主线候选
+    有 36 行永远进不了治理器,剩下的还被切成 5~8 样本的碎片当「样本不足」处理。
+
+    理由文本本身有 ``timing``/``candidate_timing`` 承载,不在这里丢。
+    """
+    text = str(raw or "").strip()
+    if not text or not _LANE_SLUG_SHAPE.fullmatch(text):
+        return fallback
+    return normalize_candidate_entry_key(text) or fallback
+
+
 def candidate_entry_key(
     item: Mapping[str, Any],
     known_keys: Iterable[str] | None = None,

--- a/core/mainline_engine.py
+++ b/core/mainline_engine.py
@@ -18,6 +18,7 @@ from core._price_math import upper_shadow_pct as _upper_shadow_pct
 from core._price_math import vol_ratio as _vol_ratio
 from core.candidate_metadata import code6
 from core.candidate_policy import candidate_score_value
+from core.candidate_tracks import lane_slug_or
 from core.main_force_signal import MainForceSignal, analyze_main_force_signal
 from core.theme_radar import normalize_theme_name
 from utils.safe import safe_float as _safe_float
@@ -594,7 +595,10 @@ def _candidate_entry(item: dict[str, Any]) -> dict[str, Any]:
         "code": item["code"],
         "track": "trend",
         "signal_key": "mainline",
-        "entry_type": str(item.get("entry_type") or "mainline"),
+        # 内部 ``item["entry_type"]`` 是 _timing_result 拼的中文买点理由（本文件
+        # 667 行起还按子串匹配它做加减分），契约这一列要的是车道 slug。理由文本
+        # 走下面的 ``timing``,别再落到这里。
+        "entry_type": lane_slug_or(item.get("entry_type"), "mainline"),
         "lane": "mainline",
         "score": score,
         "opportunity": _candidate_opportunity(item),

--- a/core/recommendation_payload.py
+++ b/core/recommendation_payload.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from core.candidate_metadata import CANDIDATE_ATTRIBUTION_COLUMNS, STRATEGY_VERSION_CANDIDATE_LANE_V1
 from core.candidate_metadata import code6 as _code6
+from core.candidate_tracks import strip_lane_status_suffix
 from core.constants import TABLE_RECOMMENDATION_TRACKING
 from utils.safe import safe_float
 
@@ -271,7 +272,13 @@ def _extract_recommendation_attribution(row: dict[str, Any]) -> dict[str, Any]:
     signal_types = _optional_text_list(row.get("signal_types"))
     primary_signal = _optional_text(row.get("primary_signal")) or (signal_types[0] if signal_types else None)
     candidate_lane = (
-        _optional_text(row.get("candidate_lane")) or primary_signal or _optional_text(row.get("selection_source"))
+        _optional_text(row.get("candidate_lane"))
+        or primary_signal
+        # selection_source 走到这里已经带上了 :market_blocked,原样落进车道列会把
+        # 同一条车道按市场状态劈成两个标签,归因侧看成两条车道。后缀留在
+        # selection_source 自己那一列。
+        or strip_lane_status_suffix(row.get("selection_source"))
+        or None
     )
     entry_type = _optional_text(row.get("entry_type")) or candidate_lane
     return {

--- a/tests/core/test_candidate_metadata.py
+++ b/tests/core/test_candidate_metadata.py
@@ -72,12 +72,19 @@ def test_candidate_signal_triggers_treats_invalid_scores_as_zero() -> None:
 
 
 def test_candidate_metadata_signal_key_prefers_structured_signal_over_display_text() -> None:
+    """展示文案不该顶掉结构化字段——包括 entry_type 这一列自己。
+
+    原断言写的是 ``entry_type == "主线回踩MA20"``,与用例名要表达的意思正相反:
+    这一列的契约是车道 slug,中文买点理由属于 candidate_timing。理由文本不丢,
+    但不能占着 slug 的位置,否则下游按它 group by 会碎成散文键。
+    """
     metadata = build_candidate_metadata_map(
         [{"code": "300308", "entry_type": "主线回踩MA20", "signal_key": "mainline", "score": 86.0}]
     )
 
-    assert metadata["300308"]["entry_type"] == "主线回踩MA20"
+    assert metadata["300308"]["entry_type"] == "mainline"
     assert metadata["300308"]["signal_key"] == "mainline"
+    assert metadata["300308"]["candidate_timing"] == "主线回踩MA20"
 
 
 def test_candidate_metadata_materializes_report_semantics() -> None:
@@ -271,3 +278,58 @@ def test_lane_dedup_conflict_ignores_agreeing_and_single_lane_codes() -> None:
     assert stats["multi_lane_codes"] == 1
     assert stats["disagreed_codes"] == 0
     assert stats["details"] == []
+
+
+def test_lane_slug_guard_admits_every_production_lane() -> None:
+    """假阳性一侧:13 个线上合法车道取值一个都不能被拦。
+
+    门槛写歪成「只认白名单」就会把新车道静默换成 fallback,和这次要修的 bug 同形,
+    只是方向相反、更难发现。
+    """
+    from core.candidate_tracks import lane_slug_or
+
+    for lane in (
+        "sos",
+        "evr",
+        "lps",
+        "spring",
+        "compression",
+        "trend_pullback",
+        "trend_lane_pullback",
+        "mainline",
+        "breakout",
+        "main_force_entry",
+        "future_leader",
+        "accumulation_ready",
+        "rotation",
+        "pre_breakout",
+        "volatile_pullback",
+    ):
+        assert lane_slug_or(lane, "FALLBACK") == lane, lane
+
+    # 大小写与分隔符照旧归一,不算「形状不对」
+    assert lane_slug_or("Main Force Entry", "FALLBACK") == "main_force_entry"
+    assert lane_slug_or("trend-pullback", "FALLBACK") == "trend_pullback"
+
+
+def test_lane_slug_guard_rejects_timing_prose() -> None:
+    from core.candidate_tracks import lane_slug_or
+
+    for prose in (
+        "主线回踩MA5 + 主线平台再突破",
+        "主题低位修复",
+        "主线回踩MA20",
+    ):
+        assert lane_slug_or(prose, "mainline") == "mainline", prose
+    assert lane_slug_or(None, "mainline") == "mainline"
+    assert lane_slug_or("", "mainline") == "mainline"
+
+
+def test_mainline_metadata_splits_lane_slug_from_timing_prose() -> None:
+    from core.candidate_metadata import mainline_metadata
+
+    meta = mainline_metadata({"code": "600000", "entry_type": "主线回踩MA5 + 主线平台再突破", "status": "主线买点候选"})
+
+    assert meta["entry_type"] == "mainline"
+    assert meta["candidate_lane"] == "mainline"
+    assert meta["candidate_timing"] == "主线回踩MA5 + 主线平台再突破"

--- a/tests/core/test_mainline_engine.py
+++ b/tests/core/test_mainline_engine.py
@@ -350,3 +350,33 @@ def test_replay_funnel_does_not_pass_future_theme_to_mainline_engine(monkeypatch
     assert len(received) == 1
     assert received[0]["theme_radar"]["themes"] == []
     assert received[0]["theme_radar"]["trade_date"] == frame["date"].max().date().isoformat()
+
+
+def test_mainline_contract_entry_carries_lane_slug_not_timing_prose() -> None:
+    """契约层 ``entry_type`` 必须是车道 slug,中文买点理由留在 ``timing``。
+
+    内部 MainlineCandidate 的 entry_type 是 ``_timing_result`` 拼的理由文本(本文件
+    另有按子串加减分的逻辑读它),越过契约边界就变成了车道列的取值。实测 63 行主线
+    候选被打散成 29 个键,治理器 MIN_CONTEXT_SAMPLES=5 只放行 4 个,36 行永远不被
+    评估——所以这里要钉住边界两侧各自拿到什么。
+    """
+    candidates = build_mainline_candidates(
+        l1_passed=["000010"],
+        l2_passed=[],
+        concept_map={"000010": ["创新药"]},
+        concept_heat=[{"name": "创新药", "pct": 5.2, "net_inflow": 900_000_000}],
+        theme_radar={"themes": [{"theme": "创新药", "score": 0.70}], "strategic_candidates": []},
+        df_map={"000010": _frame(_event_reversal_values(), amount=200_000_000.0)},
+        financial_map={},
+        name_map={"000010": "事件修复A"},
+        config=MainlineEngineConfig(),
+    )
+
+    # 内部字段保持原样:同文件的子串匹配打分依赖它
+    assert "主题低位修复" in candidates[0]["entry_type"]
+
+    entry = mainline_candidate_entries(candidates, max_count=3)[0]
+    assert entry["entry_type"] == "mainline"
+    assert entry["lane"] == "mainline"
+    assert entry["signal_key"] == "mainline"
+    assert "主题低位修复" in entry["timing"]

--- a/tests/core/test_recommendation_lane_columns.py
+++ b/tests/core/test_recommendation_lane_columns.py
@@ -1,0 +1,53 @@
+"""``candidate_lane``/``entry_type`` 这两列只放车道标识,不放市场状态。
+
+``_tracking_source`` 会在市场闸门关闭时给 ``selection_source`` 追加
+``:market_blocked``,标的是「这一行写入时闸门是关的」。而 candidate_lane 缺失时
+会退到 selection_source,后缀就跟着进了车道列:生产库实测 ``signal_confirmed``
+开市侧 14 行、拦截侧 94 行,跨 20260805~20260828 共 13 个交易日,按车道汇总的归因
+会把同一条车道读成两条,且占多数的那半是带后缀的那个标签。
+"""
+
+from __future__ import annotations
+
+from core.recommendation_payload import build_recommendation_payload
+
+
+def _row(**over: object) -> dict[str, object]:
+    base = {"code": "600000", "name": "测试", "price": 10.0, "tag": "AI复核候选"}
+    base.update(over)
+    return base
+
+
+def _build(item: dict[str, object]) -> dict[str, object]:
+    return build_recommendation_payload(20260805, [item], {}, {})[0]
+
+
+def test_market_block_suffix_does_not_enter_lane_columns() -> None:
+    row = _build(_row(selection_source="signal_confirmed:market_blocked"))
+
+    assert row["candidate_lane"] == "signal_confirmed"
+    assert row["entry_type"] == "signal_confirmed"
+    assert row["signal_key"] == "signal_confirmed"
+
+
+def test_open_market_and_blocked_market_share_one_lane_label() -> None:
+    """同一条车道在两种市场状态下必须落成同一个标签,否则归因分母被劈开。"""
+    open_row = _build(_row(selection_source="signal_confirmed"))
+    blocked_row = _build(_row(selection_source="signal_confirmed:market_blocked"))
+
+    assert open_row["candidate_lane"] == blocked_row["candidate_lane"]
+
+
+def test_explicit_candidate_lane_still_wins_over_selection_source() -> None:
+    """显式车道优先级不变:摘后缀只作用在退到 selection_source 的那条路上。"""
+    row = _build(_row(candidate_lane="sos", selection_source="signal_confirmed:market_blocked"))
+
+    assert row["candidate_lane"] == "sos"
+
+
+def test_lane_stays_empty_when_no_source_is_available() -> None:
+    """没有任何来源时不能把空串写成车道,否则出现一个 '' 车道桶。"""
+    row = _build(_row())
+
+    assert not row.get("candidate_lane")
+    assert not row.get("entry_type")


### PR DESCRIPTION
## 问题

`entry_type` 这一列的契约是车道 slug，实际躺着两种非 slug 取值，来源不同、危害同向。

**一、主线链路的中文买点理由。** `_timing_result` 拼出「主线回踩MA5 + 主线平台再突破」这类文案，
存进 `MainlineCandidate.entry_type`（本文件 700 行附近还按子串匹配它做加减分，这部分是对的），
可越过契约边界时被原样写进车道列：

```
"entry_type": str(item.get("entry_type") or "mainline"),   # 散文进了 slug 列
"lane": "mainline",                                        # 正确的 slug 已经在这
"timing": str(item.get("entry_type") or ""),               # 散文本该只在这
```

`core/candidate_metadata.py` 两处镜像了同样的写法，其中 `candidate_timing` 那一行已经把它
当 timing 文案在用——代码知道这是散文，却仍让它占着 slug 的位置。

**二、市场闸门后缀。** `_tracking_source` 在闸门关闭时给 `selection_source` 追加
`:market_blocked`，而 `candidate_lane` 缺失时会退到 `selection_source`，后缀跟着进了车道列，
再传给 `entry_type` 和 `signal_key`。

危害都在下游的 group by。`_signal_context_key`（归因）和 `_context_scope`（治理器）都拿
`entry_type` 当分组键：

- trace 实测 63 行主线候选被 `_norm_key` 打散成 **29 个键**，`MIN_CONTEXT_SAMPLES=5` 只放行
  4 个（覆盖 27 行），**另外 36 行永远进不了治理器**，放行的那几个还被切成 5~8 样本的碎片，
  被当成「样本不足」处理。合成一个 `mainline` 键的话 63 行整体过阈。
- 生产库 `recommendation_tracking` 1143 行里 98 行是非 slug 取值：`signal_confirmed` 这条车道
  被后缀劈成 **开市侧 14 行 / 拦截侧 94 行**，跨 20260805~20260828 共 13 个交易日，占多数的
  那半还是带后缀的标签。按车道汇总的归因把同一条车道读成两条。

和 `candidate_status` 当年那次一模一样：一字段两语义，下游各自打补丁，没人查写入侧。

## 改动

`core/candidate_tracks.py` 加两个判据，只在这一处：

- `lane_slug_or(raw, fallback)`：形状不是 ASCII slug 就退回 fallback。13 个线上合法车道
  全部通过，`Main Force Entry` / `trend-pullback` 照旧归一。
- `strip_lane_status_suffix(raw)`：摘掉 `:market_blocked`，后缀留在 `selection_source` 自己那列。

三个写入点接上判据：`core/mainline_engine.py` 契约边界发 slug、散文留在 `timing`；
`core/candidate_metadata.py` 两处同样处理，并给 `candidate_timing` 加了第三个兜底——生产者
只在 `entry_type` 里放了文案、没填 `timing` 时，拦下来的那段文字挪到它该在的列，不丢；
`core/recommendation_payload.py` 退到 `selection_source` 前先摘后缀。

`mainline_engine` 内部按散文子串加减分的逻辑跑在边界之前，没动。

## 验证

`test_candidate_metadata_signal_key_prefers_structured_signal_over_display_text` 原来断言
`entry_type == "主线回踩MA20"`，与用例名要表达的意思正相反——名字说的是「展示文案不该顶掉
结构化字段」，断言钉住的是 bug 本身。改成钉 slug，并补断言文案落在 `candidate_timing`。

新增用例覆盖两侧：假阳性侧钉住 15 个合法车道一个都不被拦（门槛写歪成白名单会静默换掉新
车道，同形但更难发现）；真阳性侧钉住散文和后缀都被替换、文案不丢、显式车道优先级不变、
无来源时不落空串车道。契约边界一条钉内部散文保留、外部三列都是 slug。

全量 5028 passed / 22 skipped，`ruff@0.16.2 check` + `format` 干净，`--check-no-sql` 干净。

历史数据两条回填语句已单独发出（98 行都不丢信息：94 行的后缀仍在 `selection_source`，
4 行主线的文案 `candidate_timing` 已存同文）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)