### PR TITLE
fix(review): trace 分四批加字段却共用一个 schema_version,读侧分不清没上线和没值

### DIFF
--- a/tests/workflows/test_review_list_replay.py
+++ b/tests/workflows/test_review_list_replay.py
@@ -43,7 +43,16 @@ from workflows.review_report_render import (
     build_report_lines,
     short_code_list,
 )
-from workflows.review_trace import build_review_trace, load_review_trace_artifact, write_review_trace_artifact
+from workflows.review_trace import (
+    REVIEW_TRACE_PER_ROW_FIELDS,
+    REVIEW_TRACE_ROW_FIELDS,
+    REVIEW_TRACE_SCHEMA,
+    build_review_trace,
+    load_review_trace_artifact,
+    trace_has_row_field,
+    trace_row_fields,
+    write_review_trace_artifact,
+)
 
 
 def _row(code: str, name: str, stage: str) -> dict[str, str]:
@@ -1077,3 +1086,100 @@ def test_previous_funnel_scope_blocks_persistence_and_restores_environment(monke
     assert is_server_write_context()
     assert os.environ.get("WYCKOFF_SHARED_READ_ONLY") is None
     assert all(os.environ.get(key) == original for key in ("END_CALENDAR_DAY", "DAILY_JOB_ARTIFACTS_DIR"))
+
+
+def test_review_trace_declares_exactly_the_row_fields_it_writes() -> None:
+    """头里的 row_fields 必须等于每行都真写了的那些键，声明不许骗人。
+
+    逐行字段是分四批上线的（trigger_labels/risk_signal 从 2026-08-13、close 与
+    rps_* 从 09-02、risk_evaluated/l3_eligible_strict 从 09-08），而 schema_version
+    四批都写 v1。以后再加逐行字段却忘了进 REVIEW_TRACE_ROW_FIELDS，声明就又开始
+    骗人，这条用例是那道闸。
+    """
+    payload = build_review_trace(_l3_strict_inputs(), {}, {})
+    rows = payload["symbols"]
+    assert len(rows) >= 2
+
+    always_present = set.intersection(*(set(row.keys()) for row in rows.values()))
+    assert always_present - REVIEW_TRACE_PER_ROW_FIELDS == set(REVIEW_TRACE_ROW_FIELDS)
+    assert payload["row_fields"] == list(REVIEW_TRACE_ROW_FIELDS)
+    assert payload["schema_version"] == REVIEW_TRACE_SCHEMA
+    assert trace_row_fields(payload) == frozenset(REVIEW_TRACE_ROW_FIELDS)
+
+
+def test_trace_row_fields_infers_the_writer_field_set_for_legacy_traces() -> None:
+    """v1 没有声明，得从行里反推：非可选字段全行都有或全行都没有。
+
+    反推取交集而不是并集——并集会把「只有候选命中行才有的 entry」也算成 writer
+    字段，于是别的行缺 entry 又被读成「值缺失」，正是这个函数要消掉的混淆。
+    """
+    legacy = {
+        "schema_version": "review_trace_v1",
+        "trade_date": "2026-08-12",
+        "symbols": {
+            "000001": {"stage": "候选命中", "l1_eligible": True, "entry": {"lane": "sos"}},
+            "000002": {"stage": "结构强度不足", "l1_eligible": True, "shadow_lane": "near_l2"},
+        },
+    }
+
+    assert trace_row_fields(legacy) == frozenset({"stage", "l1_eligible"})
+    assert trace_has_row_field(legacy, "l1_eligible") is True
+    # 09-02 才上线的字段：v1 老产物里它是「那天还没有」，不是「这只票没值」。
+    assert trace_has_row_field(legacy, "rps_fast") is False
+    assert trace_has_row_field(legacy, "entry") is False
+
+
+def test_trace_row_fields_separates_absent_field_from_missing_value() -> None:
+    """字段写过但值为 None，和字段没上线，是两件事。
+
+    只看 ``row.get(field) is None`` 两者同形：照那么写的筛子会静默丢掉 22 个交易日
+    里的 15 个，再把剩下 7 个当全样本报出来。
+    """
+    written_but_null = {
+        "schema_version": REVIEW_TRACE_SCHEMA,
+        "row_fields": ["stage", "rps_fast"],
+        "symbols": {"000001": {"stage": "买点未触发", "rps_fast": None}},
+    }
+    never_written = {
+        "schema_version": "review_trace_v1",
+        "symbols": {"000001": {"stage": "买点未触发"}},
+    }
+
+    assert written_but_null["symbols"]["000001"].get("rps_fast") is None
+    assert never_written["symbols"]["000001"].get("rps_fast") is None
+    assert trace_has_row_field(written_but_null, "rps_fast") is True
+    assert trace_has_row_field(never_written, "rps_fast") is False
+
+
+def test_trace_row_fields_falls_back_when_declaration_is_unusable() -> None:
+    """声明为空或缺失就退回反推：行才是事实，别把每个字段都读成「没上线」。"""
+    rows = {"000001": {"stage": "买点未触发", "rps_fast": 92.5}}
+
+    assert trace_row_fields({"row_fields": [], "symbols": rows}) == frozenset({"stage", "rps_fast"})
+    assert trace_row_fields({"symbols": rows}) == frozenset({"stage", "rps_fast"})
+    assert trace_row_fields({"symbols": {}}) == frozenset()
+    assert trace_row_fields({}) == frozenset()
+
+
+def test_load_review_trace_artifact_still_reads_v1_history(tmp_path) -> None:
+    """升版本号不能把 22 份历史 trace 变成 schema mismatch，效果检验全靠它们攒样本。"""
+    import gzip
+    import json
+
+    payload = build_review_trace(_l3_strict_inputs(), {}, {})
+    legacy = {**payload, "schema_version": "review_trace_v1"}
+    legacy.pop("row_fields")
+    path = tmp_path / "review_trace_20260512.json.gz"
+    with gzip.open(path, "wt", encoding="utf-8") as handle:
+        json.dump(legacy, handle, ensure_ascii=False)
+
+    loaded = load_review_trace_artifact(path, legacy["trade_date"])
+    assert loaded["schema_version"] == "review_trace_v1"
+    # 老产物没有声明，字段集从行里反推，照样能答「这天有没有这个字段」。
+    assert trace_has_row_field(loaded, "rps_fast") is True
+
+    broken = tmp_path / "review_trace_20260513.json.gz"
+    with gzip.open(broken, "wt", encoding="utf-8") as handle:
+        json.dump({**legacy, "schema_version": "review_trace_v0"}, handle, ensure_ascii=False)
+    with pytest.raises(ValueError, match="schema mismatch"):
+        load_review_trace_artifact(broken, legacy["trade_date"])

--- a/workflows/review_trace.py
+++ b/workflows/review_trace.py
@@ -29,7 +29,54 @@ from core.funnel_taxonomy import (
 from core.review_shadow_lanes import attach_shadow_signal
 from core.wyckoff_engine import sort_by_date_if_needed
 
-REVIEW_TRACE_SCHEMA = "review_trace_v1"
+REVIEW_TRACE_SCHEMA = "review_trace_v2"
+#: 还能被 :func:`load_review_trace_artifact` 读进来的版本号。老号必须留着:v1 与 v2
+#: 的行结构完全一致,v2 只是在头里多声明了一份 ``row_fields``。只把常量一升了事,
+#: 22 份历史 trace 会全部变成「schema mismatch」——而效果检验的样本正是靠它们攒的。
+REVIEW_TRACE_COMPATIBLE_SCHEMAS = frozenset({"review_trace_v1", REVIEW_TRACE_SCHEMA})
+
+#: 每一行都会写的字段。逐行字段是分四批上线的(按 26 份历史产物实测):
+#: ``trigger_labels``/``risk_signal``(以及逐行可选的 ``shadow_*``)从 2026-08-13 起、
+#: ``close``/``layer3_quality_score``/``rps_fast``/``rps_slow`` 从 09-02 起、
+#: ``risk_evaluated``/``l3_eligible_strict`` 从 09-08 起,而 ``schema_version``
+#: 四批都写 v1。于是读侧分不清两件事:「这天的 writer 还没有这个字段」和「这只票
+#: 取不到值」。一个照着 ``if row.get("rps_fast") is None: continue`` 写的筛子会
+#: 静默丢掉 22 个交易日里的 15 个,再把剩下 7 个当成全样本报出来——把「尚未可知」
+#: 读成「事实为空」,和 nan-passes-every-truthy-guard 是同一类病。把 writer 实际
+#: 写了什么声明在 payload 头里,缺失就有据可查。
+REVIEW_TRACE_ROW_FIELDS: tuple[str, ...] = (
+    "name",
+    "sector",
+    "stage",
+    "reason",
+    "l1_eligible",
+    "l2_eligible",
+    "l3_eligible",
+    "l3_eligible_strict",
+    "l2_channel",
+    "layer3_quality_score",
+    "trigger_labels",
+    "risk_signal",
+    "risk_evaluated",
+    "rps_fast",
+    "rps_slow",
+    "close",
+)
+
+#: 只出现在部分行上的字段:``entry`` 只有候选命中行有,``shadow_*`` 只有影子车道
+#: 命中的行有。它们缺席是正常的,不能当成「writer 没有这个字段」,所以从行里反推
+#: 字段集时要先把它们排除掉。
+REVIEW_TRACE_PER_ROW_FIELDS = frozenset(
+    {
+        "entry",
+        "shadow_lane",
+        "shadow_score",
+        "shadow_ranked",
+        "shadow_reason",
+        "shadow_policy_version",
+    }
+)
+
 _BLOCKING_EXIT_SIGNALS = {"stop_loss", "distribution_warning", "upthrust_warning"}
 _SHADOW_NEAR_L2_MAX_GAP_PCT = 10.0
 
@@ -72,6 +119,9 @@ def build_review_trace(inputs: Any, triggers: dict, metrics: dict) -> dict[str, 
             "git_sha": os.getenv("GITHUB_SHA", ""),
         },
         "config_digest": _digest(config_payload),
+        # 这一版 writer 逐行写了哪些字段。读侧靠它把「字段没上线」和「这只票没值」
+        # 分开;新增逐行字段必须同时进 REVIEW_TRACE_ROW_FIELDS,否则声明就在骗人。
+        "row_fields": list(REVIEW_TRACE_ROW_FIELDS),
         "policy": _review_policy(inputs.cfg),
         "data_quality": metrics.get("data_quality") or {},
         "market_context": _market_context(metrics),
@@ -90,7 +140,7 @@ def build_review_trace(inputs: Any, triggers: dict, metrics: dict) -> dict[str, 
 def load_review_trace_artifact(path: str | Path, expected_trade_date: date | str) -> dict[str, Any]:
     with gzip.open(Path(path), "rt", encoding="utf-8") as handle:
         payload = json.load(handle)
-    if not isinstance(payload, dict) or payload.get("schema_version") != REVIEW_TRACE_SCHEMA:
+    if not isinstance(payload, dict) or payload.get("schema_version") not in REVIEW_TRACE_COMPATIBLE_SCHEMAS:
         raise ValueError("review trace schema mismatch")
     if payload.get("market") != "cn":
         raise ValueError("review trace market mismatch")
@@ -100,6 +150,47 @@ def load_review_trace_artifact(path: str | Path, expected_trade_date: date | str
     if not isinstance(payload.get("symbols"), dict):
         raise ValueError("review trace symbols missing")
     return payload
+
+
+def trace_row_fields(payload: dict[str, Any]) -> frozenset[str]:
+    """这份 trace 的 writer 实际写了哪些逐行字段。
+
+    v2 起直接读头里的 ``row_fields``。v1 没有这份声明,退回从行里反推:同一个交易日
+    内,非可选字段要么全行都有、要么全行都没有——26 份历史产物逐键数过,没有一个
+    非可选键是部分行才有的,真正逐行可选的只有 ``entry`` 与 ``shadow_*``。所以取
+    所有行键的交集、再去掉那几个逐行可选键,就是当天 writer 的字段集。
+
+    交集而不是并集:并集会把「只有候选命中行才有的 entry」也算进 writer 字段,于是
+    别的行缺 entry 又被读成「值缺失」,正是这个函数要消掉的那种混淆。
+    """
+    declared = payload.get("row_fields")
+    if isinstance(declared, list | tuple | set | frozenset):
+        names = frozenset(str(name) for name in declared if str(name or "").strip())
+        # 空声明退回反推:行本身才是事实,声明为空只可能是 writer 出错,不该让读侧
+        # 把每个字段都读成「没上线」。
+        if names:
+            return names
+    symbols = payload.get("symbols")
+    if not isinstance(symbols, dict) or not symbols:
+        return frozenset()
+    shared: set[str] | None = None
+    for row in symbols.values():
+        keys = set(row.keys()) if isinstance(row, dict) else set()
+        shared = keys if shared is None else (shared & keys)
+        if not shared:
+            return frozenset()
+    return frozenset(shared or set()) - REVIEW_TRACE_PER_ROW_FIELDS
+
+
+def trace_has_row_field(payload: dict[str, Any], field: str) -> bool:
+    """``field`` 在这份 trace 里是「写过」还是「那天还没有这个字段」。
+
+    历史 trace 里 ``rps_fast``/``risk_evaluated``/``l3_eligible_strict`` 全是 ``None``,
+    与「查过但这只票没值」同形。要按字段拆样本、或要断言某个口径可评估,先问这里,
+    别拿 ``row.get(field) is None`` 当判据——那会把「尚未可知」读成「事实为空」
+    (memory insufficient-sample-is-not-failed-control)。
+    """
+    return str(field or "") in trace_row_fields(payload)
 
 
 def _decision_rows(inputs: Any, triggers: dict, metrics: dict | None = None) -> dict[str, dict[str, Any]]:


### PR DESCRIPTION
## 问题

22 个交易日的 `review_trace_*.json.gz` 全都自报 `review_trace_v1`,但逐行字段是分四批上线的(按 26 份历史产物逐键实测):

| 区间 | 相对现在缺的逐行字段 |
| --- | --- |
| 08-12 | `close` `l3_eligible_strict` `layer3_quality_score` `risk_evaluated` `risk_signal` `rps_fast` `rps_slow` `trigger_labels`(8 个) |
| 08-13 → 09-01 | `close` `l3_eligible_strict` `layer3_quality_score` `risk_evaluated` `rps_fast` `rps_slow`(6 个) |
| 09-02 → 09-07 | `l3_eligible_strict` `risk_evaluated`(2 个) |
| 09-08 → 09-10 | 无 |

四批都写同一个 `schema_version`,于是 `row.get("rps_fast") is None` 同时表示两件事:**这天的 writer 还没有这个字段**、以及**这只票取不到值**。一个照 `if row.get("rps_fast") is None: continue` 写的筛子会静默丢掉 22 天里的 15 天,再把剩下 7 天当成全样本报出来——把「尚未可知」读成「事实为空」。

## 改动

- `REVIEW_TRACE_SCHEMA` 升到 `review_trace_v2`,同时加 `REVIEW_TRACE_COMPATIBLE_SCHEMAS = {v1, v2}`。**只升常量不留兼容集会把 22 份历史 trace 全变成 schema mismatch**,而效果检验的样本正是靠它们攒的,所以两个号都得能读进来。v1 与 v2 的行结构完全一致,v2 只是在头里多声明一份 `row_fields`。
- `build_review_trace` 在 payload 头写 `row_fields`,声明这一版 writer 逐行写了哪 16 个字段。
- 新增 `REVIEW_TRACE_PER_ROW_FIELDS`,点明真正逐行可选的 6 个键(`entry` 只有候选命中行有、`shadow_*` 只有影子车道命中的行有)。它们缺席是正常的,不能算作「writer 没这个字段」。
- 新增读侧 `trace_row_fields(payload)` / `trace_has_row_field(payload, field)`。v2 直接读声明;v1 退回从行里反推——同一交易日内非可选字段要么全行都有、要么全行都没有(26 份产物逐键数过,**没有一个非可选键是部分行才有的**),所以取所有行键的交集再去掉那 6 个可选键就是当天 writer 的字段集。取交集而非并集:并集会把 `entry` 也算进 writer 字段,于是别的行缺 `entry` 又被读成「值缺失」,正是这个函数要消掉的混淆。声明为空时也退回反推,行本身才是事实。

## 验证

- 全量测试 **5032 passed / 22 skipped**;`uvx ruff@0.16.2 check` 两个文件与 `core/ workflows/ tests/ scripts/` 全绿,`format --check` 已格式化,`quality_gate.py --check-no-sql` OK。
- 新增 5 个用例,其中一个是**防漂移守卫**:断言 `REVIEW_TRACE_ROW_FIELDS` 恰好等于 `build_review_trace` 实际逐行写出的键的交集(减去可选键)。以后加逐行字段忘了同步声明,这条会红——否则声明本身会变成新的谎。另有一条专门钉住「`written_but_null` 与 `never_written` 用 `.get(...) is None` 完全同形,而 `trace_has_row_field` 一个 True 一个 False」。
- 对 26 份真实产物量过:没有任何日期出现声明之外的 `extra` 字段,声明是精确的;行数在窗口内 5331 → 5347。
- 拿真实 09-10 trace 走了一遍 v2 dump → load 往返(5347 行),`declared == inferred` 为 True(即对当前数据 v2 不改变任何答案);最老的 08-12 文件上 `trace_has_row_field` 对 `rps_fast`/`trigger_labels` 返回 False,与行里确实没有这两个键一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)